### PR TITLE
An algebra of types for the argument of notations

### DIFF
--- a/dev/ci/user-overlays/19404-herbelin-master+general-recursive-notations.sh
+++ b/dev/ci/user-overlays/19404-herbelin-master+general-recursive-notations.sh
@@ -1,0 +1,5 @@
+overlay elpi https://github.com/herbelin/coq-elpi coq-master+adapt-coq-pr19404-general-recursive-notations 19404 master+general-recursive-notations
+overlay coq_lsp https://github.com/herbelin/coq-lsp main+adapt-coq-pr19404-general-recursive-notations 19404 master+general-recursive-notations
+overlay autosubst_ocaml https://github.com/herbelin/autosubst-ocaml master+adapt-coq-pr19404-general-recursive-notations 19404 master+general-recursive-notations
+overlay quickchick https://github.com/herbelin/QuickChick master+adapt-coq-pr19404-general-recursive-notations 19404 master+general-recursive-notations
+overlay tactician https://github.com/herbelin/coq-tactician coqdev+adapt-coq-pr19404-general-recursive-notations 19404 master+general-recursive-notations

--- a/dev/ci/user-overlays/19404-herbelin-master+general-recursive-notations.sh
+++ b/dev/ci/user-overlays/19404-herbelin-master+general-recursive-notations.sh
@@ -1,0 +1,6 @@
+overlay elpi https://github.com/herbelin/coq-elpi coq-master+adapt-coq-pr19404-general-recursive-notations 19404 master+general-recursive-notations
+overlay rocq_lsp https://github.com/herbelin/coq-lsp main+adapt-coq-pr19404-general-recursive-notations 19404 master+general-recursive-notations
+overlay autosubst_ocaml https://github.com/herbelin/autosubst-ocaml master+adapt-coq-pr19404-general-recursive-notations 19404 master+general-recursive-notations
+overlay quickchick https://github.com/herbelin/QuickChick master+adapt-coq-pr19404-general-recursive-notations 19404 master+general-recursive-notations
+overlay tactician https://github.com/herbelin/coq-tactician coqdev+adapt-coq-pr19404-general-recursive-notations 19404 master+general-recursive-notations
+overlay equations https://github.com/herbelin/coq-equations main+general-recursive-notations 19404 master+general-recursive-notations

--- a/gramlib/gramext.ml
+++ b/gramlib/gramext.ml
@@ -14,3 +14,10 @@ let pr_assoc = function
   | LeftA -> Pp.str "left associativity"
   | RightA -> Pp.str "right associativity"
   | NonA -> Pp.str "no associativity"
+
+let g_assoc_eq a1 a2 =
+  match a1, a2 with
+  | LeftA, LeftA -> true
+  | RightA, RightA -> true
+  | NonA, NonA -> true
+  | (LeftA | RightA | NonA), _ -> false

--- a/gramlib/gramext.ml
+++ b/gramlib/gramext.ml
@@ -25,3 +25,11 @@ let split_assoc = function
 
 let self_on_the_left assoc = fst (split_assoc assoc)
 let self_on_the_right assoc = snd (split_assoc assoc)
+
+let g_assoc_eq a1 a2 =
+  match a1, a2 with
+  | BothA, BothA -> true
+  | LeftA, LeftA -> true
+  | RightA, RightA -> true
+  | NonA, NonA -> true
+  | (BothA | LeftA | RightA | NonA), _ -> false

--- a/gramlib/gramext.mli
+++ b/gramlib/gramext.mli
@@ -12,3 +12,5 @@ type g_assoc = NonA | RightA | LeftA
 
 val pr_assoc : g_assoc -> Pp.t
 (** Prints a [g_assoc] value. *)
+
+val g_assoc_eq : g_assoc -> g_assoc -> bool

--- a/gramlib/gramext.mli
+++ b/gramlib/gramext.mli
@@ -18,3 +18,5 @@ val self_on_the_left : g_assoc -> bool
 
 val self_on_the_right : g_assoc -> bool
 (** Returns whether SELF means SELF on the right. *)
+
+val g_assoc_eq : g_assoc -> g_assoc -> bool

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -136,7 +136,9 @@ type cases_pattern_expr_r =
         with substitution l1) applied to arguments l2. In some
         functions (typically for parsing) s is unused (None), in
         others (typically for printing) it is used to indicate the
-        scope of the notation (Some _). *)
+        scope of the notation (Some _). Type invariant: the length of
+        list l1 is equal to the number of non terminals in n, as given
+        by function TODO (which one?) *)
   | CPatPrim   of prim_token
   | CPatRecord of (qualid * cases_pattern_expr) list
   | CPatDelimiters of delimiter_depth * string * cases_pattern_expr
@@ -218,6 +220,7 @@ and notation_arg_type_expr =
   (constr_expr, kinded_cases_pattern_expr, local_binder_expr list) notation_arg_type
 
 and notation_substitution =
+  (* List of substitutions for each non terminal in a notation. *)
   notation_arg_type_expr list
 
 type constr_pattern_expr = constr_expr

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -90,15 +90,15 @@ type 'a or_by_notation_r =
 
 type 'a or_by_notation = 'a or_by_notation_r CAst.t
 
-type ('a,'b,'c) notation_arg_kind =
-  | NtnTypeArgConstr of 'a
-  | NtnTypeArgPattern of 'b
-  | NtnTypeArgBinders of 'c
+type ('constr,'pattern,'binder) notation_arg_kind =
+  | NtnTypeArgConstr of 'constr
+  | NtnTypeArgPattern of 'pattern
+  | NtnTypeArgBinders of 'binder
 
-type ('a,'b,'c) notation_arg_type =
-  | NtnTypeArg of ('a,'b,'c) notation_arg_kind
-  | NtnTypeArgList of ('a,'b,'c) notation_arg_type list (* all elements assumed of same type *)
-  | NtnTypeArgTuple of ('a,'b,'c) notation_arg_type list
+type ('constr,'pattern,'binder) notation_arg_type =
+  | NtnTypeArg of ('constr,'pattern,'binder) notation_arg_kind
+  | NtnTypeArgList of ('constr,'pattern,'binder) notation_arg_type list (* all elements assumed of same type *)
+  | NtnTypeArgTuple of ('constr,'pattern,'binder) notation_arg_type list
 
 (* NB: the last string in [ByNotation] is actually a [Notation.delimiters],
    but this formulation avoids a useless dependency. *)

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -79,7 +79,7 @@ type notation_key = string
 type notation = notation_entry * notation_key
 
 (* A notation associated to a given interpretation *)
-type specific_notation = notation_with_optional_scope * (notation_entry * notation_key)
+type specific_notation = notation_with_optional_scope * notation
 
 type 'a or_by_notation_r =
   | AN of 'a

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -76,7 +76,10 @@ type notation_entry_relative_level = {
 type notation_key = string
 
 (* A notation associated to a given parsing rule *)
-type notation = notation_entry * notation_key
+type notation = {
+  ntn_entry : notation_entry;
+  ntn_key : notation_key;
+}
 
 (* A notation associated to a given interpretation *)
 type specific_notation = notation_with_optional_scope * notation

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -131,9 +131,12 @@ type cases_pattern_expr_r =
   | CPatAtom of qualid option
   | CPatOr   of cases_pattern_expr list
   | CPatNotation of notation_with_optional_scope option * notation * notation_substitution
-    * cases_pattern_expr list (** CPatNotation (_, n, l1 ,l2) represents
-                                  (notation n applied with substitution l1)
-                                  applied to arguments l2 *)
+    * cases_pattern_expr list
+    (** CPatNotation (s, n, l1 ,l2) represents (notation n applied
+        with substitution l1) applied to arguments l2. In some
+        functions (typically for parsing) s is unused (None), in
+        others (typically for printing) it is used to indicate the
+        scope of the notation (Some _). *)
   | CPatPrim   of prim_token
   | CPatRecord of (qualid * cases_pattern_expr) list
   | CPatDelimiters of delimiter_depth * string * cases_pattern_expr
@@ -176,6 +179,7 @@ and constr_expr_r =
   | CSort   of sort_expr
   | CCast   of constr_expr * Constr.cast_kind option * constr_expr
   | CNotation of notation_with_optional_scope option * notation * notation_substitution
+    (** See CPatNotation *)
   | CGeneralization of Glob_term.binding_kind * constr_expr
   | CPrim of prim_token
   | CDelimiters of delimiter_depth * string * constr_expr

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -139,7 +139,9 @@ type cases_pattern_expr_r =
         with substitution l1) applied to arguments l2. In some
         functions (typically for parsing) s is unused (None), in
         others (typically for printing) it is used to indicate the
-        scope of the notation (Some _). *)
+        scope of the notation (Some _). Type invariant: the length of
+        list l1 is equal to the number of non terminals in n, as given
+        by function TODO (which one?) *)
   | CPatPrim   of prim_token
   | CPatRecord of (qualid * cases_pattern_expr) list
   | CPatDelimiters of delimiter_depth * string * cases_pattern_expr
@@ -221,6 +223,7 @@ and notation_arg_type_expr =
   (constr_expr, kinded_cases_pattern_expr, local_binder_expr list) notation_arg_type
 
 and notation_substitution =
+  (* List of substitutions for each non terminal in a notation. *)
   notation_arg_type_expr list
 
 type constr_pattern_expr = constr_expr

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -93,15 +93,15 @@ type 'a or_by_notation_r =
 
 type 'a or_by_notation = 'a or_by_notation_r CAst.t
 
-type ('a,'b,'c) notation_arg_kind =
-  | NtnTypeArgConstr of 'a
-  | NtnTypeArgPattern of 'b
-  | NtnTypeArgBinders of 'c
+type ('constr,'pattern,'binder) notation_arg_kind =
+  | NtnTypeArgConstr of 'constr
+  | NtnTypeArgPattern of 'pattern
+  | NtnTypeArgBinders of 'binder
 
-type ('a,'b,'c) notation_arg_type =
-  | NtnTypeArg of ('a,'b,'c) notation_arg_kind
-  | NtnTypeArgList of ('a,'b,'c) notation_arg_type list (* all elements assumed of same type *)
-  | NtnTypeArgTuple of ('a,'b,'c) notation_arg_type list
+type ('constr,'pattern,'binder) notation_arg_type =
+  | NtnTypeArg of ('constr,'pattern,'binder) notation_arg_kind
+  | NtnTypeArgList of ('constr,'pattern,'binder) notation_arg_type list (* all elements assumed of same type *)
+  | NtnTypeArgTuple of ('constr,'pattern,'binder) notation_arg_type list
 
 (* NB: the last string in [ByNotation] is actually a [Notation.delimiters],
    but this formulation avoids a useless dependency. *)

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -134,9 +134,12 @@ type cases_pattern_expr_r =
   | CPatAtom of qualid option
   | CPatOr   of cases_pattern_expr list
   | CPatNotation of notation_with_optional_scope option * notation * notation_substitution
-    * cases_pattern_expr list (** CPatNotation (_, n, l1 ,l2) represents
-                                  (notation n applied with substitution l1)
-                                  applied to arguments l2 *)
+    * cases_pattern_expr list
+    (** CPatNotation (s, n, l1 ,l2) represents (notation n applied
+        with substitution l1) applied to arguments l2. In some
+        functions (typically for parsing) s is unused (None), in
+        others (typically for printing) it is used to indicate the
+        scope of the notation (Some _). *)
   | CPatPrim   of prim_token
   | CPatRecord of (qualid * cases_pattern_expr) list
   | CPatDelimiters of delimiter_depth * string * cases_pattern_expr
@@ -179,6 +182,7 @@ and constr_expr_r =
   | CSort   of sort_expr
   | CCast   of constr_expr * Constr.cast_kind option * constr_expr
   | CNotation of notation_with_optional_scope option * notation * notation_substitution
+    (** See CPatNotation *)
   | CGeneralization of Glob_term.binding_kind * constr_expr
   | CPrim of prim_token
   | CDelimiters of delimiter_depth * string * constr_expr

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -79,7 +79,10 @@ type notation_entry_relative_level = {
 type notation_key = string
 
 (* A notation associated to a given parsing rule *)
-type notation = notation_entry * notation_key
+type notation = {
+  ntn_entry : notation_entry;
+  ntn_key : notation_key;
+}
 
 (* A notation associated to a given interpretation *)
 type specific_notation = notation_with_optional_scope * notation

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -90,6 +90,16 @@ type 'a or_by_notation_r =
 
 type 'a or_by_notation = 'a or_by_notation_r CAst.t
 
+type ('a,'b,'c) notation_arg_kind =
+  | NtnTypeArgConstr of 'a
+  | NtnTypeArgPattern of 'b
+  | NtnTypeArgBinders of 'c
+
+type ('a,'b,'c) notation_arg_type =
+  | NtnTypeArg of ('a,'b,'c) notation_arg_kind
+  | NtnTypeArgList of ('a,'b,'c) notation_arg_type list (* all elements assumed of same type *)
+  | NtnTypeArgTuple of ('a,'b,'c) notation_arg_type list
+
 (* NB: the last string in [ByNotation] is actually a [Notation.delimiters],
    but this formulation avoids a useless dependency. *)
 
@@ -120,7 +130,7 @@ type cases_pattern_expr_r =
   (** [CPatCstr (_, c, Some l1, l2)] represents [(@ c l1) l2] *)
   | CPatAtom of qualid option
   | CPatOr   of cases_pattern_expr list
-  | CPatNotation of notation_with_optional_scope option * notation * cases_pattern_notation_substitution
+  | CPatNotation of notation_with_optional_scope option * notation * notation_substitution
     * cases_pattern_expr list (** CPatNotation (_, n, l1 ,l2) represents
                                   (notation n applied with substitution l1)
                                   applied to arguments l2 *)
@@ -131,11 +141,6 @@ type cases_pattern_expr_r =
 and cases_pattern_expr = cases_pattern_expr_r CAst.t
 
 and kinded_cases_pattern_expr = cases_pattern_expr * Glob_term.binding_kind
-
-and cases_pattern_notation_substitution =
-    cases_pattern_expr list *      (* for cases_pattern subterms parsed as terms *)
-    cases_pattern_expr list list * (* for recursive notations parsed as terms*)
-    kinded_cases_pattern_expr list (* for cases_pattern subterms parsed as binders *)
 
 and constr_expr_r =
   | CRef     of qualid * instance_expr option
@@ -170,7 +175,7 @@ and constr_expr_r =
   | CEvar   of Glob_term.existential_name CAst.t * (lident * constr_expr) list
   | CSort   of sort_expr
   | CCast   of constr_expr * Constr.cast_kind option * constr_expr
-  | CNotation of notation_with_optional_scope option * notation * constr_notation_substitution
+  | CNotation of notation_with_optional_scope option * notation * notation_substitution
   | CGeneralization of Glob_term.binding_kind * constr_expr
   | CPrim of prim_token
   | CDelimiters of delimiter_depth * string * constr_expr
@@ -204,11 +209,12 @@ and local_binder_expr =
   | CLocalDef     of lname * relevance_info_expr * constr_expr * constr_expr option
   | CLocalPattern of cases_pattern_expr
 
-and constr_notation_substitution =
-    constr_expr list *      (* for constr subterms *)
-    constr_expr list list * (* for recursive notations *)
-    kinded_cases_pattern_expr list *   (* for binders *)
-    local_binder_expr list list (* for binder lists (recursive notations) *)
+and notation_arg_type_expr =
+  (* Instances of notation variables, with their type as parsed *)
+  (constr_expr, kinded_cases_pattern_expr, local_binder_expr list) notation_arg_type
+
+and notation_substitution =
+  notation_arg_type_expr list
 
 type constr_pattern_expr = constr_expr
 

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -651,6 +651,9 @@ let ntn_loc ?loc subst =
 let error_invalid_pattern_notation ?loc () =
   CErrors.user_err ?loc  (str "Invalid notation for pattern.")
 
+let mk_ntn ntn_entry ntn_key = { ntn_entry; ntn_key }
+let mk_ntn_in_constr = mk_ntn InConstrEntry
+
 (** Pseudo-constructors *)
 
 let mkIdentC id   = CAst.make @@ CRef (qualid_of_ident id,None)

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -647,6 +647,9 @@ let ntn_loc ?loc subst =
 let error_invalid_pattern_notation ?loc () =
   CErrors.user_err ?loc  (str "Invalid notation for pattern.")
 
+let mk_ntn ntn_entry ntn_key = { ntn_entry; ntn_key }
+let mk_ntn_in_constr = mk_ntn InConstrEntry
+
 (** Pseudo-constructors *)
 
 let mkIdentC id   = CAst.make @@ CRef (qualid_of_ident id,None)

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -762,3 +762,55 @@ let rec coerce_to_cases_pattern_expr c = CAst.map_with_loc (fun ?loc -> function
 
 let isCSort a =
   match a.CAst.v with Constrexpr.CSort _ -> true | _ -> false
+
+(**********************************************************************)
+(* Contracting "{ _ }" in notations *)
+
+let rec wildcards ntn n =
+  if Int.equal n (String.length ntn) then []
+  else let l = spaces ntn (n+1) in if ntn.[n] == '_' then n::l else l
+and spaces ntn n =
+  if Int.equal n (String.length ntn) then []
+  else if ntn.[n] == ' ' then wildcards ntn (n+1) else spaces ntn (n+1)
+
+let expand_notation_string ntn n =
+  let pos = List.nth (wildcards ntn 0) n in
+  let hd = if Int.equal pos 0 then "" else String.sub ntn 0 pos in
+  let tl =
+    if Int.equal pos (String.length ntn) then ""
+    else String.sub ntn (pos+1) (String.length ntn - pos -1) in
+  hd ^ "{ _ }" ^ tl
+
+(* This contracts the special case of "{ _ }" for sumbool, sumor notations *)
+(* Remark: expansion of squash at definition is done in metasyntax.ml *)
+let contract_curly_brackets ntn subst =
+  match ntn.ntn_entry with
+  | InCustomEntry _ -> ntn, subst
+  | InConstrEntry ->
+  let ntn' = ref ntn.ntn_key in
+  let rec contract_squash n = function
+    | [] -> []
+    | NtnTypeArg (NtnTypeArgConstr { CAst.v = CNotation (None,{ntn_entry = InConstrEntry; ntn_key = "{ _ }"},[NtnTypeArg (NtnTypeArgConstr a)]) }) :: l ->
+        ntn' := expand_notation_string !ntn' n;
+        contract_squash n (NtnTypeArg (NtnTypeArgConstr a)::l)
+    | a :: l ->
+        a::contract_squash (n+1) l in
+  let subst = contract_squash 0 subst in
+  (* side effect; don't inline *)
+  mk_ntn_in_constr !ntn', subst
+
+let contract_curly_brackets_pat ntn subst =
+  match ntn.ntn_entry with
+  | InCustomEntry _ -> ntn, subst
+  | InConstrEntry ->
+  let ntn' = ref ntn.ntn_key in
+  let rec contract_squash n = function
+    | [] -> []
+    | NtnTypeArg (NtnTypeArgPattern ({ CAst.v = CPatNotation (None,{ntn_entry = InConstrEntry; ntn_key = "{ _ }"},[NtnTypeArg (NtnTypeArgPattern a)],[]) }, Explicit)) :: l ->
+        ntn' := expand_notation_string !ntn' n;
+        contract_squash n (NtnTypeArg (NtnTypeArgPattern a)::l)
+    | a :: l ->
+        a :: contract_squash (n+1) l in
+  let subst = contract_squash 0 subst in
+  (* side effect; don't inline *)
+  mk_ntn_in_constr !ntn', subst

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -95,47 +95,69 @@ let explicitation_eq pos1 pos2 = match pos1, pos2 with
 | ExplByPos n1, ExplByPos n2 -> Int.equal n1 n2
 | (ExplByName _ | ExplByPos _), _ -> false
 
-let rec cases_pattern_expr_eq p1 p2 =
-  if CAst.(p1.v == p2.v) then true
-  else match CAst.(p1.v, p2.v) with
-  | CPatAlias(a1,i1), CPatAlias(a2,i2) ->
-      CAst.eq Name.equal i1 i2 && cases_pattern_expr_eq a1 a2
-  | CPatCstr(c1,a1,b1), CPatCstr(c2,a2,b2) ->
-      qualid_eq c1 c2 &&
-      Option.equal (List.equal cases_pattern_expr_eq) a1 a2 &&
-      List.equal cases_pattern_expr_eq b1 b2
-  | CPatAtom(r1), CPatAtom(r2) ->
-    Option.equal qualid_eq r1 r2
-  | CPatOr a1, CPatOr a2 ->
-    List.equal cases_pattern_expr_eq a1 a2
-  | CPatNotation (inscope1, n1, s1, l1), CPatNotation (inscope2, n2, s2, l2) ->
-    Option.equal notation_with_optional_scope_eq inscope1 inscope2 &&
-    notation_eq n1 n2 &&
-    cases_pattern_notation_substitution_eq s1 s2 &&
-    List.equal cases_pattern_expr_eq l1 l2
-  | CPatPrim i1, CPatPrim i2 ->
-    prim_token_eq i1 i2
-  | CPatRecord l1, CPatRecord l2 ->
-    let equal (r1, e1) (r2, e2) =
-      qualid_eq r1 r2 && cases_pattern_expr_eq e1 e2
-    in
-    List.equal equal l1 l2
-  | CPatDelimiters(depth1,s1,e1), CPatDelimiters(depth2,s2,e2) ->
-    depth1 = depth2 && String.equal s1 s2 && cases_pattern_expr_eq e1 e2
-  | _ -> false
-
-and cases_pattern_notation_substitution_eq (s1, n1, b1) (s2, n2, b2) =
-  List.equal cases_pattern_expr_eq s1 s2 &&
-  List.equal (List.equal cases_pattern_expr_eq) n1 n2 &&
-  List.equal (eq_pair cases_pattern_expr_eq Glob_ops.binding_kind_eq) b1 b2
-
-let kinded_cases_pattern_expr_eq (p1,bk1) (p2,bk2) =
-  cases_pattern_expr_eq p1 p2 && Glob_ops.binding_kind_eq bk1 bk2
-
 (* We use a functor to avoid passing the recursion all over the place *)
-module EqGen (A:sig val constr_expr_eq : constr_expr -> constr_expr -> bool end) = struct
+module EqGen (A:sig
+    val constr_expr_eq : constr_expr -> constr_expr -> bool
+    val cases_pattern_expr_eq : cases_pattern_expr -> cases_pattern_expr -> bool
+  end) = struct
 
   open A
+
+  let local_binder_eq l1 l2 = match l1, l2 with
+    | CLocalDef (n1, _, e1, t1), CLocalDef (n2, _, e2, t2) ->
+      CAst.eq Name.equal n1 n2 && constr_expr_eq e1 e2 && Option.equal constr_expr_eq t1 t2
+    | CLocalAssum (n1, _, _, e1), CLocalAssum (n2, _, _, e2) ->
+      (* Don't care about the metadata *)
+      List.equal (CAst.eq Name.equal) n1 n2 && constr_expr_eq e1 e2
+    | _ -> false
+
+  let kinded_cases_pattern_expr_eq (p1,bk1) (p2,bk2) =
+    cases_pattern_expr_eq p1 p2 && Glob_ops.binding_kind_eq bk1 bk2
+
+  let notation_arg_kind_eq a1 a2 = match a1, a2 with
+    | NtnTypeArgConstr a1, NtnTypeArgConstr a2 -> constr_expr_eq a1 a2
+    | NtnTypeArgPattern b1, NtnTypeArgPattern b2 -> kinded_cases_pattern_expr_eq b1 b2
+    | NtnTypeArgBinders bll1, NtnTypeArgBinders bll2 -> List.equal local_binder_eq bll1 bll2
+    | (NtnTypeArgConstr _ | NtnTypeArgPattern _ | NtnTypeArgBinders _), _ -> false
+
+  let rec notation_arg_type_eq a1 a2 = match a1, a2 with
+    | NtnTypeArg v1, NtnTypeArg v2 -> notation_arg_kind_eq v1 v2
+    | NtnTypeArgList l1, NtnTypeArgList l2 -> List.equal notation_arg_type_eq l1 l2
+    | NtnTypeArgTuple l1, NtnTypeArgTuple l2 -> List.equal notation_arg_type_eq l1 l2
+    | (NtnTypeArg _ | NtnTypeArgList _ | NtnTypeArgTuple _), _ -> false
+
+  let notation_substitution_eq s1 s2 =
+    List.equal notation_arg_type_eq s1 s2
+
+  let rec cases_pattern_expr_eq p1 p2 =
+    if CAst.(p1.v == p2.v) then true
+    else match CAst.(p1.v, p2.v) with
+    | CPatAlias(a1,i1), CPatAlias(a2,i2) ->
+        CAst.eq Name.equal i1 i2 && cases_pattern_expr_eq a1 a2
+    | CPatCstr(c1,a1,b1), CPatCstr(c2,a2,b2) ->
+        qualid_eq c1 c2 &&
+        Option.equal (List.equal cases_pattern_expr_eq) a1 a2 &&
+        List.equal cases_pattern_expr_eq b1 b2
+    | CPatAtom(r1), CPatAtom(r2) ->
+      Option.equal qualid_eq r1 r2
+    | CPatOr a1, CPatOr a2 ->
+      List.equal cases_pattern_expr_eq a1 a2
+    | CPatNotation (inscope1, n1, s1, l1), CPatNotation (inscope2, n2, s2, l2) ->
+      Option.equal notation_with_optional_scope_eq inscope1 inscope2 &&
+      notation_eq n1 n2 &&
+      notation_substitution_eq s1 s2 &&
+      List.equal cases_pattern_expr_eq l1 l2
+    | CPatPrim i1, CPatPrim i2 ->
+      prim_token_eq i1 i2
+    | CPatRecord l1, CPatRecord l2 ->
+      let equal (r1, e1) (r2, e2) =
+        qualid_eq r1 r2 && cases_pattern_expr_eq e1 e2
+      in
+      List.equal equal l1 l2
+    | CPatDelimiters(depth1,s1,e1), CPatDelimiters(depth2,s2,e2) ->
+      depth1 = depth2 && String.equal s1 s2 && cases_pattern_expr_eq e1 e2
+    | _ -> false
+
   let args_eq (a1,e1) (a2,e2) =
     Option.equal (CAst.eq explicitation_eq) e1 e2 &&
     constr_expr_eq a1 a2
@@ -160,14 +182,6 @@ module EqGen (A:sig val constr_expr_eq : constr_expr -> constr_expr -> bool end)
 
   let recursion_order_expr_eq r1 r2 = CAst.eq recursion_order_expr_eq_r r1 r2
 
-  let local_binder_eq l1 l2 = match l1, l2 with
-    | CLocalDef (n1, _, e1, t1), CLocalDef (n2, _, e2, t2) ->
-      CAst.eq Name.equal n1 n2 && constr_expr_eq e1 e2 && Option.equal constr_expr_eq t1 t2
-    | CLocalAssum (n1, _, _, e1), CLocalAssum (n2, _, _, e2) ->
-      (* Don't care about the metadata *)
-      List.equal (CAst.eq Name.equal) n1 n2 && constr_expr_eq e1 e2
-    | _ -> false
-
   let fix_expr_eq (id1,_,r1,bl1,a1,b1) (id2,_,r2,bl2,a2,b2) =
     (lident_eq id1 id2) &&
     Option.equal recursion_order_expr_eq r1 r2 &&
@@ -180,12 +194,6 @@ module EqGen (A:sig val constr_expr_eq : constr_expr -> constr_expr -> bool end)
     List.equal local_binder_eq bl1 bl2 &&
     constr_expr_eq a1 a2 &&
     constr_expr_eq b1 b2
-
-  let constr_notation_substitution_eq (e1, el1, b1, bl1) (e2, el2, b2, bl2) =
-    List.equal constr_expr_eq e1 e2 &&
-    List.equal (List.equal constr_expr_eq) el1 el2 &&
-    List.equal kinded_cases_pattern_expr_eq b1 b2 &&
-    List.equal (List.equal local_binder_eq) bl1 bl2
 
   let instance_eq (x1,c1) (x2,c2) =
     Id.equal x1.CAst.v x2.CAst.v && constr_expr_eq c1 c2
@@ -259,7 +267,7 @@ module EqGen (A:sig val constr_expr_eq : constr_expr -> constr_expr -> bool end)
       | CNotation(inscope1, n1, s1), CNotation(inscope2, n2, s2) ->
         Option.equal notation_with_optional_scope_eq inscope1 inscope2 &&
         notation_eq n1 n2 &&
-        constr_notation_substitution_eq s1 s2
+        notation_substitution_eq s1 s2
       | CPrim i1, CPrim i2 ->
         prim_token_eq i1 i2
       | CGeneralization (bk1, e1), CGeneralization (bk2, e2) ->
@@ -281,14 +289,23 @@ module EqGen (A:sig val constr_expr_eq : constr_expr -> constr_expr -> bool end)
 
 end
 
-let constr_expr_eq_gen eq =
-  let module Eq = EqGen(struct let constr_expr_eq = eq end) in
+let constr_expr_eq_gen eq_constr eq_cases_pattern =
+  let module Eq = EqGen(struct let constr_expr_eq = eq_constr let cases_pattern_expr_eq = eq_cases_pattern end) in
   Eq.constr_expr_eq
 
+let cases_pattern_expr_eq_gen eq_constr eq_cases_pattern =
+  let module Eq = EqGen(struct let constr_expr_eq = eq_constr let cases_pattern_expr_eq = eq_cases_pattern end) in
+  Eq.cases_pattern_expr_eq
+
 module Eq = EqGen(struct
-    let rec constr_expr_eq c1 c2 = constr_expr_eq_gen constr_expr_eq c1 c2
+    let rec constr_expr_eq c1 c2 = constr_expr_eq_gen constr_expr_eq cases_pattern_expr_eq c1 c2
+    and cases_pattern_expr_eq c1 c2 = cases_pattern_expr_eq_gen constr_expr_eq cases_pattern_expr_eq c1 c2
   end)
 include Eq
+
+let rec cases_pattern_expr_eq_gen' eq_constr c = cases_pattern_expr_eq_gen eq_constr (cases_pattern_expr_eq_gen eq_constr (cases_pattern_expr_eq_gen' eq_constr)) c
+
+let constr_expr_eq_gen eq_constr = constr_expr_eq_gen eq_constr (cases_pattern_expr_eq_gen' eq_constr)
 
 let constr_loc c = CAst.(c.loc)
 let cases_pattern_expr_loc cp = CAst.(cp.loc)
@@ -314,6 +331,36 @@ let is_constructor id =
   | None -> false
   | Some gref -> Globnames.isConstructRef gref
 
+let notation_arg_kind_fold k1 k2 k3 acc = function
+  | NtnTypeArgConstr a -> k1 acc a
+  | NtnTypeArgPattern (pat,_) -> k2 acc pat
+  | NtnTypeArgBinders binder -> k3 acc binder
+
+let rec notation_arg_type_fold k1 k2 k3 acc = function
+  | NtnTypeArg a -> notation_arg_kind_fold k1 k2 k3 acc a
+  | NtnTypeArgList l -> List.fold_left (notation_arg_type_fold k1 k2 k3) acc l
+  | NtnTypeArgTuple l -> List.fold_left (notation_arg_type_fold k1 k2 k3) acc l
+
+let notation_arg_kind_fold_map k1 k2 k3 acc = function
+  | NtnTypeArgConstr a -> let acc, a = k1 acc a in acc, NtnTypeArgConstr a
+  | NtnTypeArgPattern (pat,kd) -> let acc, pat = k2 acc pat in acc, NtnTypeArgPattern (pat,kd)
+  | NtnTypeArgBinders binder -> let acc, binder = k3 acc binder in acc, NtnTypeArgBinders binder
+
+let rec notation_arg_type_fold_map k1 k2 k3 acc = function
+  | NtnTypeArg a -> let acc, a = notation_arg_kind_fold_map k1 k2 k3 acc a in acc, NtnTypeArg a
+  | NtnTypeArgList l -> let acc, l = List.fold_left_map (notation_arg_type_fold_map k1 k2 k3) acc l in acc, NtnTypeArgList l
+  | NtnTypeArgTuple l -> let acc, l = List.fold_left_map (notation_arg_type_fold_map k1 k2 k3) acc l in acc, NtnTypeArgTuple l
+
+let notation_arg_kind_map k1 k2 k3 = function
+  | NtnTypeArgConstr a -> NtnTypeArgConstr (k1 a)
+  | NtnTypeArgPattern (pat,kd) -> NtnTypeArgPattern (k2 pat,kd)
+  | NtnTypeArgBinders binder -> NtnTypeArgBinders (k3 binder)
+
+let rec notation_arg_type_map k1 k2 k3 = function
+  | NtnTypeArg a -> NtnTypeArg (notation_arg_kind_map k1 k2 k3 a)
+  | NtnTypeArgList l -> NtnTypeArgList (List.map (notation_arg_type_map k1 k2 k3) l)
+  | NtnTypeArgTuple l -> NtnTypeArgTuple (List.map (notation_arg_type_map k1 k2 k3) l)
+
 let rec cases_pattern_fold_names f h nacc pt = match CAst.(pt.v) with
   | CPatRecord l ->
     List.fold_left (fun nacc (r, cp) -> cases_pattern_fold_names f h nacc cp) nacc l
@@ -323,10 +370,13 @@ let rec cases_pattern_fold_names f h nacc pt = match CAst.(pt.v) with
   | CPatCstr (_,patl1,patl2) ->
     List.fold_left (cases_pattern_fold_names f h)
       (Option.fold_left (List.fold_left (cases_pattern_fold_names f h)) nacc patl1) patl2
-  | CPatNotation (_,_,(patl,patll,binderl),patl') ->
+  | CPatNotation (_,_,subst,patl') ->
     List.fold_left (cases_pattern_fold_names f h)
-      (List.fold_left (cases_pattern_fold_names f h) nacc
-         (patl@List.flatten patll@List.map fst binderl)) patl'
+      (List.fold_right (fun a x ->
+           notation_arg_type_fold h
+             (cases_pattern_fold_names f h)
+             (fun nacc _ -> nacc) x a)
+           subst nacc) patl'
   | CPatDelimiters (_,_,pat) -> cases_pattern_fold_names f h nacc pat
   | CPatAtom (Some qid)
       when qualid_is_ident qid && not (is_constructor @@ qualid_basename qid) ->
@@ -378,11 +428,12 @@ let fold_constr_expr_with_binders g f n acc = CAst.with_val (function
     | CLetIn (na,a,t,b) ->
       f (Name.fold_right g (na.CAst.v) n) (Option.fold_left (f n) (f n acc a) t) b
     | CCast (a,_,b) -> f n (f n acc a) b
-    | CNotation (_,_,(l,ll,bl,bll)) ->
-      (* The following is an approximation: we don't know exactly if
-         an ident is binding nor to which subterms bindings apply *)
-      let acc = List.fold_left (f n) acc (l@List.flatten ll) in
-      List.fold_left (fun acc bl -> fold_local_binders g f n acc (CAst.make @@ CHole (None)) bl) acc bll
+    | CNotation (_,_,subst) ->
+      List.fold_left (notation_arg_type_fold
+             (f n)
+             (fun acc a -> snd (cases_pattern_fold_names g (fun (n,acc) t -> (n,f n acc t)) (n,acc) a))
+             (fun acc a -> fold_local_binders g f n acc (CAst.make @@ CHole None) a))
+        acc subst
     | CGeneralization (_,c) -> f n acc c
     | CDelimiters (_,_,a) -> f n acc a
     | CRecord l -> List.fold_left (fun acc (id, c) -> f n acc c) acc l
@@ -456,12 +507,15 @@ let rec fold_map_cases_pattern f h acc (CAst.{v=pt;loc} as p) = match pt with
     let acc, patl1 = Option.fold_left_map (List.fold_left_map (fold_map_cases_pattern f h)) acc patl1 in
     let acc, patl2 = List.fold_left_map (fold_map_cases_pattern f h) acc patl2 in
     acc, CAst.make ?loc (CPatCstr (c,patl1,patl2))
-  | CPatNotation (sc,ntn,(patl,patll,binderl),patl') ->
-    let acc, patl = List.fold_left_map (fold_map_cases_pattern f h) acc patl in
-    let acc, patll = List.fold_left_map (List.fold_left_map (fold_map_cases_pattern f h)) acc patll in
-    let acc, binderl' = List.fold_left_map (fold_fst (fold_map_cases_pattern f h)) acc binderl in
+  | CPatNotation (sc,ntn,subst,patl') ->
+    let acc, subst = List.fold_left_map
+        (notation_arg_type_fold_map
+          (fun acc c -> (acc, h acc c))
+          (fold_map_cases_pattern f h)
+          (fun _ _ -> assert false))
+        acc subst in
     let acc, patl' = List.fold_left_map (fold_map_cases_pattern f h) acc patl' in
-    acc, CAst.make ?loc (CPatNotation (sc,ntn,(patl,patll,binderl'),patl'))
+    acc, CAst.make ?loc (CPatNotation (sc,ntn,subst,patl'))
   | CPatDelimiters (depth,d,pat) ->
     let acc, p = fold_map_cases_pattern f h acc pat in
     acc, CAst.make ?loc (CPatDelimiters (depth,d,pat))
@@ -505,10 +559,12 @@ let map_constr_expr_with_binders g f e = CAst.map (function
     | CLetIn (na,a,t,b) ->
       CLetIn (na,f e a,Option.map (f e) t,f (Name.fold_right g (na.CAst.v) e) b)
     | CCast (a,k,c) -> CCast (f e a, k, f e c)
-    | CNotation (inscope,n,(l,ll,bl,bll)) ->
+    | CNotation (inscope,n,subst) ->
       (* This is an approximation because we don't know what binds what *)
-      CNotation (inscope,n,(List.map (f e) l,List.map (List.map (f e)) ll, bl,
-                    List.map (fun bl -> snd (fold_map_local_binders f g e bl)) bll))
+      CNotation (inscope,n,
+                 List.map (notation_arg_type_map (f e)
+                             (fun a -> snd (fold_map_cases_pattern g f e a))
+                             (fun a -> snd (fold_map_local_binders f g e a))) subst)
     | CGeneralization (b,c) -> CGeneralization (b,f e c)
     | CDelimiters (depth,s,a) -> CDelimiters (depth,s,f e a)
     | CRecord l -> CRecord (List.map (fun (id, c) -> (id, f e c)) l)
@@ -568,15 +624,11 @@ let locs_of_notation ?loc locs ntn =
     | (ba,ea)::l -> if Int.equal pos ba then aux ea l else (pos,ba)::aux ea l
   in aux bl (List.sort (fun l1 l2 -> fst l1 - fst l2) locs)
 
-let ntn_loc ?loc (args,argslist,binders,binderslist) =
+let ntn_loc ?loc subst =
   locs_of_notation ?loc
-    (List.map constr_loc (args@List.flatten argslist)@
-     List.map (fun (x,_) -> cases_pattern_expr_loc x) binders@
-     List.map local_binders_loc binderslist)
-
-let patntn_loc ?loc (args,argslist,binders) =
-  locs_of_notation ?loc
-    (List.map cases_pattern_expr_loc (args@List.flatten argslist@List.map fst binders))
+    (List.fold_left (notation_arg_type_fold (fun acc c -> constr_loc c :: acc)
+                        (fun acc x -> cases_pattern_expr_loc x :: acc)
+                        (fun acc bl -> local_binders_loc bl :: acc)) [] subst)
 
 let error_invalid_pattern_notation ?loc () =
   CErrors.user_err ?loc  (str "Invalid notation for pattern.")
@@ -645,6 +697,16 @@ let mkAppPattern ?loc p lp =
   | CPatNotation (inscope, n, s, l) -> CPatNotation (inscope, n , s, l@lp)
   | _ -> CErrors.user_err ?loc:p.loc (Pp.str "Such pattern cannot have arguments."))
 
+let notation_arg_kind_map_coerce k1 k2 k3 = function
+  | NtnTypeArgConstr a -> NtnTypeArgPattern (k1 a)
+  | NtnTypeArgPattern (pat,kd) -> NtnTypeArgPattern (k2 pat,kd)
+  | NtnTypeArgBinders binder -> NtnTypeArgBinders (k3 binder)
+
+let rec notation_arg_type_map_coerce k1 k2 k3 = function
+  | NtnTypeArg a -> NtnTypeArg (notation_arg_kind_map_coerce k1 k2 k3 a)
+  | NtnTypeArgList l -> NtnTypeArgList (List.map (notation_arg_type_map_coerce k1 k2 k3) l)
+  | NtnTypeArgTuple l -> NtnTypeArgTuple (List.map (notation_arg_type_map_coerce k1 k2 k3) l)
+
 let rec coerce_to_cases_pattern_expr c = CAst.map_with_loc (fun ?loc -> function
   | CRef (r,None) ->
      CPatAtom (Some r)
@@ -657,10 +719,11 @@ let rec coerce_to_cases_pattern_expr c = CAst.map_with_loc (fun ?loc -> function
      (mkAppPattern (coerce_to_cases_pattern_expr p) (List.map (fun (a,_) -> coerce_to_cases_pattern_expr a) args)).CAst.v
   | CAppExpl ((r,i),args) ->
      CPatCstr (r,Some (List.map coerce_to_cases_pattern_expr args),[])
-  | CNotation (inscope,ntn,(c,cl,b,[])) ->
-     CPatNotation (inscope,ntn,(List.map coerce_to_cases_pattern_expr c,
-                                List.map (List.map coerce_to_cases_pattern_expr) cl,
-                                b),[])
+  | CNotation (inscope,ntn,subst) ->
+     CPatNotation (inscope,ntn,List.map (notation_arg_type_map_coerce
+                                           (fun c -> (coerce_to_cases_pattern_expr c, Explicit))
+                                           (fun c -> c)
+                                           (fun _ -> assert false)) subst, [])
   | CPrim p ->
      CPatPrim p
   | CRecord l ->
@@ -673,7 +736,6 @@ let rec coerce_to_cases_pattern_expr c = CAst.map_with_loc (fun ?loc -> function
   | CRef (_, Some _) | CCast (_, (Some (VMcast|NATIVEcast) | None), _)
   | CFix _ | CCoFix _ | CApp _ | CProj _ | CCases _ | CLetTuple _ | CIf _
   | CPatVar _ | CEvar _
-  | CNotation (_,_,(_,_,_,_::_))
   | CHole (Some _) | CGenarg _ | CGenargGlob _ ->
     CErrors.user_err ?loc
                       (str "This expression should be coercible to a pattern.")

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -334,18 +334,17 @@ let rec cases_pattern_fold_names f h nacc pt = match CAst.(pt.v) with
       (f (qualid_basename qid) n, acc)
   | CPatPrim _ | CPatAtom _ -> nacc
   | CPatCast (p,t) ->
-      let (n, acc) = nacc in
-      cases_pattern_fold_names f h (n, h acc t) p
+      cases_pattern_fold_names f h (h nacc t) p
 
 let ids_of_pattern_list p =
   fst (List.fold_left
-    (List.fold_left (cases_pattern_fold_names Id.Set.add (fun () _ -> ())))
+    (List.fold_left (cases_pattern_fold_names Id.Set.add (fun nacc _ -> nacc)))
     (Id.Set.empty,()) p)
 
 let ids_of_cases_tomatch tms =
   List.fold_right
     (fun (_, ona, indnal) l ->
-       Option.fold_right (fun t ids -> fst (cases_pattern_fold_names Id.Set.add (fun () _ -> ()) (ids,()) t))
+       Option.fold_right (fun t ids -> fst (cases_pattern_fold_names Id.Set.add (fun nacc _ -> nacc) (ids,()) t))
          indnal
          (Option.fold_right (CAst.with_val (Name.fold_right Id.Set.add)) ona l))
     tms Id.Set.empty
@@ -362,7 +361,7 @@ let fold_local_binder k g f n acc = let open CAst in function
     let n' = Name.fold_right g na n in
     k n' (Option.fold_left (f n) (f n acc c) t)
   | CLocalPattern pat ->
-    let n, acc = cases_pattern_fold_names g (f n) (n,acc) pat in
+    let n, acc = cases_pattern_fold_names g (fun (n,acc) t -> (n,f n acc t)) (n,acc) pat in
     k n acc
 
 let rec fold_local_binders g f n acc b = function
@@ -392,8 +391,8 @@ let fold_constr_expr_with_binders g f n acc = CAst.with_val (function
       let acc = Option.fold_left (f (Id.Set.fold g ids n)) acc rtnpo in
       let acc = List.fold_left (f n) acc (List.map (fun (fst,_,_) -> fst) al) in
       List.fold_right (fun {CAst.v=(patl,rhs)} acc ->
-          let ids = ids_of_pattern_list patl in
-          f (Id.Set.fold g ids n) acc rhs) bl acc
+          let (n,acc) = List.fold_left (List.fold_left (cases_pattern_fold_names g (fun (n,acc) t -> (n,f n acc t)))) (n,acc) patl in
+          f n acc rhs) bl acc
     | CLetTuple (nal,(ona,po),b,c) ->
       let n' = List.fold_right (CAst.with_val (Name.fold_right g)) nal n in
       f (Option.fold_right (CAst.with_val (Name.fold_right g)) ona n') (f n acc b) c
@@ -413,13 +412,24 @@ let fold_constr_expr_with_binders g f n acc = CAst.with_val (function
       acc
   )
 
+let rec free_vars_of_constr_expr_gen bdvars l = function
+  | { CAst.v = CRef (qid, _) } when qualid_is_ident qid ->
+    let id = qualid_basename qid in
+    if Id.List.mem id bdvars then l else Id.Set.add id l
+  | c -> fold_constr_expr_with_binders (fun a l -> a::l) free_vars_of_constr_expr_gen bdvars l c
+
 let free_vars_of_constr_expr c =
-  let rec aux bdvars l = function
-    | { CAst.v = CRef (qid, _) } when qualid_is_ident qid ->
-      let id = qualid_basename qid in
-      if Id.List.mem id bdvars then l else Id.Set.add id l
-    | c -> fold_constr_expr_with_binders (fun a l -> a::l) aux bdvars l c
-  in aux [] Id.Set.empty c
+  free_vars_of_constr_expr_gen [] Id.Set.empty c
+
+let free_vars_of_cases_pattern_expr c =
+  snd (cases_pattern_fold_names (fun a l -> a::l)
+    (fun (bdvars,l) t -> (bdvars,free_vars_of_constr_expr_gen bdvars l t))
+    ([],Id.Set.empty) c)
+
+let free_vars_of_local_binders bl =
+  fold_local_binders (fun a l -> a::l)
+    free_vars_of_constr_expr_gen
+    [] Id.Set.empty (CAst.make @@ CHole (None)) bl
 
 let names_of_constr_expr c =
   let vars = ref Id.Set.empty in

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -350,16 +350,24 @@ let ids_of_cases_tomatch tms =
          (Option.fold_right (CAst.with_val (Name.fold_right Id.Set.add)) ona l))
     tms Id.Set.empty
 
-let rec fold_local_binders g f n acc b = let open CAst in function
-  | CLocalAssum (nal,_,bk,t)::l ->
+(* [n] collects data from binders using [g];
+   [acc] accumulates over "constr" subterms using [f];
+   [k] is a continuation, working on the updated [n] *)
+let fold_local_binder k g f n acc = let open CAst in function
+  | CLocalAssum (nal,_,bk,t) ->
     let nal = List.(map (fun {v} -> v) nal) in
     let n' = List.fold_right (Name.fold_right g) nal n in
-    f n (fold_local_binders g f n' acc b l) t
-  | CLocalDef ( { v = na },_,c,t)::l ->
-    Option.fold_left (f n) (f n (fold_local_binders g f (Name.fold_right g na n) acc b l) c) t
-  | CLocalPattern pat :: l ->
+    k n' (f n acc t)
+  | CLocalDef ( { v = na },_,c,t) ->
+    let n' = Name.fold_right g na n in
+    k n' (Option.fold_left (f n) (f n acc c) t)
+  | CLocalPattern pat ->
     let n, acc = cases_pattern_fold_names g (f n) (n,acc) pat in
-    fold_local_binders g f n acc b l
+    k n acc
+
+let rec fold_local_binders g f n acc b = function
+  | decl :: l ->
+    fold_local_binder (fun n acc -> fold_local_binders g f n acc b l) g f n acc decl
   | [] ->
     f n acc b
 

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -467,18 +467,19 @@ let rec fold_map_cases_pattern f h acc (CAst.{v=pt;loc} as p) = match pt with
 (* Used in correctness and interface *)
 let map_binder g e nal = List.fold_right (CAst.with_val (Name.fold_right g)) nal e
 
+let fold_map_local_binder f g e = function
+  (* TODO: avoid variable capture in [t] by some [na] in [List.tl nal] *)
+  | CLocalAssum(nal,r,k,ty) ->
+    (map_binder g e nal, CLocalAssum(nal,r,k,f e ty))
+  | CLocalDef( { loc ; v = na } as cna,r,c,ty) ->
+    (Name.fold_right g na e, CLocalDef(cna,r,f e c,Option.map (f e) ty))
+  | CLocalPattern pat ->
+    let e, pat = fold_map_cases_pattern g f e pat in
+    (e, CLocalPattern pat)
+
 let fold_map_local_binders f g e bl =
   (* TODO: avoid variable capture in [t] by some [na] in [List.tl nal] *)
-  let open CAst in
-  let h (e,bl) = function
-      CLocalAssum(nal,r,k,ty) ->
-      (map_binder g e nal, CLocalAssum(nal,r,k,f e ty)::bl)
-    | CLocalDef( { loc ; v = na } as cna ,r,c,ty) ->
-      (Name.fold_right g na e, CLocalDef(cna,r,f e c,Option.map (f e) ty)::bl)
-    | CLocalPattern pat ->
-      let e, pat = fold_map_cases_pattern g f e pat in
-      (e, CLocalPattern pat::bl) in
-  let (e,rbl) = List.fold_left h (e,[]) bl in
+  let (e,rbl) = List.fold_left (fun (e,bl) b -> let (e, b) = fold_map_local_binder f g e b in (e,b::bl)) (e,[]) bl in
   (e, List.rev rbl)
 
 let map_constr_expr_with_binders g f e = CAst.map (function

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -361,124 +361,130 @@ let rec notation_arg_type_map k1 k2 k3 = function
   | NtnTypeArgList l -> NtnTypeArgList (List.map (notation_arg_type_map k1 k2 k3) l)
   | NtnTypeArgTuple l -> NtnTypeArgTuple (List.map (notation_arg_type_map k1 k2 k3) l)
 
-let rec cases_pattern_fold_names f h nacc pt = match CAst.(pt.v) with
+(* [eacc] is a pair [(e,acc)] where [e] is updated at traversal of a
+   variable by [g] and [acc] is the result of map-folding constr subterms
+   (i.e.  basically subterms in Cast and Notation) using [f];
+   By map-folding is meant that [f] updates both [e] and [acc]. *)
+let rec cases_pattern_fold_names g f eacc pt = match CAst.(pt.v) with
   | CPatRecord l ->
-    List.fold_left (fun nacc (r, cp) -> cases_pattern_fold_names f h nacc cp) nacc l
-  | CPatAlias (pat,{CAst.v=na}) -> Name.fold_right (fun na (n,acc) -> (f na n,acc)) na (cases_pattern_fold_names f h nacc pat)
+    List.fold_left (fun eacc (r, cp) -> cases_pattern_fold_names g f eacc cp) eacc l
+  | CPatAlias (pat,{CAst.v=na}) -> Name.fold_right (fun na (e,acc) -> (g na e,acc)) na (cases_pattern_fold_names g f eacc pat)
   | CPatOr (patl) ->
-    List.fold_left (cases_pattern_fold_names f h) nacc patl
+    List.fold_left (cases_pattern_fold_names g f) eacc patl
   | CPatCstr (_,patl1,patl2) ->
-    List.fold_left (cases_pattern_fold_names f h)
-      (Option.fold_left (List.fold_left (cases_pattern_fold_names f h)) nacc patl1) patl2
+    List.fold_left (cases_pattern_fold_names g f)
+      (Option.fold_left (List.fold_left (cases_pattern_fold_names g f)) eacc patl1) patl2
   | CPatNotation (_,_,subst,patl') ->
-    List.fold_left (cases_pattern_fold_names f h)
+    List.fold_left (cases_pattern_fold_names g f)
       (List.fold_right (fun a x ->
-           notation_arg_type_fold h
-             (cases_pattern_fold_names f h)
-             (fun nacc _ -> nacc) x a)
-           subst nacc) patl'
-  | CPatDelimiters (_,_,pat) -> cases_pattern_fold_names f h nacc pat
+           notation_arg_type_fold f
+             (cases_pattern_fold_names g f)
+             (fun eacc _ -> eacc) x a)
+           subst eacc) patl'
+  | CPatDelimiters (_,_,pat) -> cases_pattern_fold_names g f eacc pat
   | CPatAtom (Some qid)
       when qualid_is_ident qid && not (is_constructor @@ qualid_basename qid) ->
-      let (n, acc) = nacc in
-      (f (qualid_basename qid) n, acc)
-  | CPatPrim _ | CPatAtom _ -> nacc
+      let (e, acc) = eacc in
+      (g (qualid_basename qid) e, acc)
+  | CPatPrim _ | CPatAtom _ -> eacc
   | CPatCast (p,t) ->
-      cases_pattern_fold_names f h (h nacc t) p
+      cases_pattern_fold_names g f (f eacc t) p
 
 let ids_of_pattern_list p =
   fst (List.fold_left
-    (List.fold_left (cases_pattern_fold_names Id.Set.add (fun nacc _ -> nacc)))
+    (List.fold_left (cases_pattern_fold_names Id.Set.add (fun eacc _ -> eacc)))
     (Id.Set.empty,()) p)
 
 let ids_of_cases_tomatch tms =
   List.fold_right
     (fun (_, ona, indnal) l ->
-       Option.fold_right (fun t ids -> fst (cases_pattern_fold_names Id.Set.add (fun nacc _ -> nacc) (ids,()) t))
+       Option.fold_right (fun t ids -> fst (cases_pattern_fold_names Id.Set.add (fun eacc _ -> eacc) (ids,()) t))
          indnal
          (Option.fold_right (CAst.with_val (Name.fold_right Id.Set.add)) ona l))
     tms Id.Set.empty
 
-(* [n] collects data from binders using [g];
+(* [e] collects data from binders using [g];
    [acc] accumulates over "constr" subterms using [f];
-   [k] is a continuation, working on the updated [n] *)
-let fold_local_binder k g f n acc = let open CAst in function
+   [k] is a continuation, working on the updated [e] *)
+let fold_local_binder k g f e acc = let open CAst in function
   | CLocalAssum (nal,_,bk,t) ->
     let nal = List.(map (fun {v} -> v) nal) in
-    let n' = List.fold_right (Name.fold_right g) nal n in
-    k n' (f n acc t)
+    let e' = List.fold_right (Name.fold_right g) nal e in
+    k e' (f e acc t)
   | CLocalDef ( { v = na },_,c,t) ->
-    let n' = Name.fold_right g na n in
-    k n' (Option.fold_left (f n) (f n acc c) t)
+    let e' = Name.fold_right g na e in
+    k e' (Option.fold_left (f e) (f e acc c) t)
   | CLocalPattern pat ->
-    let n, acc = cases_pattern_fold_names g (fun (n,acc) t -> (n,f n acc t)) (n,acc) pat in
-    k n acc
+    let e, acc = cases_pattern_fold_names g (fun (e,acc) t -> (e,f e acc t)) (e,acc) pat in
+    k e acc
 
-let rec fold_local_binders g f n acc b = function
+let rec fold_local_binders g f e acc b = function
   | decl :: l ->
-    fold_local_binder (fun n acc -> fold_local_binders g f n acc b l) g f n acc decl
+    fold_local_binder (fun e acc -> fold_local_binders g f e acc b l) g f e acc decl
   | [] ->
-    f n acc b
+    f e acc b
 
-let fold_constr_expr_with_binders g f n acc = CAst.with_val (function
-    | CAppExpl ((_,_),l) -> List.fold_left (f n) acc l
-    | CApp (t,l) -> List.fold_left (f n) (f n acc t) (List.map fst l)
-    | CProj (e,_,l,t) -> f n (List.fold_left (f n) acc (List.map fst l)) t
-    | CProdN (l,b) | CLambdaN (l,b) -> fold_local_binders g f n acc b l
+(* [n] collects data from binders using [g];
+   [acc] accumulates over subterms using [f] *)
+let fold_constr_expr_with_binders g f e acc = CAst.with_val (function
+    | CAppExpl ((_,_),l) -> List.fold_left (f e) acc l
+    | CApp (t,l) -> List.fold_left (f e) (f e acc t) (List.map fst l)
+    | CProj (_,_,l,t) -> f e (List.fold_left (f e) acc (List.map fst l)) t
+    | CProdN (l,b) | CLambdaN (l,b) -> fold_local_binders g f e acc b l
     | CLetIn (na,a,t,b) ->
-      f (Name.fold_right g (na.CAst.v) n) (Option.fold_left (f n) (f n acc a) t) b
-    | CCast (a,_,b) -> f n (f n acc a) b
+      f (Name.fold_right g (na.CAst.v) e) (Option.fold_left (f e) (f e acc a) t) b
+    | CCast (a,_,b) -> f e (f e acc a) b
     | CNotation (_,_,subst) ->
       List.fold_left (notation_arg_type_fold
-             (f n)
-             (fun acc a -> snd (cases_pattern_fold_names g (fun (n,acc) t -> (n,f n acc t)) (n,acc) a))
-             (fun acc a -> fold_local_binders g f n acc (CAst.make @@ CHole None) a))
+             (f e)
+             (fun acc a -> snd (cases_pattern_fold_names g (fun (e,acc) t -> (e,f e acc t)) (e,acc) a))
+             (fun acc a -> fold_local_binders g f e acc (CAst.make @@ CHole None) a))
         acc subst
-    | CGeneralization (_,c) -> f n acc c
-    | CDelimiters (_,_,a) -> f n acc a
-    | CRecord l -> List.fold_left (fun acc (id, c) -> f n acc c) acc l
+    | CGeneralization (_,c) -> f e acc c
+    | CDelimiters (_,_,a) -> f e acc a
+    | CRecord l -> List.fold_left (fun acc (id, c) -> f e acc c) acc l
     | CCases (sty,rtnpo,al,bl) ->
       let ids = ids_of_cases_tomatch al in
-      let acc = Option.fold_left (f (Id.Set.fold g ids n)) acc rtnpo in
-      let acc = List.fold_left (f n) acc (List.map (fun (fst,_,_) -> fst) al) in
+      let acc = Option.fold_left (f (Id.Set.fold g ids e)) acc rtnpo in
+      let acc = List.fold_left (f e) acc (List.map (fun (fst,_,_) -> fst) al) in
       List.fold_right (fun {CAst.v=(patl,rhs)} acc ->
-          let (n,acc) = List.fold_left (List.fold_left (cases_pattern_fold_names g (fun (n,acc) t -> (n,f n acc t)))) (n,acc) patl in
-          f n acc rhs) bl acc
+          let (e,acc) = List.fold_left (List.fold_left (cases_pattern_fold_names g (fun (e,acc) t -> (e,f e acc t)))) (e,acc) patl in
+          f e acc rhs) bl acc
     | CLetTuple (nal,(ona,po),b,c) ->
-      let n' = List.fold_right (CAst.with_val (Name.fold_right g)) nal n in
-      f (Option.fold_right (CAst.with_val (Name.fold_right g)) ona n') (f n acc b) c
+      let e' = List.fold_right (CAst.with_val (Name.fold_right g)) nal e in
+      f (Option.fold_right (CAst.with_val (Name.fold_right g)) ona e') (f e acc b) c
     | CIf (c,(ona,po),b1,b2) ->
-      let acc = f n (f n (f n acc b1) b2) c in
+      let acc = f e (f e (f e acc b1) b2) c in
       Option.fold_left
-        (f (Option.fold_right (CAst.with_val (Name.fold_right g)) ona n)) acc po
+        (f (Option.fold_right (CAst.with_val (Name.fold_right g)) ona e)) acc po
     | CFix (_,l) ->
-      let n' = List.fold_right (fun ( { CAst.v = id },_,_,_,_,_) -> g id) l n in
+      let e' = List.fold_right (fun ( { CAst.v = id },_,_,_,_,_) -> g id) l e in
       List.fold_right (fun (_,_,ro,lb,t,c) acc ->
-          fold_local_binders g f n'
-            (fold_local_binders g f n acc t lb) c lb) l acc
+          fold_local_binders g f e'
+            (fold_local_binders g f e acc t lb) c lb) l acc
     | CCoFix (_,_) ->
       Feedback.msg_warning (strbrk "Capture check in multiple binders not done"); acc
-    | CArray (_u,t,def,ty) -> f n (f n (Array.fold_left (f n) acc t) def) ty
+    | CArray (_u,t,def,ty) -> f e (f e (Array.fold_left (f e) acc t) def) ty
     | CHole _ | CGenarg _ | CGenargGlob _ | CEvar _ | CPatVar _ | CSort _ | CPrim _ | CRef _ ->
       acc
   )
 
-let rec free_vars_of_constr_expr_gen bdvars l = function
+let rec free_vars_of_constr_expr_gen bdvars ids = function
   | { CAst.v = CRef (qid, _) } when qualid_is_ident qid ->
     let id = qualid_basename qid in
-    if Id.List.mem id bdvars then l else Id.Set.add id l
-  | c -> fold_constr_expr_with_binders (fun a l -> a::l) free_vars_of_constr_expr_gen bdvars l c
+    if Id.List.mem id bdvars then ids else Id.Set.add id ids
+  | c -> fold_constr_expr_with_binders (fun a ids -> a::ids) free_vars_of_constr_expr_gen bdvars ids c
 
 let free_vars_of_constr_expr c =
   free_vars_of_constr_expr_gen [] Id.Set.empty c
 
 let free_vars_of_cases_pattern_expr c =
-  snd (cases_pattern_fold_names (fun a l -> a::l)
-    (fun (bdvars,l) t -> (bdvars,free_vars_of_constr_expr_gen bdvars l t))
+  snd (cases_pattern_fold_names (fun a ids -> a::ids)
+    (fun (bdvars,ids) t -> (bdvars,free_vars_of_constr_expr_gen bdvars ids t))
     ([],Id.Set.empty) c)
 
 let free_vars_of_local_binders bl =
-  fold_local_binders (fun a l -> a::l)
+  fold_local_binders (fun a ids -> a::ids)
     free_vars_of_constr_expr_gen
     [] Id.Set.empty (CAst.make @@ CHole (None)) bl
 
@@ -492,46 +498,50 @@ let names_of_constr_expr c =
 
 let occur_var_constr_expr id c = Id.Set.mem id (free_vars_of_constr_expr c)
 
-let rec fold_map_cases_pattern f h acc (CAst.{v=pt;loc} as p) = match pt with
+(* applies [f] on a cases pattern, where [f] depends on an "environent" [e]
+   which is updated by [g] at each traversal of a binder *)
+let rec fold_map_cases_pattern g f e (CAst.{v=pt;loc} as p) = match pt with
   | CPatRecord l ->
-    let acc, l = List.fold_left_map (fun acc (r, cp) -> let acc, cp = fold_map_cases_pattern f h acc cp in acc, (r, cp)) acc l in
-    acc, CAst.make ?loc (CPatRecord l)
+    let e, l = List.fold_left_map (fun e (r, cp) -> let e, cp = fold_map_cases_pattern g f e cp in e, (r, cp)) e l in
+    e, CAst.make ?loc (CPatRecord l)
   | CPatAlias (pat,({CAst.v=na} as lna)) ->
-    let acc, p = fold_map_cases_pattern f h acc pat in
-    let acc = Name.fold_right f na acc in
-    acc, CAst.make ?loc (CPatAlias (pat,lna))
+    let e, p = fold_map_cases_pattern g f e pat in
+    let e = Name.fold_right g na e in
+    e, CAst.make ?loc (CPatAlias (pat,lna))
   | CPatOr patl ->
-    let acc, patl = List.fold_left_map (fold_map_cases_pattern f h) acc patl in
-    acc, CAst.make ?loc (CPatOr patl)
+    let e, patl = List.fold_left_map (fold_map_cases_pattern g f) e patl in
+    e, CAst.make ?loc (CPatOr patl)
   | CPatCstr (c,patl1,patl2) ->
-    let acc, patl1 = Option.fold_left_map (List.fold_left_map (fold_map_cases_pattern f h)) acc patl1 in
-    let acc, patl2 = List.fold_left_map (fold_map_cases_pattern f h) acc patl2 in
-    acc, CAst.make ?loc (CPatCstr (c,patl1,patl2))
+    let e, patl1 = Option.fold_left_map (List.fold_left_map (fold_map_cases_pattern g f)) e patl1 in
+    let e, patl2 = List.fold_left_map (fold_map_cases_pattern g f) e patl2 in
+    e, CAst.make ?loc (CPatCstr (c,patl1,patl2))
   | CPatNotation (sc,ntn,subst,patl') ->
-    let acc, subst = List.fold_left_map
+    let e, subst = List.fold_left_map
         (notation_arg_type_fold_map
-          (fun acc c -> (acc, h acc c))
-          (fold_map_cases_pattern f h)
+          (fun e c -> (e, f e c))
+          (fold_map_cases_pattern g f)
           (fun _ _ -> assert false))
-        acc subst in
-    let acc, patl' = List.fold_left_map (fold_map_cases_pattern f h) acc patl' in
-    acc, CAst.make ?loc (CPatNotation (sc,ntn,subst,patl'))
+        e subst in
+    let e, patl' = List.fold_left_map (fold_map_cases_pattern g f) e patl' in
+    e, CAst.make ?loc (CPatNotation (sc,ntn,subst,patl'))
   | CPatDelimiters (depth,d,pat) ->
-    let acc, p = fold_map_cases_pattern f h acc pat in
-    acc, CAst.make ?loc (CPatDelimiters (depth,d,pat))
+    let e, p = fold_map_cases_pattern g f e pat in
+    e, CAst.make ?loc (CPatDelimiters (depth,d,pat))
   | CPatAtom (Some qid)
       when qualid_is_ident qid && not (is_constructor @@ qualid_basename qid) ->
-    f (qualid_basename qid) acc, p
-  | CPatPrim _ | CPatAtom _ -> (acc,p)
+    g (qualid_basename qid) e, p
+  | CPatPrim _ | CPatAtom _ -> (e,p)
   | CPatCast (pat,t) ->
-    let acc, pat = fold_map_cases_pattern f h acc pat in
-    let t = h acc t in
-    acc, CAst.make ?loc (CPatCast (pat,t))
+    let e, pat = fold_map_cases_pattern g f e pat in
+    let t = f e t in
+    e, CAst.make ?loc (CPatCast (pat,t))
 
 (* Used in correctness and interface *)
 let map_binder g e nal = List.fold_right (CAst.with_val (Name.fold_right g)) nal e
 
-let fold_map_local_binder f g e = function
+(* applies [f] on a local binder, where [f] depends on an "environent" [e]
+   which is updated by [g] at each traversal of a binder *)
+let fold_map_local_binder g f e = function
   (* TODO: avoid variable capture in [t] by some [na] in [List.tl nal] *)
   | CLocalAssum(nal,r,k,ty) ->
     (map_binder g e nal, CLocalAssum(nal,r,k,f e ty))
@@ -541,11 +551,15 @@ let fold_map_local_binder f g e = function
     let e, pat = fold_map_cases_pattern g f e pat in
     (e, CLocalPattern pat)
 
-let fold_map_local_binders f g e bl =
+(* applies [f] on local binders, where [f] depends on an "environent" [e]
+   which is updated by [g] at each traversal of a binder *)
+let fold_map_local_binders g f e bl =
   (* TODO: avoid variable capture in [t] by some [na] in [List.tl nal] *)
-  let (e,rbl) = List.fold_left (fun (e,bl) b -> let (e, b) = fold_map_local_binder f g e b in (e,b::bl)) (e,[]) bl in
+  let (e,rbl) = List.fold_left (fun (e,bl) b -> let (e, b) = fold_map_local_binder g f e b in (e,b::bl)) (e,[]) bl in
   (e, List.rev rbl)
 
+(* applies [f] on an constr_expr, where [f] depends on an "environent" [e]
+   which is updated by [g] at each traversal of a binder *)
 let map_constr_expr_with_binders g f e = CAst.map (function
     | CAppExpl (r,l) -> CAppExpl (r,List.map (f e) l)
     | CApp (a,l) ->
@@ -553,9 +567,9 @@ let map_constr_expr_with_binders g f e = CAst.map (function
     | CProj (expl,p,l,a) ->
       CProj (expl,p,List.map (fun (a,i) -> (f e a,i)) l,f e a)
     | CProdN (bl,b) ->
-      let (e,bl) = fold_map_local_binders f g e bl in CProdN (bl,f e b)
+      let (e,bl) = fold_map_local_binders g f e bl in CProdN (bl,f e b)
     | CLambdaN (bl,b) ->
-      let (e,bl) = fold_map_local_binders f g e bl in CLambdaN (bl,f e b)
+      let (e,bl) = fold_map_local_binders g f e bl in CLambdaN (bl,f e b)
     | CLetIn (na,a,t,b) ->
       CLetIn (na,f e a,Option.map (f e) t,f (Name.fold_right g (na.CAst.v) e) b)
     | CCast (a,k,c) -> CCast (f e a, k, f e c)
@@ -564,7 +578,7 @@ let map_constr_expr_with_binders g f e = CAst.map (function
       CNotation (inscope,n,
                  List.map (notation_arg_type_map (f e)
                              (fun a -> snd (fold_map_cases_pattern g f e a))
-                             (fun a -> snd (fold_map_local_binders f g e a))) subst)
+                             (fun a -> snd (fold_map_local_binders g f e a))) subst)
     | CGeneralization (b,c) -> CGeneralization (b,f e c)
     | CDelimiters (depth,s,a) -> CDelimiters (depth,s,f e a)
     | CRecord l -> CRecord (List.map (fun (id, c) -> (id, f e c)) l)
@@ -584,7 +598,7 @@ let map_constr_expr_with_binders g f e = CAst.map (function
       CIf (f e c,(ona,Option.map (f e') po),f e b1,f e b2)
     | CFix (id,dl) ->
       CFix (id,List.map (fun (id,r,n,bl,t,d) ->
-          let (e',bl') = fold_map_local_binders f g e bl in
+          let (e',bl') = fold_map_local_binders g f e bl in
           let t' = f e' t in
           (* Note: fix names should be inserted before the arguments... *)
           let e'' = List.fold_left (fun e ({ CAst.v = id },_,_,_,_,_) -> g id e) e' dl in
@@ -592,7 +606,7 @@ let map_constr_expr_with_binders g f e = CAst.map (function
           (id,r,n,bl',t',d')) dl)
     | CCoFix (id,dl) ->
       CCoFix (id,List.map (fun (id,r,bl,t,d) ->
-          let (e',bl') = fold_map_local_binders f g e bl in
+          let (e',bl') = fold_map_local_binders g f e bl in
           let t' = f e' t in
           let e'' = List.fold_left (fun e ({ CAst.v = id },_,_,_,_) -> g id e) e' dl in
           let d' = f e'' d in

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -470,18 +470,19 @@ let rec fold_map_cases_pattern f h acc (CAst.{v=pt;loc} as p) = match pt with
 (* Used in correctness and interface *)
 let map_binder g e nal = List.fold_right (CAst.with_val (Name.fold_right g)) nal e
 
+let fold_map_local_binder f g e = function
+  (* TODO: avoid variable capture in [t] by some [na] in [List.tl nal] *)
+  | CLocalAssum(nal,r,k,ty) ->
+    (map_binder g e nal, CLocalAssum(nal,r,k,f e ty))
+  | CLocalDef( { loc ; v = na } as cna,r,c,ty) ->
+    (Name.fold_right g na e, CLocalDef(cna,r,f e c,Option.map (f e) ty))
+  | CLocalPattern pat ->
+    let e, pat = fold_map_cases_pattern g f e pat in
+    (e, CLocalPattern pat)
+
 let fold_map_local_binders f g e bl =
   (* TODO: avoid variable capture in [t] by some [na] in [List.tl nal] *)
-  let open CAst in
-  let h (e,bl) = function
-      CLocalAssum(nal,r,k,ty) ->
-      (map_binder g e nal, CLocalAssum(nal,r,k,f e ty)::bl)
-    | CLocalDef( { loc ; v = na } as cna ,r,c,ty) ->
-      (Name.fold_right g na e, CLocalDef(cna,r,f e c,Option.map (f e) ty)::bl)
-    | CLocalPattern pat ->
-      let e, pat = fold_map_cases_pattern g f e pat in
-      (e, CLocalPattern pat::bl) in
-  let (e,rbl) = List.fold_left h (e,[]) bl in
+  let (e,rbl) = List.fold_left (fun (e,bl) b -> let (e, b) = fold_map_local_binder f g e b in (e,b::bl)) (e,[]) bl in
   (e, List.rev rbl)
 
 let map_constr_expr_with_binders g f e = CAst.map (function

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -335,18 +335,17 @@ let rec cases_pattern_fold_names f h nacc pt = match CAst.(pt.v) with
       (f (qualid_basename qid) n, acc)
   | CPatPrim _ | CPatAtom _ -> nacc
   | CPatCast (p,t) ->
-      let (n, acc) = nacc in
-      cases_pattern_fold_names f h (n, h acc t) p
+      cases_pattern_fold_names f h (h nacc t) p
 
 let ids_of_pattern_list p =
   fst (List.fold_left
-    (List.fold_left (cases_pattern_fold_names Id.Set.add (fun () _ -> ())))
+    (List.fold_left (cases_pattern_fold_names Id.Set.add (fun nacc _ -> nacc)))
     (Id.Set.empty,()) p)
 
 let ids_of_cases_tomatch tms =
   List.fold_right
     (fun (_, ona, indnal) l ->
-       Option.fold_right (fun t ids -> fst (cases_pattern_fold_names Id.Set.add (fun () _ -> ()) (ids,()) t))
+       Option.fold_right (fun t ids -> fst (cases_pattern_fold_names Id.Set.add (fun nacc _ -> nacc) (ids,()) t))
          indnal
          (Option.fold_right (CAst.with_val (Name.fold_right Id.Set.add)) ona l))
     tms Id.Set.empty
@@ -363,7 +362,7 @@ let fold_local_binder k g f n acc = let open CAst in function
     let n' = Name.fold_right g na n in
     k n' (Option.fold_left (f n) (f n acc c) t)
   | CLocalPattern pat ->
-    let n, acc = cases_pattern_fold_names g (f n) (n,acc) pat in
+    let n, acc = cases_pattern_fold_names g (fun (n,acc) t -> (n,f n acc t)) (n,acc) pat in
     k n acc
 
 let rec fold_local_binders g f n acc b = function
@@ -395,8 +394,8 @@ let fold_constr_expr_with_binders g f n acc = CAst.with_val (function
       let acc = Option.fold_left (f (Id.Set.fold g ids n)) acc rtnpo in
       let acc = List.fold_left (f n) acc (List.map (fun (fst,_,_) -> fst) al) in
       List.fold_right (fun {CAst.v=(patl,rhs)} acc ->
-          let ids = ids_of_pattern_list patl in
-          f (Id.Set.fold g ids n) acc rhs) bl acc
+          let (n,acc) = List.fold_left (List.fold_left (cases_pattern_fold_names g (fun (n,acc) t -> (n,f n acc t)))) (n,acc) patl in
+          f n acc rhs) bl acc
     | CLetTuple (nal,(ona,po),b,c) ->
       let n' = List.fold_right (CAst.with_val (Name.fold_right g)) nal n in
       f (Option.fold_right (CAst.with_val (Name.fold_right g)) ona n') (f n acc b) c
@@ -416,13 +415,24 @@ let fold_constr_expr_with_binders g f n acc = CAst.with_val (function
       acc
   )
 
+let rec free_vars_of_constr_expr_gen bdvars l = function
+  | { CAst.v = CRef (qid, _) } when qualid_is_ident qid ->
+    let id = qualid_basename qid in
+    if Id.List.mem id bdvars then l else Id.Set.add id l
+  | c -> fold_constr_expr_with_binders (fun a l -> a::l) free_vars_of_constr_expr_gen bdvars l c
+
 let free_vars_of_constr_expr c =
-  let rec aux bdvars l = function
-    | { CAst.v = CRef (qid, _) } when qualid_is_ident qid ->
-      let id = qualid_basename qid in
-      if Id.List.mem id bdvars then l else Id.Set.add id l
-    | c -> fold_constr_expr_with_binders (fun a l -> a::l) aux bdvars l c
-  in aux [] Id.Set.empty c
+  free_vars_of_constr_expr_gen [] Id.Set.empty c
+
+let free_vars_of_cases_pattern_expr c =
+  snd (cases_pattern_fold_names (fun a l -> a::l)
+    (fun (bdvars,l) t -> (bdvars,free_vars_of_constr_expr_gen bdvars l t))
+    ([],Id.Set.empty) c)
+
+let free_vars_of_local_binders bl =
+  fold_local_binders (fun a l -> a::l)
+    free_vars_of_constr_expr_gen
+    [] Id.Set.empty (CAst.make @@ CHole (None)) bl
 
 let names_of_constr_expr c =
   let vars = ref Id.Set.empty in

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -95,47 +95,69 @@ let explicitation_eq pos1 pos2 = match pos1, pos2 with
 | ExplByPos n1, ExplByPos n2 -> Int.equal n1 n2
 | (ExplByName _ | ExplByPos _), _ -> false
 
-let rec cases_pattern_expr_eq p1 p2 =
-  if CAst.(p1.v == p2.v) then true
-  else match CAst.(p1.v, p2.v) with
-  | CPatAlias(a1,i1), CPatAlias(a2,i2) ->
-      CAst.eq Name.equal i1 i2 && cases_pattern_expr_eq a1 a2
-  | CPatCstr(c1,a1,b1), CPatCstr(c2,a2,b2) ->
-      qualid_eq c1 c2 &&
-      Option.equal (List.equal cases_pattern_expr_eq) a1 a2 &&
-      List.equal cases_pattern_expr_eq b1 b2
-  | CPatAtom(r1), CPatAtom(r2) ->
-    Option.equal qualid_eq r1 r2
-  | CPatOr a1, CPatOr a2 ->
-    List.equal cases_pattern_expr_eq a1 a2
-  | CPatNotation (inscope1, n1, s1, l1), CPatNotation (inscope2, n2, s2, l2) ->
-    Option.equal notation_with_optional_scope_eq inscope1 inscope2 &&
-    notation_eq n1 n2 &&
-    cases_pattern_notation_substitution_eq s1 s2 &&
-    List.equal cases_pattern_expr_eq l1 l2
-  | CPatPrim i1, CPatPrim i2 ->
-    prim_token_eq i1 i2
-  | CPatRecord l1, CPatRecord l2 ->
-    let equal (r1, e1) (r2, e2) =
-      qualid_eq r1 r2 && cases_pattern_expr_eq e1 e2
-    in
-    List.equal equal l1 l2
-  | CPatDelimiters(depth1,s1,e1), CPatDelimiters(depth2,s2,e2) ->
-    depth1 = depth2 && String.equal s1 s2 && cases_pattern_expr_eq e1 e2
-  | _ -> false
-
-and cases_pattern_notation_substitution_eq (s1, n1, b1) (s2, n2, b2) =
-  List.equal cases_pattern_expr_eq s1 s2 &&
-  List.equal (List.equal cases_pattern_expr_eq) n1 n2 &&
-  List.equal (eq_pair cases_pattern_expr_eq Glob_ops.binding_kind_eq) b1 b2
-
-let kinded_cases_pattern_expr_eq (p1,bk1) (p2,bk2) =
-  cases_pattern_expr_eq p1 p2 && Glob_ops.binding_kind_eq bk1 bk2
-
 (* We use a functor to avoid passing the recursion all over the place *)
-module EqGen (A:sig val constr_expr_eq : constr_expr -> constr_expr -> bool end) = struct
+module EqGen (A:sig
+    val constr_expr_eq : constr_expr -> constr_expr -> bool
+    val cases_pattern_expr_eq : cases_pattern_expr -> cases_pattern_expr -> bool
+  end) = struct
 
   open A
+
+  let local_binder_eq l1 l2 = match l1, l2 with
+    | CLocalDef (n1, _, e1, t1), CLocalDef (n2, _, e2, t2) ->
+      CAst.eq Name.equal n1 n2 && constr_expr_eq e1 e2 && Option.equal constr_expr_eq t1 t2
+    | CLocalAssum (n1, _, _, e1), CLocalAssum (n2, _, _, e2) ->
+      (* Don't care about the metadata *)
+      List.equal (CAst.eq Name.equal) n1 n2 && constr_expr_eq e1 e2
+    | _ -> false
+
+  let kinded_cases_pattern_expr_eq (p1,bk1) (p2,bk2) =
+    cases_pattern_expr_eq p1 p2 && Glob_ops.binding_kind_eq bk1 bk2
+
+  let notation_arg_kind_eq a1 a2 = match a1, a2 with
+    | NtnTypeArgConstr a1, NtnTypeArgConstr a2 -> constr_expr_eq a1 a2
+    | NtnTypeArgPattern b1, NtnTypeArgPattern b2 -> kinded_cases_pattern_expr_eq b1 b2
+    | NtnTypeArgBinders bll1, NtnTypeArgBinders bll2 -> List.equal local_binder_eq bll1 bll2
+    | (NtnTypeArgConstr _ | NtnTypeArgPattern _ | NtnTypeArgBinders _), _ -> false
+
+  let rec notation_arg_type_eq a1 a2 = match a1, a2 with
+    | NtnTypeArg v1, NtnTypeArg v2 -> notation_arg_kind_eq v1 v2
+    | NtnTypeArgList l1, NtnTypeArgList l2 -> List.equal notation_arg_type_eq l1 l2
+    | NtnTypeArgTuple l1, NtnTypeArgTuple l2 -> List.equal notation_arg_type_eq l1 l2
+    | (NtnTypeArg _ | NtnTypeArgList _ | NtnTypeArgTuple _), _ -> false
+
+  let notation_substitution_eq s1 s2 =
+    List.equal notation_arg_type_eq s1 s2
+
+  let rec cases_pattern_expr_eq p1 p2 =
+    if CAst.(p1.v == p2.v) then true
+    else match CAst.(p1.v, p2.v) with
+    | CPatAlias(a1,i1), CPatAlias(a2,i2) ->
+        CAst.eq Name.equal i1 i2 && cases_pattern_expr_eq a1 a2
+    | CPatCstr(c1,a1,b1), CPatCstr(c2,a2,b2) ->
+        qualid_eq c1 c2 &&
+        Option.equal (List.equal cases_pattern_expr_eq) a1 a2 &&
+        List.equal cases_pattern_expr_eq b1 b2
+    | CPatAtom(r1), CPatAtom(r2) ->
+      Option.equal qualid_eq r1 r2
+    | CPatOr a1, CPatOr a2 ->
+      List.equal cases_pattern_expr_eq a1 a2
+    | CPatNotation (inscope1, n1, s1, l1), CPatNotation (inscope2, n2, s2, l2) ->
+      Option.equal notation_with_optional_scope_eq inscope1 inscope2 &&
+      notation_eq n1 n2 &&
+      notation_substitution_eq s1 s2 &&
+      List.equal cases_pattern_expr_eq l1 l2
+    | CPatPrim i1, CPatPrim i2 ->
+      prim_token_eq i1 i2
+    | CPatRecord l1, CPatRecord l2 ->
+      let equal (r1, e1) (r2, e2) =
+        qualid_eq r1 r2 && cases_pattern_expr_eq e1 e2
+      in
+      List.equal equal l1 l2
+    | CPatDelimiters(depth1,s1,e1), CPatDelimiters(depth2,s2,e2) ->
+      depth1 = depth2 && String.equal s1 s2 && cases_pattern_expr_eq e1 e2
+    | _ -> false
+
   let args_eq (a1,e1) (a2,e2) =
     Option.equal (CAst.eq explicitation_eq) e1 e2 &&
     constr_expr_eq a1 a2
@@ -160,14 +182,6 @@ module EqGen (A:sig val constr_expr_eq : constr_expr -> constr_expr -> bool end)
 
   let recursion_order_expr_eq r1 r2 = CAst.eq recursion_order_expr_eq_r r1 r2
 
-  let local_binder_eq l1 l2 = match l1, l2 with
-    | CLocalDef (n1, _, e1, t1), CLocalDef (n2, _, e2, t2) ->
-      CAst.eq Name.equal n1 n2 && constr_expr_eq e1 e2 && Option.equal constr_expr_eq t1 t2
-    | CLocalAssum (n1, _, _, e1), CLocalAssum (n2, _, _, e2) ->
-      (* Don't care about the metadata *)
-      List.equal (CAst.eq Name.equal) n1 n2 && constr_expr_eq e1 e2
-    | _ -> false
-
   let fix_expr_eq (id1,_,r1,bl1,a1,b1) (id2,_,r2,bl2,a2,b2) =
     (lident_eq id1 id2) &&
     Option.equal recursion_order_expr_eq r1 r2 &&
@@ -180,12 +194,6 @@ module EqGen (A:sig val constr_expr_eq : constr_expr -> constr_expr -> bool end)
     List.equal local_binder_eq bl1 bl2 &&
     constr_expr_eq a1 a2 &&
     constr_expr_eq b1 b2
-
-  let constr_notation_substitution_eq (e1, el1, b1, bl1) (e2, el2, b2, bl2) =
-    List.equal constr_expr_eq e1 e2 &&
-    List.equal (List.equal constr_expr_eq) el1 el2 &&
-    List.equal kinded_cases_pattern_expr_eq b1 b2 &&
-    List.equal (List.equal local_binder_eq) bl1 bl2
 
   let instance_eq (x1,c1) (x2,c2) =
     Id.equal x1.CAst.v x2.CAst.v && constr_expr_eq c1 c2
@@ -260,7 +268,7 @@ module EqGen (A:sig val constr_expr_eq : constr_expr -> constr_expr -> bool end)
       | CNotation(inscope1, n1, s1), CNotation(inscope2, n2, s2) ->
         Option.equal notation_with_optional_scope_eq inscope1 inscope2 &&
         notation_eq n1 n2 &&
-        constr_notation_substitution_eq s1 s2
+        notation_substitution_eq s1 s2
       | CPrim i1, CPrim i2 ->
         prim_token_eq i1 i2
       | CGeneralization (bk1, e1), CGeneralization (bk2, e2) ->
@@ -282,14 +290,23 @@ module EqGen (A:sig val constr_expr_eq : constr_expr -> constr_expr -> bool end)
 
 end
 
-let constr_expr_eq_gen eq =
-  let module Eq = EqGen(struct let constr_expr_eq = eq end) in
+let constr_expr_eq_gen eq_constr eq_cases_pattern =
+  let module Eq = EqGen(struct let constr_expr_eq = eq_constr let cases_pattern_expr_eq = eq_cases_pattern end) in
   Eq.constr_expr_eq
 
+let cases_pattern_expr_eq_gen eq_constr eq_cases_pattern =
+  let module Eq = EqGen(struct let constr_expr_eq = eq_constr let cases_pattern_expr_eq = eq_cases_pattern end) in
+  Eq.cases_pattern_expr_eq
+
 module Eq = EqGen(struct
-    let rec constr_expr_eq c1 c2 = constr_expr_eq_gen constr_expr_eq c1 c2
+    let rec constr_expr_eq c1 c2 = constr_expr_eq_gen constr_expr_eq cases_pattern_expr_eq c1 c2
+    and cases_pattern_expr_eq c1 c2 = cases_pattern_expr_eq_gen constr_expr_eq cases_pattern_expr_eq c1 c2
   end)
 include Eq
+
+let rec cases_pattern_expr_eq_gen' eq_constr c = cases_pattern_expr_eq_gen eq_constr (cases_pattern_expr_eq_gen eq_constr (cases_pattern_expr_eq_gen' eq_constr)) c
+
+let constr_expr_eq_gen eq_constr = constr_expr_eq_gen eq_constr (cases_pattern_expr_eq_gen' eq_constr)
 
 let constr_loc c = CAst.(c.loc)
 let cases_pattern_expr_loc cp = CAst.(cp.loc)
@@ -315,6 +332,36 @@ let is_constructor id =
   | None -> false
   | Some gref -> Globnames.isConstructRef gref
 
+let notation_arg_kind_fold k1 k2 k3 acc = function
+  | NtnTypeArgConstr a -> k1 acc a
+  | NtnTypeArgPattern (pat,_) -> k2 acc pat
+  | NtnTypeArgBinders binder -> k3 acc binder
+
+let rec notation_arg_type_fold k1 k2 k3 acc = function
+  | NtnTypeArg a -> notation_arg_kind_fold k1 k2 k3 acc a
+  | NtnTypeArgList l -> List.fold_left (notation_arg_type_fold k1 k2 k3) acc l
+  | NtnTypeArgTuple l -> List.fold_left (notation_arg_type_fold k1 k2 k3) acc l
+
+let notation_arg_kind_fold_map k1 k2 k3 acc = function
+  | NtnTypeArgConstr a -> let acc, a = k1 acc a in acc, NtnTypeArgConstr a
+  | NtnTypeArgPattern (pat,kd) -> let acc, pat = k2 acc pat in acc, NtnTypeArgPattern (pat,kd)
+  | NtnTypeArgBinders binder -> let acc, binder = k3 acc binder in acc, NtnTypeArgBinders binder
+
+let rec notation_arg_type_fold_map k1 k2 k3 acc = function
+  | NtnTypeArg a -> let acc, a = notation_arg_kind_fold_map k1 k2 k3 acc a in acc, NtnTypeArg a
+  | NtnTypeArgList l -> let acc, l = List.fold_left_map (notation_arg_type_fold_map k1 k2 k3) acc l in acc, NtnTypeArgList l
+  | NtnTypeArgTuple l -> let acc, l = List.fold_left_map (notation_arg_type_fold_map k1 k2 k3) acc l in acc, NtnTypeArgTuple l
+
+let notation_arg_kind_map k1 k2 k3 = function
+  | NtnTypeArgConstr a -> NtnTypeArgConstr (k1 a)
+  | NtnTypeArgPattern (pat,kd) -> NtnTypeArgPattern (k2 pat,kd)
+  | NtnTypeArgBinders binder -> NtnTypeArgBinders (k3 binder)
+
+let rec notation_arg_type_map k1 k2 k3 = function
+  | NtnTypeArg a -> NtnTypeArg (notation_arg_kind_map k1 k2 k3 a)
+  | NtnTypeArgList l -> NtnTypeArgList (List.map (notation_arg_type_map k1 k2 k3) l)
+  | NtnTypeArgTuple l -> NtnTypeArgTuple (List.map (notation_arg_type_map k1 k2 k3) l)
+
 let rec cases_pattern_fold_names f h nacc pt = match CAst.(pt.v) with
   | CPatRecord l ->
     List.fold_left (fun nacc (r, cp) -> cases_pattern_fold_names f h nacc cp) nacc l
@@ -324,10 +371,13 @@ let rec cases_pattern_fold_names f h nacc pt = match CAst.(pt.v) with
   | CPatCstr (_,patl1,patl2) ->
     List.fold_left (cases_pattern_fold_names f h)
       (Option.fold_left (List.fold_left (cases_pattern_fold_names f h)) nacc patl1) patl2
-  | CPatNotation (_,_,(patl,patll,binderl),patl') ->
+  | CPatNotation (_,_,subst,patl') ->
     List.fold_left (cases_pattern_fold_names f h)
-      (List.fold_left (cases_pattern_fold_names f h) nacc
-         (patl@List.flatten patll@List.map fst binderl)) patl'
+      (List.fold_right (fun a x ->
+           notation_arg_type_fold h
+             (cases_pattern_fold_names f h)
+             (fun nacc _ -> nacc) x a)
+           subst nacc) patl'
   | CPatDelimiters (_,_,pat) -> cases_pattern_fold_names f h nacc pat
   | CPatAtom (Some qid)
       when qualid_is_ident qid && not (is_constructor @@ qualid_basename qid) ->
@@ -379,11 +429,12 @@ let fold_constr_expr_with_binders g f n acc = CAst.with_val (function
     | CLetIn (na,a,t,b) ->
       f (Name.fold_right g (na.CAst.v) n) (Option.fold_left (f n) (f n acc a) t) b
     | CCast (a,_,b) -> f n (f n acc a) b
-    | CNotation (_,_,(l,ll,bl,bll)) ->
-      (* The following is an approximation: we don't know exactly if
-         an ident is binding nor to which subterms bindings apply *)
-      let acc = List.fold_left (f n) acc (l@List.flatten ll) in
-      List.fold_left (fun acc bl -> fold_local_binders g f n acc (CAst.make @@ CHole (None)) bl) acc bll
+    | CNotation (_,_,subst) ->
+      List.fold_left (notation_arg_type_fold
+             (f n)
+             (fun acc a -> snd (cases_pattern_fold_names g (fun (n,acc) t -> (n,f n acc t)) (n,acc) a))
+             (fun acc a -> fold_local_binders g f n acc (CAst.make @@ CHole None) a))
+        acc subst
     | CGeneralization (_,c) -> f n acc c
     | CDelimiters (_,_,a) -> f n acc a
     | CRecord (def,l) ->
@@ -459,12 +510,15 @@ let rec fold_map_cases_pattern f h acc (CAst.{v=pt;loc} as p) = match pt with
     let acc, patl1 = Option.fold_left_map (List.fold_left_map (fold_map_cases_pattern f h)) acc patl1 in
     let acc, patl2 = List.fold_left_map (fold_map_cases_pattern f h) acc patl2 in
     acc, CAst.make ?loc (CPatCstr (c,patl1,patl2))
-  | CPatNotation (sc,ntn,(patl,patll,binderl),patl') ->
-    let acc, patl = List.fold_left_map (fold_map_cases_pattern f h) acc patl in
-    let acc, patll = List.fold_left_map (List.fold_left_map (fold_map_cases_pattern f h)) acc patll in
-    let acc, binderl' = List.fold_left_map (fold_fst (fold_map_cases_pattern f h)) acc binderl in
+  | CPatNotation (sc,ntn,subst,patl') ->
+    let acc, subst = List.fold_left_map
+        (notation_arg_type_fold_map
+          (fun acc c -> (acc, h acc c))
+          (fold_map_cases_pattern f h)
+          (fun _ _ -> assert false))
+        acc subst in
     let acc, patl' = List.fold_left_map (fold_map_cases_pattern f h) acc patl' in
-    acc, CAst.make ?loc (CPatNotation (sc,ntn,(patl,patll,binderl'),patl'))
+    acc, CAst.make ?loc (CPatNotation (sc,ntn,subst,patl'))
   | CPatDelimiters (depth,d,pat) ->
     let acc, p = fold_map_cases_pattern f h acc pat in
     acc, CAst.make ?loc (CPatDelimiters (depth,d,pat))
@@ -508,10 +562,12 @@ let map_constr_expr_with_binders g f e = CAst.map (function
     | CLetIn (na,a,t,b) ->
       CLetIn (na,f e a,Option.map (f e) t,f (Name.fold_right g (na.CAst.v) e) b)
     | CCast (a,k,c) -> CCast (f e a, k, f e c)
-    | CNotation (inscope,n,(l,ll,bl,bll)) ->
+    | CNotation (inscope,n,subst) ->
       (* This is an approximation because we don't know what binds what *)
-      CNotation (inscope,n,(List.map (f e) l,List.map (List.map (f e)) ll, bl,
-                    List.map (fun bl -> snd (fold_map_local_binders f g e bl)) bll))
+      CNotation (inscope,n,
+                 List.map (notation_arg_type_map (f e)
+                             (fun a -> snd (fold_map_cases_pattern g f e a))
+                             (fun a -> snd (fold_map_local_binders f g e a))) subst)
     | CGeneralization (b,c) -> CGeneralization (b,f e c)
     | CDelimiters (depth,s,a) -> CDelimiters (depth,s,f e a)
     | CRecord (def,l) -> CRecord (Option.map (f e) def, List.map (fun (id, c) -> (id, f e c)) l)
@@ -571,15 +627,11 @@ let locs_of_notation ?loc locs ntn =
     | (ba,ea)::l -> if Int.equal pos ba then aux ea l else (pos,ba)::aux ea l
   in aux bl (List.sort (fun l1 l2 -> fst l1 - fst l2) locs)
 
-let ntn_loc ?loc (args,argslist,binders,binderslist) =
+let ntn_loc ?loc subst =
   locs_of_notation ?loc
-    (List.map constr_loc (args@List.flatten argslist)@
-     List.map (fun (x,_) -> cases_pattern_expr_loc x) binders@
-     List.map local_binders_loc binderslist)
-
-let patntn_loc ?loc (args,argslist,binders) =
-  locs_of_notation ?loc
-    (List.map cases_pattern_expr_loc (args@List.flatten argslist@List.map fst binders))
+    (List.fold_left (notation_arg_type_fold (fun acc c -> constr_loc c :: acc)
+                        (fun acc x -> cases_pattern_expr_loc x :: acc)
+                        (fun acc bl -> local_binders_loc bl :: acc)) [] subst)
 
 let error_invalid_pattern_notation ?loc () =
   CErrors.user_err ?loc  (str "Invalid notation for pattern.")
@@ -648,6 +700,16 @@ let mkAppPattern ?loc p lp =
   | CPatNotation (inscope, n, s, l) -> CPatNotation (inscope, n , s, l@lp)
   | _ -> CErrors.user_err ?loc:p.loc (Pp.str "Such pattern cannot have arguments."))
 
+let notation_arg_kind_map_coerce k1 k2 k3 = function
+  | NtnTypeArgConstr a -> NtnTypeArgPattern (k1 a)
+  | NtnTypeArgPattern (pat,kd) -> NtnTypeArgPattern (k2 pat,kd)
+  | NtnTypeArgBinders binder -> NtnTypeArgBinders (k3 binder)
+
+let rec notation_arg_type_map_coerce k1 k2 k3 = function
+  | NtnTypeArg a -> NtnTypeArg (notation_arg_kind_map_coerce k1 k2 k3 a)
+  | NtnTypeArgList l -> NtnTypeArgList (List.map (notation_arg_type_map_coerce k1 k2 k3) l)
+  | NtnTypeArgTuple l -> NtnTypeArgTuple (List.map (notation_arg_type_map_coerce k1 k2 k3) l)
+
 let rec coerce_to_cases_pattern_expr c = CAst.map_with_loc (fun ?loc -> function
   | CRef (r,None) ->
      CPatAtom (Some r)
@@ -660,10 +722,11 @@ let rec coerce_to_cases_pattern_expr c = CAst.map_with_loc (fun ?loc -> function
      (mkAppPattern (coerce_to_cases_pattern_expr p) (List.map (fun (a,_) -> coerce_to_cases_pattern_expr a) args)).CAst.v
   | CAppExpl ((r,i),args) ->
      CPatCstr (r,Some (List.map coerce_to_cases_pattern_expr args),[])
-  | CNotation (inscope,ntn,(c,cl,b,[])) ->
-     CPatNotation (inscope,ntn,(List.map coerce_to_cases_pattern_expr c,
-                                List.map (List.map coerce_to_cases_pattern_expr) cl,
-                                b),[])
+  | CNotation (inscope,ntn,subst) ->
+     CPatNotation (inscope,ntn,List.map (notation_arg_type_map_coerce
+                                           (fun c -> (coerce_to_cases_pattern_expr c, Explicit))
+                                           (fun c -> c)
+                                           (fun _ -> assert false)) subst, [])
   | CPrim p ->
      CPatPrim p
   | CRecord (None,l) ->
@@ -676,7 +739,6 @@ let rec coerce_to_cases_pattern_expr c = CAst.map_with_loc (fun ?loc -> function
   | CRef (_, Some _) | CCast (_, (Some (VMcast|NATIVEcast) | None), _)
   | CFix _ | CCoFix _ | CApp _ | CProj _ | CCases _ | CLetTuple _ | CIf _
   | CPatVar _ | CEvar _
-  | CNotation (_,_,(_,_,_,_::_))
   | CRecord (Some _, _) | CHole (Some _) | CGenarg _ | CGenargGlob _ ->
     CErrors.user_err ?loc
                       (str "This expression should be coercible to a pattern.")

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -362,126 +362,132 @@ let rec notation_arg_type_map k1 k2 k3 = function
   | NtnTypeArgList l -> NtnTypeArgList (List.map (notation_arg_type_map k1 k2 k3) l)
   | NtnTypeArgTuple l -> NtnTypeArgTuple (List.map (notation_arg_type_map k1 k2 k3) l)
 
-let rec cases_pattern_fold_names f h nacc pt = match CAst.(pt.v) with
+(* [eacc] is a pair [(e,acc)] where [e] is updated at traversal of a
+   variable by [g] and [acc] is the result of map-folding constr subterms
+   (i.e.  basically subterms in Cast and Notation) using [f];
+   By map-folding is meant that [f] updates both [e] and [acc]. *)
+let rec cases_pattern_fold_names g f eacc pt = match CAst.(pt.v) with
   | CPatRecord l ->
-    List.fold_left (fun nacc (r, cp) -> cases_pattern_fold_names f h nacc cp) nacc l
-  | CPatAlias (pat,{CAst.v=na}) -> Name.fold_right (fun na (n,acc) -> (f na n,acc)) na (cases_pattern_fold_names f h nacc pat)
+    List.fold_left (fun eacc (r, cp) -> cases_pattern_fold_names g f eacc cp) eacc l
+  | CPatAlias (pat,{CAst.v=na}) -> Name.fold_right (fun na (e,acc) -> (g na e,acc)) na (cases_pattern_fold_names g f eacc pat)
   | CPatOr (patl) ->
-    List.fold_left (cases_pattern_fold_names f h) nacc patl
+    List.fold_left (cases_pattern_fold_names g f) eacc patl
   | CPatCstr (_,patl1,patl2) ->
-    List.fold_left (cases_pattern_fold_names f h)
-      (Option.fold_left (List.fold_left (cases_pattern_fold_names f h)) nacc patl1) patl2
+    List.fold_left (cases_pattern_fold_names g f)
+      (Option.fold_left (List.fold_left (cases_pattern_fold_names g f)) eacc patl1) patl2
   | CPatNotation (_,_,subst,patl') ->
-    List.fold_left (cases_pattern_fold_names f h)
+    List.fold_left (cases_pattern_fold_names g f)
       (List.fold_right (fun a x ->
-           notation_arg_type_fold h
-             (cases_pattern_fold_names f h)
-             (fun nacc _ -> nacc) x a)
-           subst nacc) patl'
-  | CPatDelimiters (_,_,pat) -> cases_pattern_fold_names f h nacc pat
+           notation_arg_type_fold f
+             (cases_pattern_fold_names g f)
+             (fun eacc _ -> eacc) x a)
+           subst eacc) patl'
+  | CPatDelimiters (_,_,pat) -> cases_pattern_fold_names g f eacc pat
   | CPatAtom (Some qid)
       when qualid_is_ident qid && not (is_constructor @@ qualid_basename qid) ->
-      let (n, acc) = nacc in
-      (f (qualid_basename qid) n, acc)
-  | CPatPrim _ | CPatAtom _ -> nacc
+      let (e, acc) = eacc in
+      (g (qualid_basename qid) e, acc)
+  | CPatPrim _ | CPatAtom _ -> eacc
   | CPatCast (p,t) ->
-      cases_pattern_fold_names f h (h nacc t) p
+      cases_pattern_fold_names g f (f eacc t) p
 
 let ids_of_pattern_list p =
   fst (List.fold_left
-    (List.fold_left (cases_pattern_fold_names Id.Set.add (fun nacc _ -> nacc)))
+    (List.fold_left (cases_pattern_fold_names Id.Set.add (fun eacc _ -> eacc)))
     (Id.Set.empty,()) p)
 
 let ids_of_cases_tomatch tms =
   List.fold_right
     (fun (_, ona, indnal) l ->
-       Option.fold_right (fun t ids -> fst (cases_pattern_fold_names Id.Set.add (fun nacc _ -> nacc) (ids,()) t))
+       Option.fold_right (fun t ids -> fst (cases_pattern_fold_names Id.Set.add (fun eacc _ -> eacc) (ids,()) t))
          indnal
          (Option.fold_right (CAst.with_val (Name.fold_right Id.Set.add)) ona l))
     tms Id.Set.empty
 
-(* [n] collects data from binders using [g];
+(* [e] collects data from binders using [g];
    [acc] accumulates over "constr" subterms using [f];
-   [k] is a continuation, working on the updated [n] *)
-let fold_local_binder k g f n acc = let open CAst in function
+   [k] is a continuation, working on the updated [e] *)
+let fold_local_binder k g f e acc = let open CAst in function
   | CLocalAssum (nal,_,bk,t) ->
     let nal = List.(map (fun {v} -> v) nal) in
-    let n' = List.fold_right (Name.fold_right g) nal n in
-    k n' (f n acc t)
+    let e' = List.fold_right (Name.fold_right g) nal e in
+    k e' (f e acc t)
   | CLocalDef ( { v = na },_,c,t) ->
-    let n' = Name.fold_right g na n in
-    k n' (Option.fold_left (f n) (f n acc c) t)
+    let e' = Name.fold_right g na e in
+    k e' (Option.fold_left (f e) (f e acc c) t)
   | CLocalPattern pat ->
-    let n, acc = cases_pattern_fold_names g (fun (n,acc) t -> (n,f n acc t)) (n,acc) pat in
-    k n acc
+    let e, acc = cases_pattern_fold_names g (fun (e,acc) t -> (e,f e acc t)) (e,acc) pat in
+    k e acc
 
-let rec fold_local_binders g f n acc b = function
+let rec fold_local_binders g f e acc b = function
   | decl :: l ->
-    fold_local_binder (fun n acc -> fold_local_binders g f n acc b l) g f n acc decl
+    fold_local_binder (fun e acc -> fold_local_binders g f e acc b l) g f e acc decl
   | [] ->
-    f n acc b
+    f e acc b
 
-let fold_constr_expr_with_binders g f n acc = CAst.with_val (function
-    | CAppExpl ((_,_),l) -> List.fold_left (f n) acc l
-    | CApp (t,l) -> List.fold_left (f n) (f n acc t) (List.map fst l)
-    | CProj (e,_,l,t) -> f n (List.fold_left (f n) acc (List.map fst l)) t
-    | CProdN (l,b) | CLambdaN (l,b) -> fold_local_binders g f n acc b l
+(* [n] collects data from binders using [g];
+   [acc] accumulates over subterms using [f] *)
+let fold_constr_expr_with_binders g f e acc = CAst.with_val (function
+    | CAppExpl ((_,_),l) -> List.fold_left (f e) acc l
+    | CApp (t,l) -> List.fold_left (f e) (f e acc t) (List.map fst l)
+    | CProj (_,_,l,t) -> f e (List.fold_left (f e) acc (List.map fst l)) t
+    | CProdN (l,b) | CLambdaN (l,b) -> fold_local_binders g f e acc b l
     | CLetIn (na,a,t,b) ->
-      f (Name.fold_right g (na.CAst.v) n) (Option.fold_left (f n) (f n acc a) t) b
-    | CCast (a,_,b) -> f n (f n acc a) b
+      f (Name.fold_right g (na.CAst.v) e) (Option.fold_left (f e) (f e acc a) t) b
+    | CCast (a,_,b) -> f e (f e acc a) b
     | CNotation (_,_,subst) ->
       List.fold_left (notation_arg_type_fold
-             (f n)
-             (fun acc a -> snd (cases_pattern_fold_names g (fun (n,acc) t -> (n,f n acc t)) (n,acc) a))
-             (fun acc a -> fold_local_binders g f n acc (CAst.make @@ CHole None) a))
+             (f e)
+             (fun acc a -> snd (cases_pattern_fold_names g (fun (e,acc) t -> (e,f e acc t)) (e,acc) a))
+             (fun acc a -> fold_local_binders g f e acc (CAst.make @@ CHole None) a))
         acc subst
-    | CGeneralization (_,c) -> f n acc c
-    | CDelimiters (_,_,a) -> f n acc a
+    | CGeneralization (_,c) -> f e acc c
+    | CDelimiters (_,_,a) -> f e acc a
     | CRecord (def,l) ->
-      let acc = Option.fold_left (f n) acc def in
-      List.fold_left (fun acc (id, c) -> f n acc c) acc l
+      let acc = Option.fold_left (f e) acc def in
+      List.fold_left (fun acc (id, c) -> f e acc c) acc l
     | CCases (sty,rtnpo,al,bl) ->
       let ids = ids_of_cases_tomatch al in
-      let acc = Option.fold_left (f (Id.Set.fold g ids n)) acc rtnpo in
-      let acc = List.fold_left (f n) acc (List.map (fun (fst,_,_) -> fst) al) in
+      let acc = Option.fold_left (f (Id.Set.fold g ids e)) acc rtnpo in
+      let acc = List.fold_left (f e) acc (List.map (fun (fst,_,_) -> fst) al) in
       List.fold_right (fun {CAst.v=(patl,rhs)} acc ->
-          let (n,acc) = List.fold_left (List.fold_left (cases_pattern_fold_names g (fun (n,acc) t -> (n,f n acc t)))) (n,acc) patl in
-          f n acc rhs) bl acc
+          let (e,acc) = List.fold_left (List.fold_left (cases_pattern_fold_names g (fun (e,acc) t -> (e,f e acc t)))) (e,acc) patl in
+          f e acc rhs) bl acc
     | CLetTuple (nal,(ona,po),b,c) ->
-      let n' = List.fold_right (CAst.with_val (Name.fold_right g)) nal n in
-      f (Option.fold_right (CAst.with_val (Name.fold_right g)) ona n') (f n acc b) c
+      let e' = List.fold_right (CAst.with_val (Name.fold_right g)) nal e in
+      f (Option.fold_right (CAst.with_val (Name.fold_right g)) ona e') (f e acc b) c
     | CIf (c,(ona,po),b1,b2) ->
-      let acc = f n (f n (f n acc b1) b2) c in
+      let acc = f e (f e (f e acc b1) b2) c in
       Option.fold_left
-        (f (Option.fold_right (CAst.with_val (Name.fold_right g)) ona n)) acc po
+        (f (Option.fold_right (CAst.with_val (Name.fold_right g)) ona e)) acc po
     | CFix (_,l) ->
-      let n' = List.fold_right (fun ( { CAst.v = id },_,_,_,_,_) -> g id) l n in
+      let e' = List.fold_right (fun ( { CAst.v = id },_,_,_,_,_) -> g id) l e in
       List.fold_right (fun (_,_,ro,lb,t,c) acc ->
-          fold_local_binders g f n'
-            (fold_local_binders g f n acc t lb) c lb) l acc
+          fold_local_binders g f e'
+            (fold_local_binders g f e acc t lb) c lb) l acc
     | CCoFix (_,_) ->
       Feedback.msg_warning (strbrk "Capture check in multiple binders not done"); acc
-    | CArray (_u,t,def,ty) -> f n (f n (Array.fold_left (f n) acc t) def) ty
+    | CArray (_u,t,def,ty) -> f e (f e (Array.fold_left (f e) acc t) def) ty
     | CHole _ | CGenarg _ | CGenargGlob _ | CEvar _ | CPatVar _ | CSort _ | CPrim _ | CRef _ ->
       acc
   )
 
-let rec free_vars_of_constr_expr_gen bdvars l = function
+let rec free_vars_of_constr_expr_gen bdvars ids = function
   | { CAst.v = CRef (qid, _) } when qualid_is_ident qid ->
     let id = qualid_basename qid in
-    if Id.List.mem id bdvars then l else Id.Set.add id l
-  | c -> fold_constr_expr_with_binders (fun a l -> a::l) free_vars_of_constr_expr_gen bdvars l c
+    if Id.List.mem id bdvars then ids else Id.Set.add id ids
+  | c -> fold_constr_expr_with_binders (fun a ids -> a::ids) free_vars_of_constr_expr_gen bdvars ids c
 
 let free_vars_of_constr_expr c =
   free_vars_of_constr_expr_gen [] Id.Set.empty c
 
 let free_vars_of_cases_pattern_expr c =
-  snd (cases_pattern_fold_names (fun a l -> a::l)
-    (fun (bdvars,l) t -> (bdvars,free_vars_of_constr_expr_gen bdvars l t))
+  snd (cases_pattern_fold_names (fun a ids -> a::ids)
+    (fun (bdvars,ids) t -> (bdvars,free_vars_of_constr_expr_gen bdvars ids t))
     ([],Id.Set.empty) c)
 
 let free_vars_of_local_binders bl =
-  fold_local_binders (fun a l -> a::l)
+  fold_local_binders (fun a ids -> a::ids)
     free_vars_of_constr_expr_gen
     [] Id.Set.empty (CAst.make @@ CHole (None)) bl
 
@@ -495,46 +501,50 @@ let names_of_constr_expr c =
 
 let occur_var_constr_expr id c = Id.Set.mem id (free_vars_of_constr_expr c)
 
-let rec fold_map_cases_pattern f h acc (CAst.{v=pt;loc} as p) = match pt with
+(* applies [f] on a cases pattern, where [f] depends on an "environent" [e]
+   which is updated by [g] at each traversal of a binder *)
+let rec fold_map_cases_pattern g f e (CAst.{v=pt;loc} as p) = match pt with
   | CPatRecord l ->
-    let acc, l = List.fold_left_map (fun acc (r, cp) -> let acc, cp = fold_map_cases_pattern f h acc cp in acc, (r, cp)) acc l in
-    acc, CAst.make ?loc (CPatRecord l)
+    let e, l = List.fold_left_map (fun e (r, cp) -> let e, cp = fold_map_cases_pattern g f e cp in e, (r, cp)) e l in
+    e, CAst.make ?loc (CPatRecord l)
   | CPatAlias (pat,({CAst.v=na} as lna)) ->
-    let acc, p = fold_map_cases_pattern f h acc pat in
-    let acc = Name.fold_right f na acc in
-    acc, CAst.make ?loc (CPatAlias (pat,lna))
+    let e, p = fold_map_cases_pattern g f e pat in
+    let e = Name.fold_right g na e in
+    e, CAst.make ?loc (CPatAlias (pat,lna))
   | CPatOr patl ->
-    let acc, patl = List.fold_left_map (fold_map_cases_pattern f h) acc patl in
-    acc, CAst.make ?loc (CPatOr patl)
+    let e, patl = List.fold_left_map (fold_map_cases_pattern g f) e patl in
+    e, CAst.make ?loc (CPatOr patl)
   | CPatCstr (c,patl1,patl2) ->
-    let acc, patl1 = Option.fold_left_map (List.fold_left_map (fold_map_cases_pattern f h)) acc patl1 in
-    let acc, patl2 = List.fold_left_map (fold_map_cases_pattern f h) acc patl2 in
-    acc, CAst.make ?loc (CPatCstr (c,patl1,patl2))
+    let e, patl1 = Option.fold_left_map (List.fold_left_map (fold_map_cases_pattern g f)) e patl1 in
+    let e, patl2 = List.fold_left_map (fold_map_cases_pattern g f) e patl2 in
+    e, CAst.make ?loc (CPatCstr (c,patl1,patl2))
   | CPatNotation (sc,ntn,subst,patl') ->
-    let acc, subst = List.fold_left_map
+    let e, subst = List.fold_left_map
         (notation_arg_type_fold_map
-          (fun acc c -> (acc, h acc c))
-          (fold_map_cases_pattern f h)
+          (fun e c -> (e, f e c))
+          (fold_map_cases_pattern g f)
           (fun _ _ -> assert false))
-        acc subst in
-    let acc, patl' = List.fold_left_map (fold_map_cases_pattern f h) acc patl' in
-    acc, CAst.make ?loc (CPatNotation (sc,ntn,subst,patl'))
+        e subst in
+    let e, patl' = List.fold_left_map (fold_map_cases_pattern g f) e patl' in
+    e, CAst.make ?loc (CPatNotation (sc,ntn,subst,patl'))
   | CPatDelimiters (depth,d,pat) ->
-    let acc, p = fold_map_cases_pattern f h acc pat in
-    acc, CAst.make ?loc (CPatDelimiters (depth,d,pat))
+    let e, p = fold_map_cases_pattern g f e pat in
+    e, CAst.make ?loc (CPatDelimiters (depth,d,pat))
   | CPatAtom (Some qid)
       when qualid_is_ident qid && not (is_constructor @@ qualid_basename qid) ->
-    f (qualid_basename qid) acc, p
-  | CPatPrim _ | CPatAtom _ -> (acc,p)
+    g (qualid_basename qid) e, p
+  | CPatPrim _ | CPatAtom _ -> (e,p)
   | CPatCast (pat,t) ->
-    let acc, pat = fold_map_cases_pattern f h acc pat in
-    let t = h acc t in
-    acc, CAst.make ?loc (CPatCast (pat,t))
+    let e, pat = fold_map_cases_pattern g f e pat in
+    let t = f e t in
+    e, CAst.make ?loc (CPatCast (pat,t))
 
 (* Used in correctness and interface *)
 let map_binder g e nal = List.fold_right (CAst.with_val (Name.fold_right g)) nal e
 
-let fold_map_local_binder f g e = function
+(* applies [f] on a local binder, where [f] depends on an "environent" [e]
+   which is updated by [g] at each traversal of a binder *)
+let fold_map_local_binder g f e = function
   (* TODO: avoid variable capture in [t] by some [na] in [List.tl nal] *)
   | CLocalAssum(nal,r,k,ty) ->
     (map_binder g e nal, CLocalAssum(nal,r,k,f e ty))
@@ -544,11 +554,15 @@ let fold_map_local_binder f g e = function
     let e, pat = fold_map_cases_pattern g f e pat in
     (e, CLocalPattern pat)
 
-let fold_map_local_binders f g e bl =
+(* applies [f] on local binders, where [f] depends on an "environent" [e]
+   which is updated by [g] at each traversal of a binder *)
+let fold_map_local_binders g f e bl =
   (* TODO: avoid variable capture in [t] by some [na] in [List.tl nal] *)
-  let (e,rbl) = List.fold_left (fun (e,bl) b -> let (e, b) = fold_map_local_binder f g e b in (e,b::bl)) (e,[]) bl in
+  let (e,rbl) = List.fold_left (fun (e,bl) b -> let (e, b) = fold_map_local_binder g f e b in (e,b::bl)) (e,[]) bl in
   (e, List.rev rbl)
 
+(* applies [f] on an constr_expr, where [f] depends on an "environent" [e]
+   which is updated by [g] at each traversal of a binder *)
 let map_constr_expr_with_binders g f e = CAst.map (function
     | CAppExpl (r,l) -> CAppExpl (r,List.map (f e) l)
     | CApp (a,l) ->
@@ -556,9 +570,9 @@ let map_constr_expr_with_binders g f e = CAst.map (function
     | CProj (expl,p,l,a) ->
       CProj (expl,p,List.map (fun (a,i) -> (f e a,i)) l,f e a)
     | CProdN (bl,b) ->
-      let (e,bl) = fold_map_local_binders f g e bl in CProdN (bl,f e b)
+      let (e,bl) = fold_map_local_binders g f e bl in CProdN (bl,f e b)
     | CLambdaN (bl,b) ->
-      let (e,bl) = fold_map_local_binders f g e bl in CLambdaN (bl,f e b)
+      let (e,bl) = fold_map_local_binders g f e bl in CLambdaN (bl,f e b)
     | CLetIn (na,a,t,b) ->
       CLetIn (na,f e a,Option.map (f e) t,f (Name.fold_right g (na.CAst.v) e) b)
     | CCast (a,k,c) -> CCast (f e a, k, f e c)
@@ -567,7 +581,7 @@ let map_constr_expr_with_binders g f e = CAst.map (function
       CNotation (inscope,n,
                  List.map (notation_arg_type_map (f e)
                              (fun a -> snd (fold_map_cases_pattern g f e a))
-                             (fun a -> snd (fold_map_local_binders f g e a))) subst)
+                             (fun a -> snd (fold_map_local_binders g f e a))) subst)
     | CGeneralization (b,c) -> CGeneralization (b,f e c)
     | CDelimiters (depth,s,a) -> CDelimiters (depth,s,f e a)
     | CRecord (def,l) -> CRecord (Option.map (f e) def, List.map (fun (id, c) -> (id, f e c)) l)
@@ -587,7 +601,7 @@ let map_constr_expr_with_binders g f e = CAst.map (function
       CIf (f e c,(ona,Option.map (f e') po),f e b1,f e b2)
     | CFix (id,dl) ->
       CFix (id,List.map (fun (id,r,n,bl,t,d) ->
-          let (e',bl') = fold_map_local_binders f g e bl in
+          let (e',bl') = fold_map_local_binders g f e bl in
           let t' = f e' t in
           (* Note: fix names should be inserted before the arguments... *)
           let e'' = List.fold_left (fun e ({ CAst.v = id },_,_,_,_,_) -> g id e) e' dl in
@@ -595,7 +609,7 @@ let map_constr_expr_with_binders g f e = CAst.map (function
           (id,r,n,bl',t',d')) dl)
     | CCoFix (id,dl) ->
       CCoFix (id,List.map (fun (id,r,bl,t,d) ->
-          let (e',bl') = fold_map_local_binders f g e bl in
+          let (e',bl') = fold_map_local_binders g f e bl in
           let t' = f e' t in
           let e'' = List.fold_left (fun e ({ CAst.v = id },_,_,_,_) -> g id e) e' dl in
           let d' = f e'' d in

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -650,6 +650,9 @@ let ntn_loc ?loc subst =
 let error_invalid_pattern_notation ?loc () =
   CErrors.user_err ?loc  (str "Invalid notation for pattern.")
 
+let mk_ntn ntn_entry ntn_key = { ntn_entry; ntn_key }
+let mk_ntn_in_constr = mk_ntn InConstrEntry
+
 (** Pseudo-constructors *)
 
 let mkIdentC id   = CAst.make @@ CRef (qualid_of_ident id,None)

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -351,16 +351,24 @@ let ids_of_cases_tomatch tms =
          (Option.fold_right (CAst.with_val (Name.fold_right Id.Set.add)) ona l))
     tms Id.Set.empty
 
-let rec fold_local_binders g f n acc b = let open CAst in function
-  | CLocalAssum (nal,_,bk,t)::l ->
+(* [n] collects data from binders using [g];
+   [acc] accumulates over "constr" subterms using [f];
+   [k] is a continuation, working on the updated [n] *)
+let fold_local_binder k g f n acc = let open CAst in function
+  | CLocalAssum (nal,_,bk,t) ->
     let nal = List.(map (fun {v} -> v) nal) in
     let n' = List.fold_right (Name.fold_right g) nal n in
-    f n (fold_local_binders g f n' acc b l) t
-  | CLocalDef ( { v = na },_,c,t)::l ->
-    Option.fold_left (f n) (f n (fold_local_binders g f (Name.fold_right g na n) acc b l) c) t
-  | CLocalPattern pat :: l ->
+    k n' (f n acc t)
+  | CLocalDef ( { v = na },_,c,t) ->
+    let n' = Name.fold_right g na n in
+    k n' (Option.fold_left (f n) (f n acc c) t)
+  | CLocalPattern pat ->
     let n, acc = cases_pattern_fold_names g (f n) (n,acc) pat in
-    fold_local_binders g f n acc b l
+    k n acc
+
+let rec fold_local_binders g f n acc b = function
+  | decl :: l ->
+    fold_local_binder (fun n acc -> fold_local_binders g f n acc b l) g f n acc decl
   | [] ->
     f n acc b
 

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -765,3 +765,55 @@ let rec coerce_to_cases_pattern_expr c = CAst.map_with_loc (fun ?loc -> function
 
 let isCSort a =
   match a.CAst.v with Constrexpr.CSort _ -> true | _ -> false
+
+(**********************************************************************)
+(* Contracting "{ _ }" in notations *)
+
+let rec wildcards ntn n =
+  if Int.equal n (String.length ntn) then []
+  else let l = spaces ntn (n+1) in if ntn.[n] == '_' then n::l else l
+and spaces ntn n =
+  if Int.equal n (String.length ntn) then []
+  else if ntn.[n] == ' ' then wildcards ntn (n+1) else spaces ntn (n+1)
+
+let expand_notation_string ntn n =
+  let pos = List.nth (wildcards ntn 0) n in
+  let hd = if Int.equal pos 0 then "" else String.sub ntn 0 pos in
+  let tl =
+    if Int.equal pos (String.length ntn) then ""
+    else String.sub ntn (pos+1) (String.length ntn - pos -1) in
+  hd ^ "{ _ }" ^ tl
+
+(* This contracts the special case of "{ _ }" for sumbool, sumor notations *)
+(* Remark: expansion of squash at definition is done in metasyntax.ml *)
+let contract_curly_brackets ntn subst =
+  match ntn.ntn_entry with
+  | InCustomEntry _ -> ntn, subst
+  | InConstrEntry ->
+  let ntn' = ref ntn.ntn_key in
+  let rec contract_squash n = function
+    | [] -> []
+    | NtnTypeArg (NtnTypeArgConstr { CAst.v = CNotation (None,{ntn_entry = InConstrEntry; ntn_key = "{ _ }"},[NtnTypeArg (NtnTypeArgConstr a)]) }) :: l ->
+        ntn' := expand_notation_string !ntn' n;
+        contract_squash n (NtnTypeArg (NtnTypeArgConstr a)::l)
+    | a :: l ->
+        a::contract_squash (n+1) l in
+  let subst = contract_squash 0 subst in
+  (* side effect; don't inline *)
+  mk_ntn_in_constr !ntn', subst
+
+let contract_curly_brackets_pat ntn subst =
+  match ntn.ntn_entry with
+  | InCustomEntry _ -> ntn, subst
+  | InConstrEntry ->
+  let ntn' = ref ntn.ntn_key in
+  let rec contract_squash n = function
+    | [] -> []
+    | NtnTypeArg (NtnTypeArgPattern ({ CAst.v = CPatNotation (None,{ntn_entry = InConstrEntry; ntn_key = "{ _ }"},[NtnTypeArg (NtnTypeArgPattern a)],[]) }, Explicit)) :: l ->
+        ntn' := expand_notation_string !ntn' n;
+        contract_squash n (NtnTypeArg (NtnTypeArgPattern a)::l)
+    | a :: l ->
+        a :: contract_squash (n+1) l in
+  let subst = contract_squash 0 subst in
+  (* side effect; don't inline *)
+  mk_ntn_in_constr !ntn', subst

--- a/interp/constrexpr_ops.mli
+++ b/interp/constrexpr_ops.mli
@@ -127,6 +127,9 @@ val replace_vars_constr_expr :
 val free_vars_of_constr_expr : constr_expr -> Id.Set.t
 val occur_var_constr_expr : Id.t -> constr_expr -> bool
 
+val free_vars_of_cases_pattern_expr : cases_pattern_expr -> Id.Set.t
+val free_vars_of_local_binders : local_binder_expr list -> Id.Set.t
+
 (** Return all (non-qualified) names treating binders as names *)
 val names_of_constr_expr : constr_expr -> Id.Set.t
 

--- a/interp/constrexpr_ops.mli
+++ b/interp/constrexpr_ops.mli
@@ -133,10 +133,28 @@ val free_vars_of_local_binders : local_binder_expr list -> Id.Set.t
 (** Return all (non-qualified) names treating binders as names *)
 val names_of_constr_expr : constr_expr -> Id.Set.t
 
-val ntn_loc : ?loc:Loc.t -> constr_notation_substitution -> notation -> (int * int) list
-val patntn_loc : ?loc:Loc.t -> cases_pattern_notation_substitution -> notation -> (int * int) list
+val ntn_loc : ?loc:Loc.t -> notation_substitution -> notation -> (int * int) list
 
 val isCSort : constr_expr -> bool
 
 (** For cases pattern parsing errors *)
 val error_invalid_pattern_notation : ?loc:Loc.t -> unit -> 'a
+
+val notation_arg_type_fold_map :
+  ('a -> 'b -> 'a * 'c) ->
+  ('a -> 'd -> 'a * 'e) ->
+  ('a -> 'f -> 'a * 'g) ->
+  'a ->
+  ('b, 'd * 'h, 'f) Constrexpr.notation_arg_type ->
+  'a * ('c, 'e * 'h, 'g) Constrexpr.notation_arg_type
+val notation_arg_type_fold :
+  ('a -> 'b -> 'a) ->
+  ('a -> 'c -> 'a) ->
+  ('a -> 'd -> 'a) ->
+  'a -> ('b, 'c * 'e, 'd) Constrexpr.notation_arg_type -> 'a
+val notation_arg_type_map :
+  ('a -> 'b) ->
+  ('c -> 'd) ->
+  ('e -> 'f) ->
+  ('a, 'c * 'g, 'e) Constrexpr.notation_arg_type ->
+  ('b, 'd * 'g, 'f) Constrexpr.notation_arg_type

--- a/interp/constrexpr_ops.mli
+++ b/interp/constrexpr_ops.mli
@@ -49,6 +49,9 @@ val local_binders_loc : local_binder_expr list -> Loc.t option
 
 (** {6 Constructors} *)
 
+val mk_ntn : notation_entry -> notation_key -> notation
+val mk_ntn_in_constr : notation_key -> notation
+
 (** {7 Term constructors} *)
 
 (** Basic form of the corresponding constructors *)

--- a/interp/constrexpr_ops.mli
+++ b/interp/constrexpr_ops.mli
@@ -122,6 +122,27 @@ val map_constr_expr_with_binders :
   (Id.t -> 'a -> 'a) -> ('a -> constr_expr -> constr_expr) ->
       'a -> constr_expr -> constr_expr
 
+val notation_arg_type_fold_map :
+  ('a -> 'b -> 'a * 'c) ->  (* constr_expr *)
+  ('a -> 'd -> 'a * 'e) ->  (* cases_pattern_expr *)
+  ('a -> 'f -> 'a * 'g) ->  (* local_binder_expr list *)
+  'a ->
+  ('b, 'd * 'h, 'f) Constrexpr.notation_arg_type ->
+  'a * ('c, 'e * 'h, 'g) Constrexpr.notation_arg_type
+
+val notation_arg_type_fold :
+  ('a -> 'b -> 'a) ->  (* constr_expr *)
+  ('a -> 'c -> 'a) ->  (* cases_pattern_expr *)
+  ('a -> 'd -> 'a) ->  (* local_binder_expr list *)
+  'a -> ('b, 'c * 'e, 'd) Constrexpr.notation_arg_type -> 'a
+
+val notation_arg_type_map :
+  ('a -> 'b) ->  (* constr_expr *)
+  ('c -> 'd) ->  (* cases_pattern_expr *)
+  ('e -> 'f) ->  (* local_binder_expr list *)
+  ('a, 'c * 'g, 'e) Constrexpr.notation_arg_type ->
+  ('b, 'd * 'g, 'f) Constrexpr.notation_arg_type
+
 (** {6 Miscellaneous}*)
 
 val replace_vars_constr_expr :
@@ -142,22 +163,3 @@ val isCSort : constr_expr -> bool
 
 (** For cases pattern parsing errors *)
 val error_invalid_pattern_notation : ?loc:Loc.t -> unit -> 'a
-
-val notation_arg_type_fold_map :
-  ('a -> 'b -> 'a * 'c) ->
-  ('a -> 'd -> 'a * 'e) ->
-  ('a -> 'f -> 'a * 'g) ->
-  'a ->
-  ('b, 'd * 'h, 'f) Constrexpr.notation_arg_type ->
-  'a * ('c, 'e * 'h, 'g) Constrexpr.notation_arg_type
-val notation_arg_type_fold :
-  ('a -> 'b -> 'a) ->
-  ('a -> 'c -> 'a) ->
-  ('a -> 'd -> 'a) ->
-  'a -> ('b, 'c * 'e, 'd) Constrexpr.notation_arg_type -> 'a
-val notation_arg_type_map :
-  ('a -> 'b) ->
-  ('c -> 'd) ->
-  ('e -> 'f) ->
-  ('a, 'c * 'g, 'e) Constrexpr.notation_arg_type ->
-  ('b, 'd * 'g, 'f) Constrexpr.notation_arg_type

--- a/interp/constrexpr_ops.mli
+++ b/interp/constrexpr_ops.mli
@@ -163,3 +163,13 @@ val isCSort : constr_expr -> bool
 
 (** For cases pattern parsing errors *)
 val error_invalid_pattern_notation : ?loc:Loc.t -> unit -> 'a
+
+(** Ad hoc support for curly brackets in notations; avoid as much as possible *)
+
+val contract_curly_brackets : Constrexpr.notation ->
+    (Constrexpr.constr_expr, 'a, 'b) Constrexpr.notation_arg_type list ->
+    Constrexpr.notation * (Constrexpr.constr_expr, 'a, 'b) Constrexpr.notation_arg_type list
+
+val contract_curly_brackets_pat : Constrexpr.notation ->
+    ('a, Constrexpr.kinded_cases_pattern_expr, 'b) Constrexpr.notation_arg_type list ->
+    Constrexpr.notation * ('a, Constrexpr.kinded_cases_pattern_expr, 'b) Constrexpr.notation_arg_type list

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -165,11 +165,11 @@ let insert_pat_alias ?loc p = function
 
 let rec insert_entry_coercion ?loc l c = match l with
   | [] -> c
-  | (inscope,ntn)::l -> CAst.make ?loc @@ CNotation (Some inscope,ntn,([insert_entry_coercion ?loc l c],[],[],[]))
+  | (inscope,ntn)::l -> CAst.make ?loc @@ CNotation (Some inscope,ntn,[NtnTypeArg (NtnTypeArgConstr (insert_entry_coercion ?loc l c))])
 
 let rec insert_pat_coercion ?loc l c = match l with
   | [] -> c
-  | (inscope,ntn)::l -> CAst.make ?loc @@ CPatNotation (Some inscope,ntn,([insert_pat_coercion ?loc l c],[],[]),[])
+  | (inscope,ntn)::l -> CAst.make ?loc @@ CPatNotation (Some inscope,ntn,[NtnTypeArg (NtnTypeArgPattern (insert_pat_coercion ?loc l c, Explicit))],[])
 
 (**********************************************************************)
 (* conversion of references                                           *)
@@ -219,9 +219,10 @@ let rec fill_arg_scopes args subscopes (_,scopes as all) =
     (a, ((constr_some_level,None), ([], scopes))) :: fill_arg_scopes args [] all
 
 let overlap_right_left {notation_entry = entry} lev_after ((typs,_):Notation_term.interpretation) =
-  List.exists (fun (_id,(({notation_subentry = entry'; notation_relative_level = lev; notation_position = side},_),_,_)) ->
-      match side with
-      | Some Right when notation_entry_eq entry entry' -> may_capture_cont_after lev_after lev
+  List.exists (function
+      | (_id,Notation_term.NtnTypeVar ((({notation_subentry = entry'; notation_relative_level = lev; notation_position = Some Right},_),_),_))
+        when notation_entry_eq entry entry' ->
+        may_capture_cont_after lev_after lev
       | _ -> false) typs
 
 let update_with_subscope from_entry (entry,(scopt,scl)) lev_after closed scopes =
@@ -230,7 +231,7 @@ let update_with_subscope from_entry (entry,(scopt,scl)) lev_after closed scopes 
   let lev_after =
     match side with
     | Some Left -> Some from_entry.notation_level
-    | Some Right  -> if closed then None else lev_after
+    | Some Right -> if closed then None else lev_after
     | None -> None in
   let subentry' = {notation_subentry = entry; notation_relative_level = lev; notation_position = side} in
   ((subentry',lev_after),(scopt,scl@scopes))
@@ -294,44 +295,47 @@ let drop_implicits_in_patt cst nb_expl args =
 let destPrim = function { CAst.v = CPrim t } -> Some t | _ -> None
 let destPatPrim = function { CAst.v = CPatPrim t } -> Some t | _ -> None
 
-let make_notation_gen loc ntn mknot mkprim destprim l bl =
-  match snd ntn,List.map destprim l with
+let parenthesis_notation ?loc subst =
+  CAst.make ?loc @@ CNotation (None,(InConstrEntry,"( _ )"),subst)
+let parenthesis_pat_notation ?loc subst =
+  CAst.make ?loc @@ CPatNotation (None,(InConstrEntry,"( _ )"),subst,[])
+
+let make_notation_gen loc ntn mknot mkprim destprim subst =
+  match snd ntn, subst with
+  | "- _", [NtnTypeArg x] ->
+    (match x with
     (* Special case to avoid writing "- 3" for e.g. (Z.opp 3) *)
-    | "- _", [Some (Number p)] when not (NumTok.Signed.is_zero p) ->
-        assert (bl=[]);
-        mknot (loc,ntn,([mknot (loc,(InConstrEntry,"( _ )"),l,[])]),[])
-    | _ ->
-        match decompose_notation_key ntn, l with
-        | (InConstrEntry,[Terminal x]), [] ->
-           begin match String.unquote_coq_string x with
-           | Some s -> mkprim (loc, String s)
-           | None ->
-           match NumTok.Unsigned.parse_string x with
-           | Some n -> mkprim (loc, Number (NumTok.SPlus,n))
-           | None -> mknot (loc,ntn,l,bl) end
-        | (InConstrEntry,[Terminal "-"; Terminal x]), [] ->
-           begin match NumTok.Unsigned.parse_string x with
-           | Some n -> mkprim (loc, Number (NumTok.SMinus,n))
-           | None -> mknot (loc,ntn,l,bl) end
-        | _ -> mknot (loc,ntn,l,bl)
+    | NtnTypeArgConstr {CAst.v = CPrim (Number p)} when not (NumTok.Signed.is_zero p) ->
+      mknot (loc,ntn,[NtnTypeArg (NtnTypeArgConstr (parenthesis_notation ?loc subst))])
+    | NtnTypeArgPattern ({CAst.v = CPatPrim (Number p)}, Explicit) when not (NumTok.Signed.is_zero p) ->
+      mknot (loc,ntn,[NtnTypeArg (NtnTypeArgPattern (parenthesis_pat_notation ?loc subst,Explicit))])
+    | _ -> mknot (loc, ntn, subst))
+  | _ ->
+    match decompose_notation_key ntn, subst with
+    | (InConstrEntry,[Terminal x]), [] ->
+      begin match String.unquote_coq_string x with
+      | Some s -> mkprim (loc, String s)
+      | None ->
+        match NumTok.Unsigned.parse_string x with
+        | Some n -> mkprim (loc, Number (NumTok.SPlus,n))
+        | None -> mknot (loc,ntn,subst) end
+    | (InConstrEntry,[Terminal "-"; Terminal x]), [] ->
+      begin match NumTok.Unsigned.parse_string x with
+      | Some n -> mkprim (loc, Number (NumTok.SMinus,n))
+      | None -> mknot (loc,ntn,subst) end
+    | _ -> mknot (loc,ntn,subst)
 
-let make_notation loc (inscope,ntn) (terms,termlists,binders,binderlists as subst) =
-  if not (List.is_empty termlists) || not (List.is_empty binderlists) then
-    CAst.make ?loc @@ CNotation (Some inscope,ntn,subst)
-  else
-    make_notation_gen loc ntn
-      (fun (loc,ntn,l,bl) -> CAst.make ?loc @@ CNotation (Some inscope,ntn,(l,[],bl,[])))
-      (fun (loc,p) -> CAst.make ?loc @@ CPrim p)
-      destPrim terms binders
-
-let make_pat_notation ?loc (inscope,ntn) (terms,termlists,binders as subst) =
-  if not (List.is_empty termlists && List.is_empty binders) then
-    (CAst.make ?loc @@ CPatNotation (Some inscope,ntn,subst,[]))
-  else
+let make_notation loc (inscope,ntn) subst =
   make_notation_gen loc ntn
-    (fun (loc,ntn,l,_) -> CAst.make ?loc @@ CPatNotation (Some inscope,ntn,(l,[],[]),[]))
+    (fun (loc,ntn,subst) -> CAst.make ?loc @@ CNotation (Some inscope,ntn,subst))
+    (fun (loc,p) -> CAst.make ?loc @@ CPrim p)
+    destPrim subst
+
+let make_pat_notation ?loc (inscope,ntn) subst =
+  make_notation_gen loc ntn
+    (fun (loc,ntn,subst) -> CAst.make ?loc @@ CPatNotation (Some inscope,ntn,subst,[]))
     (fun (loc,p)     -> CAst.make ?loc @@ CPatPrim p)
-    destPatPrim terms []
+    destPatPrim subst
 
 let apply_pat_notation (CAst.{v;loc} as c) args =
   if List.is_empty args then c else
@@ -431,7 +435,7 @@ let rec extern_cases_pattern_in_scope ((custom,(lev_after:int option)),scopes as
       in
       insert_pat_coercion coercion pat
 
-and apply_notation_to_pattern ?loc gr ((terms,termlists,binders),(no_implicit,nb_to_drop,more_args))
+and apply_notation_to_pattern ?loc gr (subst,(no_implicit,nb_to_drop,more_args))
     ((custom, lev_after), (tmp_scope, scopes) as allscopes) vars pat rule =
   let lev_after = if List.is_empty more_args then lev_after else Some Notation.app_level in
   let extra_args =
@@ -439,7 +443,8 @@ and apply_notation_to_pattern ?loc gr ((terms,termlists,binders),(no_implicit,nb
     let more_args_scopes = try List.skipn nb_to_drop subscopes with Failure _ -> [] in
     let more_args = fill_arg_scopes more_args more_args_scopes (snd allscopes) in
     let more_args = List.map (fun (c,allscopes) -> extern_cases_pattern_in_scope allscopes vars c) more_args in
-    if Constrintern.get_asymmetric_patterns () || not (List.is_empty termlists) then more_args
+    let has_list = Id.Map.exists (fun _ -> function (NtnTypeArgList _) -> true | _ -> false) subst in
+    if Constrintern.get_asymmetric_patterns () || has_list then more_args
     else if no_implicit then more_args else
       match drop_implicits_in_patt gr nb_to_drop more_args with
       | Some true_args -> true_args
@@ -458,27 +463,17 @@ and apply_notation_to_pattern ?loc gr ((terms,termlists,binders),(no_implicit,nb
           (* Uninterpretation is allowed in current context *)
           | Some (scopt,key) ->
             let scopes' = Option.List.cons scopt scopes in
-            let l =
-              List.map (fun (c,subscope) ->
-                let scopes = update_with_subscope entry subscope lev_after closed scopes' in
-                extern_cases_pattern_in_scope scopes vars c)
-                terms in
-            let ll =
-              List.map (fun (c,subscope) ->
-                let scopes = update_with_subscope entry subscope lev_after closed scopes' in
-                List.map (extern_cases_pattern_in_scope scopes vars) c)
-                termlists in
-            let bl =
-              List.map (fun (c,subscope) ->
-                let scopes = update_with_subscope entry subscope lev_after closed scopes' in
-                (extern_cases_pattern_in_scope scopes vars c, Explicit))
-                binders
+            let fullscopes = (entry,lev_after,closed,scopes',vars) in
+            let subst =
+              List.map (fun (id,typ) ->
+                  let a = try Id.Map.find id subst with Not_found -> raise No_match in
+                  extern_cases_pattern_notation_substitution fullscopes typ a) (fst pat)
             in
             insert_pat_coercion appcoercion
               (insert_pat_delimiters ?loc
                  (apply_pat_notation
                     (insert_pat_coercion coercion
-                       (make_pat_notation ?loc specific_ntn (l,ll,bl)))
+                       (make_pat_notation ?loc specific_ntn subst))
                     extra_args)
                  key)
       end
@@ -487,12 +482,13 @@ and apply_notation_to_pattern ?loc gr ((terms,termlists,binders),(no_implicit,nb
       | None -> raise No_match
       | Some coercion ->
       let qid = Nametab.shortest_qualid_of_abbreviation ?loc vars kn in
-      let l1 =
-        List.rev_map (fun (c,(subentry,(scopt,scl))) ->
-          extern_cases_pattern_in_scope ((subentry,lev_after),(scopt,scl@scopes)) vars c)
-          terms in
-      assert (List.is_empty termlists);
-      assert (List.is_empty binders);
+      let fullscopes = (constr_lowest_level,lev_after,false,scopes,vars) in
+      let subst =
+        List.map (fun (id,typ) ->
+            let arg = try Id.Map.find id subst with Not_found -> raise No_match in
+            extern_cases_pattern_notation_substitution fullscopes typ arg) (fst pat)
+      in
+      let l1 = List.map (function NtnTypeArg (NtnTypeArgPattern (c,bk)) -> c | _ -> assert false) subst in
       insert_pat_coercion ?loc coercion (CAst.make ?loc @@ CPatCstr (qid,None,List.rev_append l1 extra_args))
 
 and extern_notation_pattern allscopes vars t = function
@@ -511,6 +507,23 @@ and extern_notation_pattern allscopes vars t = function
         | PatVar (Name id) -> CAst.make ?loc @@ CPatAtom (Some (qualid_of_ident ?loc id))
     with
         No_match -> extern_notation_pattern allscopes vars t rules
+
+and extern_cases_pattern_notation_substitution_arg (entry,lev_after,closed,scopes',vars) subscopes typ arg =
+  let scopes = update_with_subscope entry subscopes lev_after closed scopes' in
+  let open Notation_term in
+  match typ, arg with
+  | (NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern | NtnTypeVarPattern _), NtnTypeArgPattern c ->
+    NtnTypeArg (NtnTypeArgPattern (extern_cases_pattern_in_scope scopes vars c, Explicit))
+  | NtnTypeVarBinders _, NtnTypeArgBinders _ -> anomaly (str "Unexpected binders in pattern notation.")
+  | (NtnTypeVarConstr _ | NtnTypeVarPattern _ | NtnTypeVarBinders _), _ -> assert false (* ill-typed *)
+
+and extern_cases_pattern_notation_substitution fullscopes typ arg =
+  let open Notation_term in
+  match typ, arg with
+  | NtnTypeVar ((scopes, _), typ), NtnTypeArg c -> extern_cases_pattern_notation_substitution_arg fullscopes scopes typ c
+  | NtnTypeVarList typ, NtnTypeArgList l -> NtnTypeArgList (List.map (extern_cases_pattern_notation_substitution fullscopes typ) l)
+  | NtnTypeVarTuple typl, NtnTypeArgTuple l -> NtnTypeArgTuple (List.map2 (extern_cases_pattern_notation_substitution fullscopes) typl l)
+  | (NtnTypeVar _ | NtnTypeVarList _ | NtnTypeVarTuple _), _ -> assert false (* ill-typed *)
 
 let rec extern_notation_ind_pattern allscopes vars ind args = function
   | [] -> raise No_match
@@ -839,6 +852,21 @@ let extended_glob_local_binder_of_decl loc = function
     | _ -> GLocalDef (p,r,x,Some t)
 
 let extended_glob_local_binder_of_decl ?loc u = DAst.make ?loc (extended_glob_local_binder_of_decl loc u)
+
+let glob_constr_of_local_binder_expr pat =
+  match DAst.get pat with
+  | GLocalPattern ((disjpat,_),_,_,_) ->
+    List.map (glob_constr_of_cases_pattern (Global.env())) disjpat
+  | GLocalAssum (Anonymous,_,bk,t) ->
+    let hole = DAst.make (GHole (GBinderType Anonymous)) in
+    [DAst.make (GCast (hole, Some DEFAULTcast, t))]
+  | GLocalAssum (Name id,_,bk,t) ->
+    [DAst.make (GCast (DAst.make (GVar id), Some DEFAULTcast, t))]
+  | GLocalDef _ -> raise No_match
+
+let glob_constr_of_disjunctive_cases_pattern = function
+  | [pat] -> glob_constr_of_cases_pattern (Global.env()) pat
+  | _ -> raise No_match
 
 (**********************************************************************)
 (* mapping special floats                                             *)
@@ -1338,7 +1366,7 @@ and extern_notation depth inctx ((custom,(lev_after: int option)),scopes as alls
           | AppBoundedNotation _ -> raise No_match in
         (* Try matching ... *)
         let vars, uvars = vars in
-        let terms,termlists,binders,binderlists =
+        let subst =
           match_notation_constr ~print_parentheses:!print_parentheses ~print_univ:(!print_universes)
             t ~vars pat
         in
@@ -1354,49 +1382,30 @@ and extern_notation depth inctx ((custom,(lev_after: int option)),scopes as alls
             let entry = fst (Notation.level_of_notation ntn) in
             let non_included = overlap_right_left entry lev_after pat in
             let coercion, appcoercion = find_entry_coercion_with_application ~non_included custom entry (is_empty_extra_args extra_args) in
+            let closed = not (List.is_empty coercion) in
             (match availability_of_notation specific_ntn scopes with
                   (* Uninterpretation is not allowed in current context *)
               | None -> raise No_match
                   (* Uninterpretation is allowed in current context *)
               | Some (scopt,key) ->
-                  let closed = not (List.is_empty coercion) in
                   let scopes' = Option.List.cons scopt (snd scopes) in
-                  let l =
-                    List.map (fun ((vars,c),subscope) ->
-                      let scopes = update_with_subscope entry subscope lev_after closed scopes' in
-                      extern depth (* assuming no overloading: *) true scopes (vars,uvars) c)
-                      terms
+                  let fullscopes = (entry,lev_after,closed,scopes',uvars) in
+                  let subst =
+                    List.map (fun (id,typ) ->
+                        let a = try Id.Map.find id subst with Not_found -> raise No_match in
+                        extern_notation_substitution depth fullscopes typ a) (fst pat)
                   in
-                  let ll =
-                    List.map (fun ((vars,l),subscope) ->
-                      let scopes = update_with_subscope entry subscope lev_after closed scopes' in
-                      List.map (extern depth true scopes (vars,uvars)) l)
-                      termlists
-                  in
-                  let bl =
-                    List.map (fun ((vars,bl),subscope) ->
-                      let scopes = update_with_subscope entry subscope lev_after closed scopes' in
-                        (mkCPatOr (List.map
-                                     (extern_cases_pattern_in_scope scopes vars) bl)),
-                        Explicit)
-                      binders
-                  in
-                  let bll =
-                    List.map (fun ((vars,bl),subscope) ->
-                      let scopes = update_with_subscope entry subscope lev_after closed scopes' in
-                      pi3 (extern_local_binder depth scopes (vars,uvars) bl))
-                      binderlists
-                  in
-                  let c = make_notation loc specific_ntn (l,ll,bl,bll) in
+                  let c = make_notation loc specific_ntn subst in
                   let c = insert_entry_coercion coercion (insert_delimiters c key) in
                   insert_entry_coercion appcoercion (CAst.make ?loc @@ extern_applied_notation c extra_args))
           | AbbrevRule kn ->
-              let l =
-                List.map (fun ((vars,c),subscope) ->
-                    let scopes = update_with_subscope constr_lowest_level subscope lev_after false (snd scopes) in
-                  extern depth true scopes (vars,uvars) c)
-                  terms
+              let fullscopes = (constr_lowest_level,lev_after,false,snd scopes,uvars) in
+              let subst =
+                List.map (fun (id,typ) ->
+                    let a = try Id.Map.find id subst with Not_found -> raise No_match in
+                    extern_notation_substitution depth fullscopes typ a) (fst pat)
               in
+              let l = List.map (function NtnTypeArg (NtnTypeArgConstr c) -> c | _ -> assert false) subst in
               let cf = Nametab.shortest_qualid_of_abbreviation ?loc vars kn in
               let a = CRef (cf,None) in
               let c = CAst.make ?loc @@ extern_applied_abbreviation (a,cf) l extra_args in
@@ -1406,6 +1415,39 @@ and extern_notation depth inctx ((custom,(lev_after: int option)),scopes as alls
                 | Some coercion -> insert_entry_coercion coercion c
       with
           No_match -> extern_notation depth inctx allscopes vars t rules
+
+and extern_notation_substitution_arg depth (entry,lev_after,closed,scopes',uvars) subscopes typ arg =
+  (* From interpretation types to parsing types *)
+  let scopes = update_with_subscope entry subscopes lev_after closed scopes' in
+  let open Notation_term in
+  match typ, arg with
+  | NtnTypeVarConstr _, NtnTypeArgConstr (vars,_,c) ->
+    NtnTypeArg (NtnTypeArgConstr (extern (* assuming no overloading: *) depth true scopes (vars,uvars) c))
+  | NtnTypeVarPattern k, NtnTypeArgPattern (vars,_,patl) ->
+    let b = match k with
+     | NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _ ->
+       NtnTypeArgPattern (mkCPatOr (List.map (extern_cases_pattern_in_scope scopes vars) patl), Explicit)
+     | NtnBinderParsedAsConstr _ ->
+       let c = glob_constr_of_disjunctive_cases_pattern patl in
+       NtnTypeArgConstr (extern depth true scopes (vars,uvars) c)
+    in
+    NtnTypeArg b
+  | NtnTypeVarBinders k, NtnTypeArgBinders (vars,_,bl) ->
+    (match k with
+      | NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _ ->
+        NtnTypeArg (NtnTypeArgBinders (pi3 (extern_local_binder depth scopes (vars,uvars) bl)))
+      | NtnBinderParsedAsConstr _ ->
+        let l = List.map_append glob_constr_of_local_binder_expr bl in
+        NtnTypeArgList (List.map (fun c -> NtnTypeArg (NtnTypeArgConstr (extern depth true scopes (vars,uvars) c))) l))
+  | (NtnTypeVarConstr _ | NtnTypeVarPattern _ | NtnTypeVarBinders _), _ -> assert false (* ill-typed *)
+
+and extern_notation_substitution depth fullscopes typ arg =
+  let open Notation_term in
+  match typ, arg with
+  | NtnTypeVar ((scopes, _), typ), NtnTypeArg c -> extern_notation_substitution_arg depth fullscopes scopes typ c
+  | NtnTypeVarList typ, NtnTypeArgList l -> NtnTypeArgList (List.map (extern_notation_substitution depth fullscopes typ) l)
+  | NtnTypeVarTuple typl, NtnTypeArgTuple l -> NtnTypeArgTuple (List.map2 (extern_notation_substitution depth fullscopes) typl l)
+  | (NtnTypeVar _ | NtnTypeVarList _ | NtnTypeVarTuple _), _ -> assert false (* ill-typed *)
 
 and extern_applied_proj depth inctx scopes vars (cst,us) params c extraargs =
   let ref = GlobRef.ConstRef cst in

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1392,8 +1392,9 @@ and extern_notation depth inctx ((custom,(lev_after: int option)),scopes as alls
                   insert_entry_coercion appcoercion (CAst.make ?loc @@ extern_applied_notation c extra_args))
           | AbbrevRule kn ->
               let l =
-                List.map (fun ((vars,c),(subentry,(scopt,scl))) ->
-                  extern depth true ((subentry,lev_after),(scopt,scl@snd scopes)) (vars,uvars) c)
+                List.map (fun ((vars,c),subscope) ->
+                    let scopes = update_with_subscope constr_lowest_level subscope lev_after false (snd scopes) in
+                  extern depth true scopes (vars,uvars) c)
                   terms
               in
               let cf = Nametab.shortest_qualid_of_abbreviation ?loc vars kn in

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -296,12 +296,12 @@ let destPrim = function { CAst.v = CPrim t } -> Some t | _ -> None
 let destPatPrim = function { CAst.v = CPatPrim t } -> Some t | _ -> None
 
 let parenthesis_notation ?loc subst =
-  CAst.make ?loc @@ CNotation (None,(InConstrEntry,"( _ )"),subst)
+  CAst.make ?loc @@ CNotation (None,mk_ntn_in_constr "( _ )",subst)
 let parenthesis_pat_notation ?loc subst =
-  CAst.make ?loc @@ CPatNotation (None,(InConstrEntry,"( _ )"),subst,[])
+  CAst.make ?loc @@ CPatNotation (None,mk_ntn_in_constr "( _ )",subst,[])
 
 let make_notation_gen loc ntn mknot mkprim destprim subst =
-  match snd ntn, subst with
+  match ntn.ntn_key, subst with
   | "- _", [NtnTypeArg x] ->
     (match x with
     (* Special case to avoid writing "- 3" for e.g. (Z.opp 3) *)

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -45,8 +45,7 @@ let is_reserved_type ~flags na t =
   | Name id ->
     try
       let pat = Reserve.find_reserved_type id in
-      let _ : _ * _ * _ * _ =
-        match_notation_constr ~print_parentheses:true ~factorize_eqns:flags.factorize_eqns
+      let _ = match_notation_constr ~print_parentheses:true ~factorize_eqns:flags.factorize_eqns
           t ~vars:Id.Set.empty ([],pat)
       in
       true
@@ -69,11 +68,11 @@ let insert_pat_alias ?loc p = function
 
 let rec insert_entry_coercion ?loc l c = match l with
   | [] -> c
-  | (inscope,ntn)::l -> CAst.make ?loc @@ CNotation (Some inscope,ntn,([insert_entry_coercion ?loc l c],[],[],[]))
+  | (inscope,ntn)::l -> CAst.make ?loc @@ CNotation (Some inscope,ntn,[NtnTypeArg (NtnTypeArgConstr (insert_entry_coercion ?loc l c))])
 
 let rec insert_pat_coercion ?loc l c = match l with
   | [] -> c
-  | (inscope,ntn)::l -> CAst.make ?loc @@ CPatNotation (Some inscope,ntn,([insert_pat_coercion ?loc l c],[],[]),[])
+  | (inscope,ntn)::l -> CAst.make ?loc @@ CPatNotation (Some inscope,ntn,[NtnTypeArg (NtnTypeArgPattern (insert_pat_coercion ?loc l c, Explicit))],[])
 
 (**********************************************************************)
 (* conversion of references                                           *)
@@ -112,9 +111,10 @@ let rec fill_arg_scopes args subscopes (_,scopes as all) =
     (a, ((constr_some_level,None), ([], scopes))) :: fill_arg_scopes args [] all
 
 let overlap_right_left {notation_entry = entry} lev_after ((typs,_):Notation_term.interpretation) =
-  List.exists (fun (_id,(({notation_subentry = entry'; notation_relative_level = lev; notation_position = side},_),_,_)) ->
-      match side with
-      | Some Right when notation_entry_eq entry entry' -> may_capture_cont_after lev_after lev
+  List.exists (function
+      | (_id,Notation_term.NtnTypeVar ((({notation_subentry = entry'; notation_relative_level = lev; notation_position = Some Right},_),_),_))
+        when notation_entry_eq entry entry' ->
+        may_capture_cont_after lev_after lev
       | _ -> false) typs
 
 let update_with_subscope ~flags from_entry (entry,(scopt,scl)) lev_after closed scopes =
@@ -123,7 +123,7 @@ let update_with_subscope ~flags from_entry (entry,(scopt,scl)) lev_after closed 
   let lev_after =
     match side with
     | Some Left -> Some from_entry.notation_level
-    | Some Right  -> if closed then None else lev_after
+    | Some Right -> if closed then None else lev_after
     | None -> None in
   let subentry' = {notation_subentry = entry; notation_relative_level = lev; notation_position = side} in
   ((subentry',lev_after),(scopt,scl@scopes))
@@ -188,44 +188,47 @@ let drop_implicits_in_patt ~flags cst nb_expl ?(tags=[]) args =
 let destPrim = function { CAst.v = CPrim t } -> Some t | _ -> None
 let destPatPrim = function { CAst.v = CPatPrim t } -> Some t | _ -> None
 
-let make_notation_gen loc ntn mknot mkprim destprim l bl =
-  match snd ntn,List.map destprim l with
+let parenthesis_notation ?loc subst =
+  CAst.make ?loc @@ CNotation (None,(InConstrEntry,"( _ )"),subst)
+let parenthesis_pat_notation ?loc subst =
+  CAst.make ?loc @@ CPatNotation (None,(InConstrEntry,"( _ )"),subst,[])
+
+let make_notation_gen loc ntn mknot mkprim destprim subst =
+  match snd ntn, subst with
+  | "- _", [NtnTypeArg x] ->
+    (match x with
     (* Special case to avoid writing "- 3" for e.g. (Z.opp 3) *)
-    | "- _", [Some (Number p)] when not (NumTok.Signed.is_zero p) ->
-        assert (bl=[]);
-        mknot (loc,ntn,([mknot (loc,(InConstrEntry,"( _ )"),l,[])]),[])
-    | _ ->
-        match decompose_notation_key ntn, l with
-        | (InConstrEntry,[Terminal x]), [] ->
-           begin match String.unquote_coq_string x with
-           | Some s -> mkprim (loc, String s)
-           | None ->
-           match NumTok.Unsigned.parse_string x with
-           | Some n -> mkprim (loc, Number (NumTok.SPlus,n))
-           | None -> mknot (loc,ntn,l,bl) end
-        | (InConstrEntry,[Terminal "-"; Terminal x]), [] ->
-           begin match NumTok.Unsigned.parse_string x with
-           | Some n -> mkprim (loc, Number (NumTok.SMinus,n))
-           | None -> mknot (loc,ntn,l,bl) end
-        | _ -> mknot (loc,ntn,l,bl)
+    | NtnTypeArgConstr {CAst.v = CPrim (Number p)} when not (NumTok.Signed.is_zero p) ->
+      mknot (loc,ntn,[NtnTypeArg (NtnTypeArgConstr (parenthesis_notation ?loc subst))])
+    | NtnTypeArgPattern ({CAst.v = CPatPrim (Number p)}, Explicit) when not (NumTok.Signed.is_zero p) ->
+      mknot (loc,ntn,[NtnTypeArg (NtnTypeArgPattern (parenthesis_pat_notation ?loc subst,Explicit))])
+    | _ -> mknot (loc, ntn, subst))
+  | _ ->
+    match decompose_notation_key ntn, subst with
+    | (InConstrEntry,[Terminal x]), [] ->
+      begin match String.unquote_coq_string x with
+      | Some s -> mkprim (loc, String s)
+      | None ->
+        match NumTok.Unsigned.parse_string x with
+        | Some n -> mkprim (loc, Number (NumTok.SPlus,n))
+        | None -> mknot (loc,ntn,subst) end
+    | (InConstrEntry,[Terminal "-"; Terminal x]), [] ->
+      begin match NumTok.Unsigned.parse_string x with
+      | Some n -> mkprim (loc, Number (NumTok.SMinus,n))
+      | None -> mknot (loc,ntn,subst) end
+    | _ -> mknot (loc,ntn,subst)
 
-let make_notation loc (inscope,ntn) (terms,termlists,binders,binderlists as subst) =
-  if not (List.is_empty termlists) || not (List.is_empty binderlists) then
-    CAst.make ?loc @@ CNotation (Some inscope,ntn,subst)
-  else
-    make_notation_gen loc ntn
-      (fun (loc,ntn,l,bl) -> CAst.make ?loc @@ CNotation (Some inscope,ntn,(l,[],bl,[])))
-      (fun (loc,p) -> CAst.make ?loc @@ CPrim p)
-      destPrim terms binders
-
-let make_pat_notation ?loc (inscope,ntn) (terms,termlists,binders as subst) =
-  if not (List.is_empty termlists && List.is_empty binders) then
-    (CAst.make ?loc @@ CPatNotation (Some inscope,ntn,subst,[]))
-  else
+let make_notation loc (inscope,ntn) subst =
   make_notation_gen loc ntn
-    (fun (loc,ntn,l,_) -> CAst.make ?loc @@ CPatNotation (Some inscope,ntn,(l,[],[]),[]))
+    (fun (loc,ntn,subst) -> CAst.make ?loc @@ CNotation (Some inscope,ntn,subst))
+    (fun (loc,p) -> CAst.make ?loc @@ CPrim p)
+    destPrim subst
+
+let make_pat_notation ?loc (inscope,ntn) subst =
+  make_notation_gen loc ntn
+    (fun (loc,ntn,subst) -> CAst.make ?loc @@ CPatNotation (Some inscope,ntn,subst,[]))
     (fun (loc,p)     -> CAst.make ?loc @@ CPatPrim p)
-    destPatPrim terms []
+    destPatPrim subst
 
 let apply_pat_notation (CAst.{v;loc} as c) args =
   if List.is_empty args then c else
@@ -329,7 +332,7 @@ let rec extern_cases_pattern_in_scope ~flags ((custom,(lev_after:int option)),sc
       in
       insert_pat_coercion coercion pat
 
-and apply_notation_to_pattern ?loc ~flags gr ((terms,termlists,binders),(no_implicit,nb_to_drop,more_args))
+and apply_notation_to_pattern ?loc ~flags gr (subst,(no_implicit,nb_to_drop,more_args))
     ((custom, lev_after), (tmp_scope, scopes) as allscopes) vars pat rule =
   let lev_after = if List.is_empty more_args then lev_after else Some Notation.app_level in
   let extra_args =
@@ -337,7 +340,8 @@ and apply_notation_to_pattern ?loc ~flags gr ((terms,termlists,binders),(no_impl
     let more_args_scopes = try List.skipn nb_to_drop subscopes with Failure _ -> [] in
     let more_args = fill_arg_scopes more_args more_args_scopes (snd allscopes) in
     let more_args = List.map (fun (c,allscopes) -> extern_cases_pattern_in_scope ~flags allscopes vars c) more_args in
-    if Constrintern.get_asymmetric_patterns () || not (List.is_empty termlists) then more_args
+    let has_list = Id.Map.exists (fun _ -> function (NtnTypeArgList _) -> true | _ -> false) subst in
+    if Constrintern.get_asymmetric_patterns () || has_list then more_args
     else if no_implicit then more_args else
       match drop_implicits_in_patt ~flags gr nb_to_drop more_args with
       | Some true_args -> true_args
@@ -356,27 +360,17 @@ and apply_notation_to_pattern ?loc ~flags gr ((terms,termlists,binders),(no_impl
           (* Uninterpretation is allowed in current context *)
           | Some (scopt,key) ->
             let scopes' = Option.List.cons scopt scopes in
-            let l =
-              List.map (fun (c,subscope) ->
-                let scopes = update_with_subscope ~flags entry subscope lev_after closed scopes' in
-                extern_cases_pattern_in_scope ~flags scopes vars c)
-                terms in
-            let ll =
-              List.map (fun (c,subscope) ->
-                let scopes = update_with_subscope ~flags entry subscope lev_after closed scopes' in
-                List.map (extern_cases_pattern_in_scope ~flags scopes vars) c)
-                termlists in
-            let bl =
-              List.map (fun (c,subscope) ->
-                let scopes = update_with_subscope ~flags entry subscope lev_after closed scopes' in
-                (extern_cases_pattern_in_scope ~flags scopes vars c, Explicit))
-                binders
+            let fullscopes = (entry,lev_after,closed,scopes',vars) in
+            let subst =
+              List.map (fun (id,typ) ->
+                  let a = try Id.Map.find id subst with Not_found -> raise No_match in
+                  extern_cases_pattern_notation_substitution ~flags fullscopes typ a) (fst pat)
             in
             insert_pat_coercion appcoercion
               (insert_pat_delimiters ?loc
                  (apply_pat_notation
                     (insert_pat_coercion coercion
-                       (make_pat_notation ?loc specific_ntn (l,ll,bl)))
+                       (make_pat_notation ?loc specific_ntn subst))
                     extra_args)
                  key)
       end
@@ -385,12 +379,13 @@ and apply_notation_to_pattern ?loc ~flags gr ((terms,termlists,binders),(no_impl
       | None -> raise No_match
       | Some coercion ->
       let qid = Nametab.shortest_qualid_of_abbreviation ?loc vars kn in
-      let l1 =
-        List.rev_map (fun (c,(subentry,(scopt,scl))) ->
-          extern_cases_pattern_in_scope ~flags ((subentry,lev_after),(scopt,scl@scopes)) vars c)
-          terms in
-      assert (List.is_empty termlists);
-      assert (List.is_empty binders);
+      let fullscopes = (constr_lowest_level,lev_after,false,scopes,vars) in
+      let subst =
+        List.map (fun (id,typ) ->
+            let arg = try Id.Map.find id subst with Not_found -> raise No_match in
+            extern_cases_pattern_notation_substitution ~flags fullscopes typ arg) (fst pat)
+      in
+      let l1 = List.map (function NtnTypeArg (NtnTypeArgPattern (c,bk)) -> c | _ -> assert false) subst in
       insert_pat_coercion ?loc coercion (CAst.make ?loc @@ CPatCstr (qid,None,List.rev_append l1 extra_args))
 
 and extern_notation_pattern ~flags allscopes vars t = function
@@ -409,6 +404,23 @@ and extern_notation_pattern ~flags allscopes vars t = function
         | PatVar (Name id) -> CAst.make ?loc @@ CPatAtom (Some (qualid_of_ident ?loc id))
     with
         No_match -> extern_notation_pattern ~flags allscopes vars t rules
+
+and extern_cases_pattern_notation_substitution_arg ~flags (entry,lev_after,closed,scopes',vars) subscopes typ arg =
+  let scopes = update_with_subscope ~flags entry subscopes lev_after closed scopes' in
+  let open Notation_term in
+  match typ, arg with
+  | (NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern | NtnTypeVarPattern _), NtnTypeArgPattern c ->
+    NtnTypeArg (NtnTypeArgPattern (extern_cases_pattern_in_scope ~flags scopes vars c, Explicit))
+  | NtnTypeVarBinders _, NtnTypeArgBinders _ -> anomaly (Pp.str "Unexpected binders in pattern notation.")
+  | (NtnTypeVarConstr _ | NtnTypeVarPattern _ | NtnTypeVarBinders _), _ -> assert false (* ill-typed *)
+
+and extern_cases_pattern_notation_substitution ~flags fullscopes typ arg =
+  let open Notation_term in
+  match typ, arg with
+  | NtnTypeVar ((scopes, _), typ), NtnTypeArg c -> extern_cases_pattern_notation_substitution_arg ~flags fullscopes scopes typ c
+  | NtnTypeVarList typ, NtnTypeArgList l -> NtnTypeArgList (List.map (extern_cases_pattern_notation_substitution ~flags fullscopes typ) l)
+  | NtnTypeVarTuple typl, NtnTypeArgTuple l -> NtnTypeArgTuple (List.map2 (extern_cases_pattern_notation_substitution ~flags fullscopes) typl l)
+  | (NtnTypeVar _ | NtnTypeVarList _ | NtnTypeVarTuple _), _ -> assert false (* ill-typed *)
 
 let rec extern_notation_ind_pattern ~flags allscopes vars ind args = function
   | [] -> raise No_match
@@ -734,6 +746,21 @@ let extended_glob_local_binder_of_decl loc = function
     | _ -> GLocalDef (p,r,x,Some t)
 
 let extended_glob_local_binder_of_decl ?loc u = DAst.make ?loc (extended_glob_local_binder_of_decl loc u)
+
+let glob_constr_of_local_binder_expr pat =
+  match DAst.get pat with
+  | GLocalPattern ((disjpat,_),_,_,_) ->
+    List.map (glob_constr_of_cases_pattern (Global.env())) disjpat
+  | GLocalAssum (Anonymous,_,bk,t) ->
+    let hole = DAst.make (GHole (GBinderType Anonymous)) in
+    [DAst.make (GCast (hole, Some DEFAULTcast, t))]
+  | GLocalAssum (Name id,_,bk,t) ->
+    [DAst.make (GCast (DAst.make (GVar id), Some DEFAULTcast, t))]
+  | GLocalDef _ -> raise No_match
+
+let glob_constr_of_disjunctive_cases_pattern = function
+  | [pat] -> glob_constr_of_cases_pattern (Global.env()) pat
+  | _ -> raise No_match
 
 (**********************************************************************)
 (* mapping special floats                                             *)
@@ -1225,7 +1252,7 @@ and extern_notation depth inctx ((custom,(lev_after: int option)),scopes as alls
             end
           | AppBoundedNotation _ -> raise No_match in
         (* Try matching ... *)
-        let terms,termlists,binders,binderlists =
+        let subst =
           match_notation_constr
             ~print_parentheses:eenv.flags.parentheses
             ~factorize_eqns:eenv.flags.factorize_eqns
@@ -1243,50 +1270,30 @@ and extern_notation depth inctx ((custom,(lev_after: int option)),scopes as alls
             let entry = fst (Notation.level_of_notation ntn) in
             let non_included = overlap_right_left entry lev_after pat in
             let coercion, appcoercion = find_entry_coercion_with_application ~non_included custom entry (is_empty_extra_args extra_args) in
+            let closed = not (List.is_empty coercion) in
             (match availability_of_notation specific_ntn scopes with
                   (* Uninterpretation is not allowed in current context *)
               | None -> raise No_match
                   (* Uninterpretation is allowed in current context *)
               | Some (scopt,key) ->
-                  let closed = not (List.is_empty coercion) in
                   let scopes' = Option.List.cons scopt (snd scopes) in
-                  let l =
-                    List.map (fun ((vars,c),subscope) ->
-                      let scopes = update_with_subscope ~flags:eenv.flags entry subscope lev_after closed scopes' in
-                      extern depth (* assuming no overloading: *) true scopes { eenv with vars} c)
-                      terms
+                  let fullscopes = (entry,lev_after,closed,scopes',eenv) in
+                  let subst =
+                    List.map (fun (id,typ) ->
+                        let a = try Id.Map.find id subst with Not_found -> raise No_match in
+                        extern_notation_substitution depth fullscopes typ a) (fst pat)
                   in
-                  let ll =
-                    List.map (fun ((vars,l),subscope) ->
-                      let scopes = update_with_subscope ~flags:eenv.flags entry subscope lev_after closed scopes' in
-                      List.map (extern depth true scopes { eenv with vars }) l)
-                      termlists
-                  in
-                  let bl =
-                    List.map (fun ((vars,bl),subscope) ->
-                      let scopes = update_with_subscope ~flags:eenv.flags entry subscope lev_after closed scopes' in
-                      (mkCPatOr
-                         (List.map
-                            (extern_cases_pattern_in_scope ~flags:eenv.flags scopes vars) bl)),
-                        Explicit)
-                      binders
-                  in
-                  let bll =
-                    List.map (fun ((vars,bl),subscope) ->
-                      let scopes = update_with_subscope ~flags:eenv.flags entry subscope lev_after closed scopes' in
-                      pi3 (extern_local_binder depth scopes { eenv with vars } bl))
-                      binderlists
-                  in
-                  let c = make_notation loc specific_ntn (l,ll,bl,bll) in
+                  let c = make_notation loc specific_ntn subst in
                   let c = insert_entry_coercion coercion (insert_delimiters c key) in
                   insert_entry_coercion appcoercion (CAst.make ?loc @@ extern_applied_notation c extra_args))
           | AbbrevRule kn ->
-              let l =
-                List.map (fun ((vars,c),subscope) ->
-                    let scopes = update_with_subscope ~flags:eenv.flags constr_lowest_level subscope lev_after false (snd scopes) in
-                  extern depth true scopes { eenv with vars } c)
-                  terms
+              let fullscopes = (constr_lowest_level,lev_after,false,snd scopes,eenv) in
+              let subst =
+                List.map (fun (id,typ) ->
+                    let a = try Id.Map.find id subst with Not_found -> raise No_match in
+                    extern_notation_substitution depth fullscopes typ a) (fst pat)
               in
+              let l = List.map (function NtnTypeArg (NtnTypeArgConstr c) -> c | _ -> assert false) subst in
               let cf = Nametab.shortest_qualid_of_abbreviation ?loc eenv.vars kn in
               let a = CRef (cf,None) in
               let c = CAst.make ?loc @@ extern_applied_abbreviation (a,cf) l extra_args in
@@ -1296,6 +1303,39 @@ and extern_notation depth inctx ((custom,(lev_after: int option)),scopes as alls
                 | Some coercion -> insert_entry_coercion coercion c
       with
           No_match -> extern_notation depth inctx allscopes eenv t rules
+
+and extern_notation_substitution_arg depth (entry,lev_after,closed,scopes',eenv) subscopes typ arg =
+  (* From interpretation types to parsing types *)
+  let scopes = update_with_subscope ~flags:eenv.flags entry subscopes lev_after closed scopes' in
+  let open Notation_term in
+  match typ, arg with
+  | NtnTypeVarConstr _, NtnTypeArgConstr (vars,_,c) ->
+    NtnTypeArg (NtnTypeArgConstr (extern (* assuming no overloading: *) depth true scopes { eenv with vars } c))
+  | NtnTypeVarPattern k, NtnTypeArgPattern (vars,_,patl) ->
+    let b = match k with
+     | NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _ ->
+       NtnTypeArgPattern (mkCPatOr (List.map (extern_cases_pattern_in_scope ~flags:eenv.flags scopes vars) patl), Explicit)
+     | NtnBinderParsedAsConstr _ ->
+       let c = glob_constr_of_disjunctive_cases_pattern patl in
+       NtnTypeArgConstr (extern depth true scopes { eenv with vars } c)
+    in
+    NtnTypeArg b
+  | NtnTypeVarBinders k, NtnTypeArgBinders (vars,_,bl) ->
+    (match k with
+      | NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _ ->
+        NtnTypeArg (NtnTypeArgBinders (pi3 (extern_local_binder depth scopes { eenv with vars } bl)))
+      | NtnBinderParsedAsConstr _ ->
+        let l = List.map_append glob_constr_of_local_binder_expr bl in
+        NtnTypeArgList (List.map (fun c -> NtnTypeArg (NtnTypeArgConstr (extern depth true scopes { eenv with vars } c))) l))
+  | (NtnTypeVarConstr _ | NtnTypeVarPattern _ | NtnTypeVarBinders _), _ -> assert false (* ill-typed *)
+
+and extern_notation_substitution depth fullscopes typ arg =
+  let open Notation_term in
+  match typ, arg with
+  | NtnTypeVar ((scopes, _), typ), NtnTypeArg c -> extern_notation_substitution_arg depth fullscopes scopes typ c
+  | NtnTypeVarList typ, NtnTypeArgList l -> NtnTypeArgList (List.map (extern_notation_substitution depth fullscopes typ) l)
+  | NtnTypeVarTuple typl, NtnTypeArgTuple l -> NtnTypeArgTuple (List.map2 (extern_notation_substitution depth fullscopes) typl l)
+  | (NtnTypeVar _ | NtnTypeVarList _ | NtnTypeVarTuple _), _ -> assert false (* ill-typed *)
 
 and extern_applied_proj depth inctx scopes eenv (cst,us) params c extraargs =
   let ref = GlobRef.ConstRef cst in

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -189,12 +189,12 @@ let destPrim = function { CAst.v = CPrim t } -> Some t | _ -> None
 let destPatPrim = function { CAst.v = CPatPrim t } -> Some t | _ -> None
 
 let parenthesis_notation ?loc subst =
-  CAst.make ?loc @@ CNotation (None,(InConstrEntry,"( _ )"),subst)
+  CAst.make ?loc @@ CNotation (None,mk_ntn_in_constr "( _ )",subst)
 let parenthesis_pat_notation ?loc subst =
-  CAst.make ?loc @@ CPatNotation (None,(InConstrEntry,"( _ )"),subst,[])
+  CAst.make ?loc @@ CPatNotation (None,mk_ntn_in_constr "( _ )",subst,[])
 
 let make_notation_gen loc ntn mknot mkprim destprim subst =
-  match snd ntn, subst with
+  match ntn.ntn_key, subst with
   | "- _", [NtnTypeArg x] ->
     (match x with
     (* Special case to avoid writing "- 3" for e.g. (Z.opp 3) *)

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1282,8 +1282,9 @@ and extern_notation depth inctx ((custom,(lev_after: int option)),scopes as alls
                   insert_entry_coercion appcoercion (CAst.make ?loc @@ extern_applied_notation c extra_args))
           | AbbrevRule kn ->
               let l =
-                List.map (fun ((vars,c),(subentry,(scopt,scl))) ->
-                  extern depth true ((subentry,lev_after),(scopt,scl@snd scopes)) { eenv with vars } c)
+                List.map (fun ((vars,c),subscope) ->
+                    let scopes = update_with_subscope ~flags:eenv.flags constr_lowest_level subscope lev_after false (snd scopes) in
+                  extern depth true scopes { eenv with vars } c)
                   terms
               in
               let cf = Nametab.shortest_qualid_of_abbreviation ?loc eenv.vars kn in

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -214,36 +214,36 @@ let expand_notation_string ntn n =
 (* This contracts the special case of "{ _ }" for sumbool, sumor notations *)
 (* Remark: expansion of squash at definition is done in metasyntax.ml *)
 let contract_curly_brackets ntn subst =
-  match ntn with
-  | InCustomEntry _,_ -> ntn, subst
-  | InConstrEntry, ntn ->
-  let ntn' = ref ntn in
+  match ntn.ntn_entry with
+  | InCustomEntry _ -> ntn, subst
+  | InConstrEntry ->
+  let ntn' = ref ntn.ntn_key in
   let rec contract_squash n = function
     | [] -> []
-    | NtnTypeArg (NtnTypeArgConstr { CAst.v = CNotation (None,(InConstrEntry,"{ _ }"),[NtnTypeArg (NtnTypeArgConstr a)]) }) :: l ->
+    | NtnTypeArg (NtnTypeArgConstr { CAst.v = CNotation (None,{ntn_entry = InConstrEntry; ntn_key = "{ _ }"},[NtnTypeArg (NtnTypeArgConstr a)]) }) :: l ->
         ntn' := expand_notation_string !ntn' n;
         contract_squash n (NtnTypeArg (NtnTypeArgConstr a)::l)
     | a :: l ->
         a::contract_squash (n+1) l in
   let subst = contract_squash 0 subst in
   (* side effect; don't inline *)
-  (InConstrEntry,!ntn'), subst
+  mk_ntn_in_constr !ntn', subst
 
 let contract_curly_brackets_pat ntn subst =
-  match ntn with
-  | InCustomEntry _,_ -> ntn, subst
-  | InConstrEntry, ntn ->
-  let ntn' = ref ntn in
+  match ntn.ntn_entry with
+  | InCustomEntry _ -> ntn, subst
+  | InConstrEntry ->
+  let ntn' = ref ntn.ntn_key in
   let rec contract_squash n = function
     | [] -> []
-    | NtnTypeArg (NtnTypeArgPattern ({ CAst.v = CPatNotation (None,(InConstrEntry,"{ _ }"),[NtnTypeArg (NtnTypeArgPattern a)],[]) }, Explicit)) :: l ->
+    | NtnTypeArg (NtnTypeArgPattern ({ CAst.v = CPatNotation (None,{ntn_entry = InConstrEntry; ntn_key = "{ _ }"},[NtnTypeArg (NtnTypeArgPattern a)],[]) }, Explicit)) :: l ->
         ntn' := expand_notation_string !ntn' n;
         contract_squash n (NtnTypeArg (NtnTypeArgPattern a)::l)
     | a :: l ->
         a :: contract_squash (n+1) l in
   let subst = contract_squash 0 subst in
   (* side effect; don't inline *)
-  (InConstrEntry,!ntn'), subst
+  mk_ntn_in_constr !ntn', subst
 
 type local_univs = { bound : UnivNames.universe_binders; unb_univs : bool }
 
@@ -1863,12 +1863,12 @@ let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
         | Some (g,pl) -> DAst.make ?loc @@ RCPatCstr (g, pl)
         | None -> Loc.raise ?loc (InternalizationError (NotAConstructor qid))
       end
-    | CPatNotation (_,(InConstrEntry,"- _"),[NtnTypeArg (NtnTypeArgPattern (a,Explicit))],[]) when is_non_zero_pat a ->
+    | CPatNotation (_,{ntn_entry = InConstrEntry; ntn_key = "- _"},[NtnTypeArg (NtnTypeArgPattern (a,Explicit))],[]) when is_non_zero_pat a ->
       let p = match a.CAst.v with CPatPrim (Number (_, p)) -> p | _ -> assert false in
       let pat, _df = Notation.interp_prim_token_cases_pattern_expr ?loc
           (check_allowed_ref_in_pat test_kind) (Number (SMinus,p)) scopes in
       rcp_of_glob scopes pat
-    | CPatNotation (_,(InConstrEntry,"( _ )"),[NtnTypeArg (NtnTypeArgPattern (a,Explicit))],[]) ->
+    | CPatNotation (_,{ntn_entry = InConstrEntry; ntn_key = "( _ )"},[NtnTypeArg (NtnTypeArgPattern (a,Explicit))],[]) ->
       in_pat test_kind scopes a
     | CPatNotation (_,ntn,fullargs,extrargs) ->
       let ntn, subst = contract_curly_brackets_pat ntn fullargs in
@@ -2250,10 +2250,10 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
         DAst.make ?loc @@
         GLetIn (na.CAst.v, None, inc1, int,
           intern_restart_binders (push_name_env ~dump:true ntnvars (impls_term_list 1 inc1) env na) c2)
-    | CNotation (_,(InConstrEntry,"- _"), [NtnTypeArg (NtnTypeArgConstr a)]) when is_non_zero a ->
+    | CNotation (_,{ntn_entry = InConstrEntry; ntn_key = "- _"}, [NtnTypeArg (NtnTypeArgConstr a)]) when is_non_zero a ->
       let p = match a.CAst.v with CPrim (Number (_, p)) -> p | _ -> assert false in
        intern env (CAst.make ?loc @@ CPrim (Number (SMinus,p)))
-    | CNotation (_,(InConstrEntry,"( _ )"),[NtnTypeArg (NtnTypeArgConstr a)]) -> intern env a
+    | CNotation (_,{ntn_entry = InConstrEntry; ntn_key = "( _ )"},[NtnTypeArg (NtnTypeArgConstr a)]) -> intern env a
     | CNotation (_,ntn,args) ->
         let c = intern_notation intern env ntnvars loc ntn args in
         apply_impargs env loc c []

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -262,6 +262,7 @@ type intern_env = {
   impls: internalization_env;
   binder_block_names: abstraction_kind option (* None = unknown *) option;
   ntn_binding_ids: Id.Set.t; (* subset of ids that are notation variables *)
+  only_in_constr: bool; (* for notations, tell that the current subterm is a constr even in notations for patterns *)
 }
 
 type pattern_intern_env = {
@@ -306,29 +307,31 @@ let error_expect_binder_notation_type ?loc id =
    (Id.print id ++
     str " is expected to occur in binding position in the right-hand side.")
 
-let set_notation_var_scope ?loc id (tmp_scope,subscopes as scopes) ntnbinders ntnvars =
+let set_notation_var_scope ?loc id {tmp_scope;scopes;ntn_binding_ids;only_in_constr} ntnvars =
   try
     let {Genintern.ntnvar_typ=typ} as status = Id.Map.find id ntnvars in
     match typ with
     | Notation_term.NtnInternTypeOnlyBinder -> error_expect_binder_notation_type ?loc id
     | Notation_term.NtnInternTypeAny principal ->
       let () = match status.ntnvar_scopes with
-      | None -> status.ntnvar_scopes <- Some scopes
+      | None -> status.ntnvar_scopes <- Some (tmp_scope, scopes)
       | Some (tmp_scope', subscopes') ->
         let s' = make_current_scope tmp_scope' subscopes' in
-        let s = make_current_scope tmp_scope subscopes in
+        let s = make_current_scope tmp_scope scopes in
         if Option.is_empty principal && not (List.equal String.equal s' s) then
-          warn_inconsistent_scope ?loc (id,s',s)
+          warn_inconsistent_scope ?loc (id,s',s);
+        ()
       in
       let () = match status.ntnvar_binding_ids with
-      | None -> status.ntnvar_binding_ids <- Some ntnbinders
-      | Some ntnbinders' -> status.ntnvar_binding_ids <- Some (Id.Set.inter ntnbinders ntnbinders')
+      | None -> status.ntnvar_binding_ids <- Some ntn_binding_ids
+      | Some ntnbinders' -> status.ntnvar_binding_ids <- Some (Id.Set.inter ntn_binding_ids ntnbinders')
       in
       let () = match status.ntnvar_used with
         | [] -> () (* not recording if notation var is used *)
         | true :: _ -> () (* already marked used *)
         | false :: rest -> status.ntnvar_used <- true :: rest
       in
+      let () = status.ntnvar_is_only_in_constr <- status.ntnvar_is_only_in_constr || only_in_constr in
       ()
  with Not_found ->
     (* Not in a notation *)
@@ -341,6 +344,8 @@ let set_var_is_binder ?loc id ntnvars =
   with Not_found ->
     (* Not in a notation *)
     ()
+
+let set_only_in_constr env = {env with only_in_constr = true}
 
 let set_type_scope env = {env with tmp_scope = Notation.current_type_scope_names ()}
 
@@ -617,7 +622,7 @@ let intern_letin_binder ~dump intern ntnvars env (({loc;v=na} as locna),def,ty) 
 
 let intern_cases_pattern_as_binder ~dump intern test_kind ntnvars env bk (CAst.{v=p;loc} as pv) =
   let p,t,tmp_scope = match p with
-  | CPatCast (p, t) -> (p, Some t, (* Redone later, not nice: *) Notation.compute_glob_type_scope (intern (set_type_scope env) t))
+  | CPatCast (p, t) -> (p, Some t, (* Redone later, not nice: *) Notation.compute_glob_type_scope (intern (set_type_scope (set_only_in_constr env)) t))
   | _ -> (pv, None, []) in
   let il,disjpat =
     let (il, subst_disjpat) = !intern_cases_pattern_fwd test_kind ntnvars (env_for_pattern {env with tmp_scope}) p in
@@ -1133,7 +1138,7 @@ let intern_var env (ltacvars,ntnvars) namedctx loc id us =
   (* Is [id] a notation variable *)
   if Id.Map.mem id ntnvars then
     begin
-      if not (Id.Map.mem id env.impls) then set_notation_var_scope ?loc id (env.tmp_scope,env.scopes) env.ntn_binding_ids ntnvars;
+      if not (Id.Map.mem id env.impls) then set_notation_var_scope ?loc id env ntnvars;
       gvar (loc,id) us
     end
   else
@@ -1475,7 +1480,8 @@ let interp_reference vars r =
       {ids = Id.Set.empty; strict_check = Some true;
        local_univs = empty_local_univs;(* <- doesn't matter here *)
        tmp_scope = []; scopes = []; impls = empty_internalization_env;
-       binder_block_names = None; ntn_binding_ids = Id.Set.empty}
+       binder_block_names = None; ntn_binding_ids = Id.Set.empty;
+       only_in_constr = false}
       Environ.empty_named_context_val
       (vars, Id.Map.empty) None [] r
   in r
@@ -2680,7 +2686,8 @@ let intern_gen kind env sigma
   internalize env {ids = extract_ids env; strict_check;
                    local_univs = { bound = bound_univs sigma; unb_univs = true };
                    tmp_scope = tmp_scope; scopes = [];
-                   impls; binder_block_names = Some k; ntn_binding_ids = Id.Set.empty}
+                   impls; binder_block_names = Some k; ntn_binding_ids = Id.Set.empty;
+                   only_in_constr = false}
     pattern_mode (ltacvars, Id.Map.empty) c
 
 let intern_unknown_if_term_or_type env sigma c =
@@ -2775,7 +2782,8 @@ let intern_core kind env sigma ?strict_check ?(pattern_mode=false) ?(ltacvars=em
     {ids; strict_check;
      local_univs = { bound = bound_univs sigma; unb_univs = true };
      tmp_scope; scopes = []; impls;
-     binder_block_names = Some (Some k); ntn_binding_ids = Id.Set.empty}
+     binder_block_names = Some (Some k); ntn_binding_ids = Id.Set.empty;
+     only_in_constr = false}
     pattern_mode (ltacvars, vl) c
 
 let interp_notation_constr env ?(impls=empty_internalization_env) nenv a =
@@ -2786,6 +2794,7 @@ let interp_notation_constr env ?(impls=empty_internalization_env) nenv a =
     ntnvar_used_as_binder = false;
     ntnvar_scopes = scopes;
     ntnvar_binding_ids = None;
+    ntnvar_is_only_in_constr = false;
     ntnvar_typ = typ;
   }
   in
@@ -2797,7 +2806,8 @@ let interp_notation_constr env ?(impls=empty_internalization_env) nenv a =
   let c = internalize env
       {ids; strict_check = Some true;
        local_univs = empty_local_univs;
-       tmp_scope = []; scopes = []; impls; binder_block_names = None; ntn_binding_ids = Id.Set.empty}
+       tmp_scope = []; scopes = []; impls; binder_block_names = None; ntn_binding_ids = Id.Set.empty;
+       only_in_constr = false}
       false (empty_ltac_sign, vl) a
   in
   (* Splits variables into those that are binding, bound, or both *)
@@ -2808,8 +2818,12 @@ let interp_notation_constr env ?(impls=empty_internalization_env) nenv a =
   let out_bindings = function None -> Id.Set.empty | Some a -> a in
   let unused = match reversible with NonInjective ids -> ids | _ -> [] in
   let vars = Id.Map.mapi (fun id status ->
-      (status.Genintern.ntnvar_used_as_binder && not (List.mem_f Id.equal id unused),
-       out_scope status.ntnvar_scopes, out_bindings status.ntnvar_binding_ids)) vl in
+      status.Genintern.ntnvar_used_as_binder && not (List.mem_f Id.equal id unused),
+      out_scope status.ntnvar_scopes,
+      out_bindings status.ntnvar_binding_ids,
+      status.ntnvar_is_only_in_constr)
+      vl
+  in
   (* Returns [a] and the ordered list of variables with their scopes *)
   vars, a, reversible
 
@@ -2833,7 +2847,8 @@ let default_internalization_env ids bound_univs impl_env =
    local_univs = { bound = bound_univs; unb_univs = true };
    tmp_scope = []; scopes = []; impls = impl_env;
    binder_block_names = Some (Some AbsPi);
-   ntn_binding_ids = Id.Set.empty}
+   ntn_binding_ids = Id.Set.empty;
+   only_in_constr = false}
 
 let intern_context env ~bound_univs impl_env binders =
   let lvar = (empty_ltac_sign, Id.Map.empty) in

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -213,37 +213,37 @@ let expand_notation_string ntn n =
 
 (* This contracts the special case of "{ _ }" for sumbool, sumor notations *)
 (* Remark: expansion of squash at definition is done in metasyntax.ml *)
-let contract_curly_brackets ntn (l,ll,bl,bll) =
+let contract_curly_brackets ntn subst =
   match ntn with
-  | InCustomEntry _,_ -> ntn,(l,ll,bl,bll)
+  | InCustomEntry _,_ -> ntn, subst
   | InConstrEntry, ntn ->
   let ntn' = ref ntn in
   let rec contract_squash n = function
     | [] -> []
-    | { CAst.v = CNotation (None,(InConstrEntry,"{ _ }"),([a],[],[],[])) } :: l ->
+    | NtnTypeArg (NtnTypeArgConstr { CAst.v = CNotation (None,(InConstrEntry,"{ _ }"),[NtnTypeArg (NtnTypeArgConstr a)]) }) :: l ->
         ntn' := expand_notation_string !ntn' n;
-        contract_squash n (a::l)
+        contract_squash n (NtnTypeArg (NtnTypeArgConstr a)::l)
     | a :: l ->
         a::contract_squash (n+1) l in
-  let l = contract_squash 0 l in
+  let subst = contract_squash 0 subst in
   (* side effect; don't inline *)
-  (InConstrEntry,!ntn'),(l,ll,bl,bll)
+  (InConstrEntry,!ntn'), subst
 
-let contract_curly_brackets_pat ntn (l,ll,bl) =
+let contract_curly_brackets_pat ntn subst =
   match ntn with
-  | InCustomEntry _,_ -> ntn,(l,ll,bl)
+  | InCustomEntry _,_ -> ntn, subst
   | InConstrEntry, ntn ->
   let ntn' = ref ntn in
   let rec contract_squash n = function
     | [] -> []
-    | { CAst.v = CPatNotation (None,(InConstrEntry,"{ _ }"),([a],[],[]),[]) } :: l ->
+    | NtnTypeArg (NtnTypeArgPattern ({ CAst.v = CPatNotation (None,(InConstrEntry,"{ _ }"),[NtnTypeArg (NtnTypeArgPattern a)],[]) }, Explicit)) :: l ->
         ntn' := expand_notation_string !ntn' n;
-        contract_squash n (a::l)
+        contract_squash n (NtnTypeArg (NtnTypeArgPattern a)::l)
     | a :: l ->
-        a::contract_squash (n+1) l in
-  let l = contract_squash 0 l in
+        a :: contract_squash (n+1) l in
+  let subst = contract_squash 0 subst in
   (* side effect; don't inline *)
-  (InConstrEntry,!ntn'),(l,ll,bl)
+  (InConstrEntry,!ntn'), subst
 
 type local_univs = { bound : UnivNames.universe_binders; unb_univs : bool }
 
@@ -712,18 +712,24 @@ let option_mem_assoc id = function
   | Some (id',c) -> Id.equal id id'
   | None -> false
 
-let find_fresh_name renaming (terms,termlists,binders,binderlists) avoid id =
-  let fold1 _ (c, _) accu = Id.Set.union (free_vars_of_constr_expr c) accu in
-  let fold2 _ (l, _) accu =
-    let fold accu c = Id.Set.union (free_vars_of_constr_expr c) accu in
-    List.fold_left fold accu l
-  in
-  let fold3 _ x accu = Id.Set.add x accu in
-  let fvs1 = Id.Map.fold fold1 terms avoid in
-  let fvs2 = Id.Map.fold fold2 termlists fvs1 in
-  let fvs3 = Id.Map.fold fold3 renaming fvs2 in
+let find_fresh_name renaming subst avoid id =
+  let fold_atom a accu =
+    let ids = match a with
+    | NtnTypeArgConstr c -> free_vars_of_constr_expr c
+    | NtnTypeArgPattern (c,bk) -> free_vars_of_cases_pattern_expr c
+    | NtnTypeArgBinders bl -> free_vars_of_local_binders bl in
+    Id.Set.union ids accu in
+  let rec fold_arg a accu =
+    match a with
+    | NtnTypeArg a -> fold_atom a accu
+    | NtnTypeArgList l -> List.fold_right fold_arg l accu
+    | NtnTypeArgTuple l -> List.fold_right fold_arg l accu in
+  let fold _ (a,_) accu = fold_arg a accu in
+  let fold_renaming _ x accu = Id.Set.add x accu in
+  let fvs1 = Id.Map.fold fold subst avoid in
+  let fvs2 = Id.Map.fold fold_renaming renaming fvs1 in
   (* TODO binders *)
-  next_ident_away_from id (fun id -> Id.Set.mem id fvs3)
+  next_ident_away_from id (fun id -> Id.Set.mem id fvs2)
 
 let is_patvar c =
   match DAst.get c with
@@ -774,21 +780,79 @@ let extract_pattern_from_binder b =
     let pat, na = cook_pattern (patl, id) in
     pat, na, bk, ty
 
-let traverse_binder intern_pat ntnvars (terms,_,binders,_ as subst) binderopt avoid (renaming,env) na ty =
+let check_explicit = function
+  | Explicit -> ()
+  | MaxImplicit | NonMaxImplicit -> user_err (str "Implicit arguments not supported.") (* shouldn't arrive *)
+
+let is_onlyident = function
+  | AsIdent | AsName -> true
+  | AsAnyPattern | AsStrictPattern -> false
+
+let only_ntn_binder_kind = function
+  | NtnBinderParsedAsConstr k -> is_onlyident k
+  | NtnBinderParsedAsBinder -> false
+  | NtnBinderParsedAsSomeBinderKind k -> is_onlyident k
+
+let cases_pattern_of_id {loc;v=id} =
+  CAst.make ?loc (CPatAtom (Some (qualid_of_ident ?loc id)))
+
+let cases_pattern_of_name {loc;v=na} =
+  let atom = match na with Name id -> Some (qualid_of_ident ?loc id) | Anonymous -> None in
+  CAst.make ?loc (CPatAtom atom)
+
+let cases_pattern_of_binder_as_constr a = function
+  | AsAnyPattern | AsStrictPattern -> coerce_to_cases_pattern_expr a
+  | AsIdent -> cases_pattern_of_id (coerce_to_id a)
+  | AsName -> cases_pattern_of_name (coerce_to_name a)
+
+let get_list f = function
+  | NtnTypeArgList l, NtnTypeVarList t -> List.map (fun a -> f (a,t)) l
+  | _ -> raise Not_found
+
+let get_term_opt = function
+  | NtnTypeArg (NtnTypeArgConstr c), NtnTypeVar (scopes, NtnTypeVarConstr _) -> Some (c, scopes)
+  | _ -> None
+
+let get_term v = match get_term_opt v with None -> raise Not_found | Some v -> v
+
+let get_pattern = function
+  | NtnTypeArg (NtnTypeArgPattern (c, bk)), NtnTypeVar (scopes, (NtnTypeVarPattern _ | NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern)) ->
+    check_explicit bk; (c : cases_pattern_expr), scopes
+  | _ -> raise Not_found
+
+let get_binder_opt = function
+  | NtnTypeArg (NtnTypeArgPattern (c, bk)),
+    NtnTypeVar (scopes, NtnTypeVarPattern (NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _ as k)) ->
+    Some ((c, bk), (only_ntn_binder_kind k, scopes))
+  | NtnTypeArg (NtnTypeArgConstr c), NtnTypeVar (scopes, NtnTypeVarPattern NtnBinderParsedAsConstr k) ->
+    Some ((cases_pattern_of_binder_as_constr c k, Explicit), (is_onlyident k, scopes))
+  | _ -> None
+
+let get_binder v = match get_binder_opt v with None -> raise Not_found | Some v -> v
+
+let get_binders = function
+  | NtnTypeArg (NtnTypeArgBinders bl), NtnTypeVar (scopes, NtnTypeVarBinders k) -> bl, scopes
+  | NtnTypeArgList l, NtnTypeVar (scopes, NtnTypeVarBinders (NtnBinderParsedAsConstr k)) ->
+    let bl = List.map (function NtnTypeArg (NtnTypeArgConstr a) -> CLocalPattern (cases_pattern_of_binder_as_constr a k)
+      | _ -> anomaly (str "Ill-typed notation variable.")) l in
+    bl, scopes
+  | _ -> raise Not_found
+
+let traverse_binder intern_pat ntnvars subst binderopt avoid (renaming,env) na ty =
   match na with
   | Anonymous -> (renaming,env), None, Anonymous, Explicit, set_type ty None
   | Name id ->
   let test_kind = test_kind_tolerant in
   try
     (* We instantiate binder name with patterns which may be parsed as terms *)
-    let pat = coerce_to_cases_pattern_expr (fst (Id.Map.find id terms)) in
+    let pat = coerce_to_cases_pattern_expr (fst (get_term (Id.Map.find id subst))) in
     let env,pat,bk,t = intern_pat test_kind ntnvars env Explicit pat in
     let pat, na = cook_pattern pat in
     (renaming,env), pat, na, bk, set_type ty (Some t)
   with Not_found ->
   try
     (* Trying to associate a pattern *)
-    let (pat,bk),(onlyident,scopes) = Id.Map.find id binders in
+    let (pat,bk),(onlyident,((_,scopes),ntn_binding_ids)) = get_binder (Id.Map.find id subst) in
     let env = set_env_scopes env scopes in
     if onlyident then
       (* Do not try to interpret a variable as a constructor *)
@@ -815,7 +879,7 @@ let traverse_binder intern_pat ntnvars (terms,_,binders,_ as subst) binderopt av
 
 type binder_action =
   | AddLetIn of lname * constr_expr * constr_expr option
-  | AddTermIter of (constr_expr * subscopes) Names.Id.Map.t
+  | AddTermIter of (notation_arg_type_expr * notation_var_type) Names.Id.Map.t
   | AddPreBinderIter of Id.t * local_binder_expr (* A binder to be internalized *)
   | AddBinderIter of Id.t * extended_glob_local_binder (* A binder already internalized - used for generalized binders *)
   | AddNList (* Insert a ".. term .." block *)
@@ -842,11 +906,11 @@ let terms_of_binders bl =
     | bnd :: l ->
       let loc = bnd.loc in
       begin match DAst.get bnd with
-      | GLocalAssum (Name id,_,_,_) -> (CAst.make ?loc @@ CRef (qualid_of_ident ?loc id, None)) :: extract_variables l
+      | GLocalAssum (Name id,_,_,_) -> (CAst.make ?loc @@ CRef (qualid_of_ident ?loc id, None), dummy_subscopes) :: extract_variables l
       | GLocalDef (Name id,_,_,_) -> extract_variables l
       | GLocalDef (Anonymous,_,_,_)
       | GLocalAssum (Anonymous,_,_,_) -> user_err Pp.(str "Cannot turn \"_\" into a term.")
-      | GLocalPattern (([u],_),_,_,_) -> term_of_pat u :: extract_variables l
+      | GLocalPattern (([u],_),_,_,_) -> (term_of_pat u,dummy_subscopes) :: extract_variables l
       | GLocalPattern ((_,_),_,_,_) -> error_cannot_coerce_disjunctive_pattern_term ?loc ()
       end
     | [] -> [] in
@@ -882,15 +946,15 @@ let rec adjust_env env = function
   | NRec _ | NSort _ | NProj _ | NInt _ | NFloat _ | NString _ | NArray _
   | NList _ | NBinderList _ -> env (* to be safe, but restart should be ok *)
 
-let subst_var loc intern_pat intern ntnvars binders (terms, binderopt, _terminopt) (renaming, env) id =
+let subst_var loc intern_pat intern ntnvars subst (terms, binderopt, _terminopt) (renaming, env) id =
   (* subst remembers the delimiters stack in the interpretation *)
   (* of the notations *)
   try
-    let (a,scopes) = Id.Map.find id terms in
+    let (a,((_,scopes),_)) = get_term (Id.Map.find id terms) in
     intern (set_env_scopes env scopes) a
   with Not_found ->
   try
-    let (pat,bk),(onlyident,scopes) = Id.Map.find id binders in
+    let (pat,bk),(onlyident,((_,scopes),_)) = get_binder (Id.Map.find id subst) in
     let env = set_env_scopes env scopes in
     let test_kind =
       if onlyident then test_kind_ident_in_notation
@@ -906,7 +970,7 @@ let subst_var loc intern_pat intern ntnvars binders (terms, binderopt, _terminop
     | Some (x,binder) when Id.equal x id ->
       let terms = terms_of_binders [binder] in
       assert (List.length terms = 1);
-      intern env (List.hd terms)
+      intern env (fst (List.hd terms))
     | _ -> raise Not_found
   with Not_found ->
     DAst.make ?loc (
@@ -917,7 +981,6 @@ let subst_var loc intern_pat intern ntnvars binders (terms, binderopt, _terminop
         GVar id)
 
 let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
-  let (terms,termlists,binders,binderlists) = subst in
   (* when called while defining a notation, avoid capturing the private binders
      of the expression by variables bound by the notation (see #3892) *)
   let avoid = Id.Map.domain ntnvars in
@@ -946,31 +1009,31 @@ let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
            DAst.make ?loc (GApp (DAst.make ?loc (GVar ldots_var), [aux_letin env (rest,terminator,iter)]))
         in
         aux_letin env (Option.get iteropt)
-    | NVar id -> subst_var loc intern_pat intern ntnvars binders subst' (renaming, env) id
+    | NVar id -> subst_var loc intern_pat intern ntnvars subst subst' (renaming, env) id
     | NList (x,y,iter,terminator,revert) ->
-      let l,(scopt,subscopes) =
+      let l =
         (* All elements of the list are in scopes (scopt,subscopes) *)
         try
-          let l,scopes = Id.Map.find x termlists in
-          (if revert then List.rev l else l),scopes
+          let l = get_list get_term (Id.Map.find x subst) in
+          if revert then List.rev l else l
         with Not_found ->
         try
-          let (bl,(scopt,subscopes)) = Id.Map.find x binderlists in
+          let (bl,(scopt,subscopes)) = get_binders (Id.Map.find x subst) in
           let env,bl' = List.fold_left (intern_local_binder_aux ~dump:true intern ntnvars) (env,[]) bl in
-          terms_of_binders (if revert then bl' else List.rev bl'),([],[])
+          terms_of_binders (if revert then bl' else List.rev bl')
         with Not_found ->
-          anomaly (Pp.str "Inconsistent substitution of recursive notation.") in
-      let select_iter a =
+          anomaly (Pp.str "Inconsistent substitution of recursive notation2.") in
+      let select_iter (a,scopes) =
         match a.CAst.v with
         | CRef (qid,None) when qualid_is_ident qid && Id.equal (qualid_basename qid) ldots_var -> AddNList
-        | _ -> AddTermIter (Id.Map.add y (a,(scopt,subscopes)) terms) in
+        | _ -> AddTermIter (Id.Map.add y (NtnTypeArg (NtnTypeArgConstr a), NtnTypeVar (scopes,NtnTypeVarConstr (* Does not natter: *) NtnConstrForConstrAndPatternForPattern)) subst) in
       let l = List.map select_iter l in
       aux (terms,None,Some (l,terminator,iter)) subinfos (NVar ldots_var)
     | NHole (knd) ->
       let knd = match knd with
       | GBinderType (Name id as na) ->
         let na =
-          try (coerce_to_name (fst (Id.Map.find id terms))).v
+          try (coerce_to_name (fst (get_term (Id.Map.find id terms)))).v
           with Not_found ->
           try Name (Id.Map.find id renaming)
           with Not_found -> na
@@ -980,12 +1043,12 @@ let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
       in
       DAst.make ?loc @@ GHole (knd)
     | NGenarg arg ->
-      let glob_of_term (c, scopes) =
+      let glob_of_term (c, ((_,scopes),_)) =
         let nenv = set_env_scopes env scopes in
         let gc = intern nenv c in
         gc
       in
-      let glob_of_binder ((c,_bk), (onlyident,(tmp_scope,subscopes))) =
+      let glob_of_binder ((c,_bk), (onlyident,((_,(tmp_scope,subscopes)),_))) =
         let nenv = {env with tmp_scope; scopes = subscopes @ env.scopes} in
         let test_kind =
           if onlyident then test_kind_ident_in_notation
@@ -997,18 +1060,21 @@ let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
         | _ -> error_cannot_coerce_disjunctive_pattern_term ?loc:c.loc ()
       in
       let get_glob id =
-        match Id.Map.find_opt id terms with
-        | Some term -> Some (glob_of_term term)
-        | None -> match Id.Map.find_opt id binders with
-          | Some binder -> Some (glob_of_binder binder)
-          | None -> None
+        match Id.Map.find_opt id subst with
+        | None -> None
+        | Some a ->
+          match get_term_opt a with
+          | Some v -> Some (glob_of_term v)
+          | None -> match get_binder_opt a with
+            | Some v -> Some (glob_of_binder v)
+            | None -> None
       in
       let arg = Genintern.generic_substitute_notation ntnvars get_glob arg in
       DAst.make ?loc @@ GGenarg arg
     | NBinderList (x,y,iter,terminator,revert) ->
       (try
         (* All elements of the list are in scopes (scopt,subscopes) *)
-        let (bl,(scopt,subscopes)) = Id.Map.find x binderlists in
+        let (bl,(scopt,subscopes)) = get_binders (Id.Map.find x subst) in
         (* We flatten binders so that we can interpret them at substitution time *)
         let bl = flatten_binders bl in
         let bl = if revert then List.rev bl else bl in
@@ -1028,100 +1094,14 @@ let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
     | t ->
       glob_constr_of_notation_constr_with_binders ?loc
         (traverse_binder intern_pat ntnvars subst binderopt avoid) (aux subst') ~h:binder_status_fun subinfos t
-  in aux (terms,None,None) infos c
+  in aux (subst,None,None) infos c
 
 (* Turning substitution coming from parsing and based on production
    into a substitution for interpretation and based on binding/constr
    distinction *)
 
-let cases_pattern_of_id {loc;v=id} =
-  CAst.make ?loc (CPatAtom (Some (qualid_of_ident ?loc id)))
-
-let cases_pattern_of_name {loc;v=na} =
-  let atom = match na with Name id -> Some (qualid_of_ident ?loc id) | Anonymous -> None in
-  CAst.make ?loc (CPatAtom atom)
-
-let cases_pattern_of_binder_as_constr a = function
-  | AsAnyPattern | AsStrictPattern -> coerce_to_cases_pattern_expr a
-  | AsIdent -> cases_pattern_of_id (coerce_to_id a)
-  | AsName -> cases_pattern_of_name (coerce_to_name a)
-
-let is_onlyident = function
-  | AsIdent | AsName -> true
-  | AsAnyPattern | AsStrictPattern -> false
-
-let split_by_type ids (subst : constr_notation_substitution) =
-  let bind id scl l s =
-    match l with
-    | [] -> assert false
-    | a::l -> l, Id.Map.add id (a,scl) s in
-  let (terms,termlists,binders,binderlists),subst =
-    List.fold_left (fun ((terms,termlists,binders,binderlists),(terms',termlists',binders',binderlists')) (id,((_,scl),_,typ)) ->
-    match typ with
-    | NtnTypeConstr ->
-       let terms,terms' = bind id scl terms terms' in
-       (terms,termlists,binders,binderlists),(terms',termlists',binders',binderlists')
-    | NtnTypeBinder ntn_binder_kind ->
-       let onlyident,a,terms,binders =
-         match ntn_binder_kind with
-         | NtnBinderParsedAsConstr k ->
-           let a,terms = List.sep_first terms in
-           is_onlyident k, (cases_pattern_of_binder_as_constr a k, Explicit), terms, binders
-         | NtnBinderParsedAsBinder ->
-           let a,binders = List.sep_first binders in
-           false, a, terms, binders
-         | NtnBinderParsedAsSomeBinderKind k ->
-           let a,binders = List.sep_first binders in
-           is_onlyident k, a, terms, binders
-       in
-       let binders' = Id.Map.add id (a,(onlyident,scl)) binders' in
-       (terms,termlists,binders,binderlists),(terms',termlists',binders',binderlists')
-    | NtnTypeConstrList ->
-       let termlists,termlists' = bind id scl termlists termlists' in
-       (terms,termlists,binders,binderlists),(terms',termlists',binders',binderlists')
-    | NtnTypeBinderList ntn_binder_kind ->
-       let l,termlists,binderlists =
-         match ntn_binder_kind with
-         | NtnBinderParsedAsConstr k ->
-           let l,termlists = List.sep_first termlists in
-           List.map (fun a -> CLocalPattern (cases_pattern_of_binder_as_constr a k)) l, termlists, binderlists
-         | NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _ ->
-           let l,binderlists = List.sep_first binderlists in
-           l, termlists, binderlists
-       in
-       let binderlists' = Id.Map.add id (l,scl) binderlists' in
-       (terms,termlists,binders,binderlists),(terms',termlists',binders',binderlists'))
-                   (subst,(Id.Map.empty,Id.Map.empty,Id.Map.empty,Id.Map.empty)) ids in
-  assert (terms = [] && termlists = [] && binders = [] && binderlists = []);
-  subst
-
-let split_by_type_pat ?loc ids subst =
-  let bind id (_,scopes) l s =
-    match l with
-    | [] -> assert false
-    | a::l -> l, Id.Map.add id (a,scopes) s in
-  let bind_binders id (_,scopes) l s =
-    match l with
-    | [] -> assert false
-    | (a,Explicit)::l -> l, Id.Map.add id (a,scopes) s
-    | (a,(MaxImplicit|NonMaxImplicit))::l -> user_err (str "Implicit arguments not supported.") (* shouldn't arrive *)
-  in
-  let (terms,termlists,binders),subst =
-    List.fold_left (fun ((terms,termlists,binders),(terms',termlists')) (id,(scl,_,typ)) ->
-    match typ with
-    | NtnTypeConstr | NtnTypeBinder (NtnBinderParsedAsConstr _) ->
-       let terms,terms' = bind id scl terms terms' in
-       (terms,termlists,binders),(terms',termlists')
-    | NtnTypeConstrList ->
-       let termlists,termlists' = bind id scl termlists termlists' in
-       (terms,termlists,binders),(terms',termlists')
-    | NtnTypeBinder (NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _) ->
-       let binders,terms' = bind_binders id scl binders terms' in
-       (terms,termlists,binders),(terms',termlists')
-    | NtnTypeBinderList _ -> error_invalid_pattern_notation ?loc ())
-                   (subst,(Id.Map.empty,Id.Map.empty)) ids in
-  assert (terms = [] && termlists = [] && binders = []);
-  subst
+let split_by_type ids subst =
+  List.fold_left2 (fun subst (id,typ) arg -> Id.Map.add id (arg,typ) subst) Id.Map.empty ids subst
 
 let intern_notation intern env ntnvars loc ntn fullargs =
   (* Adjust to parsing of { } *)
@@ -1373,7 +1353,7 @@ let intern_qualid ?(no_secvar=false) qid intern env ntnvars us args =
       if List.length args < nids then error_not_enough_arguments ?loc;
       let args1,args2 = List.chop nids args in
       check_no_explicitation args1;
-      let subst = split_by_type ids (List.map fst args1,[],[],[]) in
+      let subst = split_by_type ids (List.map (fun (a,_) -> NtnTypeArg (NtnTypeArgConstr a)) args1) in
       let infos = (Id.Map.empty, env) in
       let c = instantiate_notation_constr loc intern (intern_cases_pattern_as_binder ~dump:true intern) ntnvars subst infos c in
       let loc = c.loc in
@@ -1426,7 +1406,7 @@ let intern_qualid_for_pattern test_global intern_not qid pats =
         let nvars = List.length vars in
         if List.length pats < nvars then error_not_enough_arguments ?loc:qid.loc;
         let pats1,pats2 = List.chop nvars pats in
-        let subst = split_by_type_pat vars (pats1,[],[]) in
+        let subst = split_by_type vars (List.map (fun c -> NtnTypeArg (NtnTypeArgPattern (c, Explicit))) pats1) in
         let args = List.map (intern_not subst) args in
         Some (g, Some args, pats2)
       | _ -> None in
@@ -1877,18 +1857,18 @@ let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
         | Some (g,pl) -> DAst.make ?loc @@ RCPatCstr (g, pl)
         | None -> Loc.raise ?loc (InternalizationError (NotAConstructor qid))
       end
-    | CPatNotation (_,(InConstrEntry,"- _"),([a],[],[]),[]) when is_non_zero_pat a ->
+    | CPatNotation (_,(InConstrEntry,"- _"),[NtnTypeArg (NtnTypeArgPattern (a,Explicit))],[]) when is_non_zero_pat a ->
       let p = match a.CAst.v with CPatPrim (Number (_, p)) -> p | _ -> assert false in
       let pat, _df = Notation.interp_prim_token_cases_pattern_expr ?loc
           (check_allowed_ref_in_pat test_kind) (Number (SMinus,p)) scopes in
       rcp_of_glob scopes pat
-    | CPatNotation (_,(InConstrEntry,"( _ )"),([a],[],[]),[]) ->
+    | CPatNotation (_,(InConstrEntry,"( _ )"),[NtnTypeArg (NtnTypeArgPattern (a,Explicit))],[]) ->
       in_pat test_kind scopes a
     | CPatNotation (_,ntn,fullargs,extrargs) ->
-      let ntn,(terms,termlists,binders) = contract_curly_brackets_pat ntn fullargs in
+      let ntn, subst = contract_curly_brackets_pat ntn fullargs in
       let ((ids',c),df) = Notation.interp_notation ?loc ntn scopes in
-      let subst = split_by_type_pat ?loc ids' (terms,termlists,binders) in
-      Dumpglob.dump_notation_location (patntn_loc ?loc fullargs ntn) ntn df;
+      let subst = split_by_type ids' subst in
+      Dumpglob.dump_notation_location (ntn_loc ?loc fullargs ntn) ntn df;
       in_not test_kind loc scopes subst extrargs c
     | CPatDelimiters (depth, key, e) ->
       let sc = find_delimiters_scope ?loc key in
@@ -1963,14 +1943,14 @@ let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
     | _, _, [], [] -> []
     | _ -> assert false in
     ntnpats_with_letin @ aux imps subscopes tags pats
-  and in_not test_kind loc scopes (terms,termlists as fullsubst) args = function
+  and in_not test_kind loc scopes subst args = function
     | NVar id ->
       begin
         (* subst remembers the delimiters stack in the interpretation *)
         (* of the notations *)
         try
-          let (a,(scopt,subscopes)) = Id.Map.find id terms in
-          in_pat test_kind (scopt,subscopes@snd scopes) (mkAppPattern ?loc a args)
+          let pat,((_,(scopt,subscopes)),_) = get_pattern (Id.Map.find id subst) in
+          in_pat test_kind (scopt,subscopes@snd scopes) (mkAppPattern ?loc pat args)
         with Not_found ->
           if Id.equal id ldots_var then
             if List.is_empty args then
@@ -1987,7 +1967,7 @@ let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
       DAst.make ?loc @@ RCPatCstr (g, in_patargs ?loc scopes g true false [] args)
     | NApp (NRef (g,_),ntnpl) ->
       ensure_kind test_kind ?loc g;
-      let ntnpl = List.map (in_not test_kind_inner loc scopes fullsubst []) ntnpl in
+      let ntnpl = List.map (in_not test_kind_inner loc scopes subst []) ntnpl in
       let no_impl =
         (* Convention: if notation is @f, encoded as NApp(Nref g,[]), then
            implicit arguments are not inherited *)
@@ -1998,11 +1978,11 @@ let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
         (strbrk "Application of arguments to a recursive notation not supported in patterns.");
       (try
          (* All elements of the list are in scopes (scopt,subscopes) *)
-         let (l,(scopt,subscopes)) = Id.Map.find x termlists in
-         let termin = in_not test_kind_inner loc scopes fullsubst [] terminator in
-         List.fold_right (fun a t ->
-           let nterms = Id.Map.add y (a, (scopt, subscopes)) terms in
-           let u = in_not test_kind_inner loc scopes (nterms, termlists) [] iter in
+         let l = get_list get_pattern (Id.Map.find x subst) in
+         let termin = in_not test_kind_inner loc scopes subst [] terminator in
+         List.fold_right (fun (a, scl) t ->
+           let subst = Id.Map.add y (NtnTypeArg (NtnTypeArgPattern (a, Explicit)), NtnTypeVar (scl, NtnTypeVarPattern (NtnBinderParsedAsConstr AsAnyPattern))) subst in
+           let u = in_not test_kind_inner loc scopes subst [] iter in
            subst_pat_iterator ldots_var t u)
            (if revert then List.rev l else l) termin
        with Not_found ->
@@ -2264,10 +2244,10 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
         DAst.make ?loc @@
         GLetIn (na.CAst.v, None, inc1, int,
           intern_restart_binders (push_name_env ~dump:true ntnvars (impls_term_list 1 inc1) env na) c2)
-    | CNotation (_,(InConstrEntry,"- _"), ([a],[],[],[])) when is_non_zero a ->
+    | CNotation (_,(InConstrEntry,"- _"), [NtnTypeArg (NtnTypeArgConstr a)]) when is_non_zero a ->
       let p = match a.CAst.v with CPrim (Number (_, p)) -> p | _ -> assert false in
        intern env (CAst.make ?loc @@ CPrim (Number (SMinus,p)))
-    | CNotation (_,(InConstrEntry,"( _ )"),([a],[],[],[])) -> intern env a
+    | CNotation (_,(InConstrEntry,"( _ )"),[NtnTypeArg (NtnTypeArgConstr a)]) -> intern env a
     | CNotation (_,ntn,args) ->
         let c = intern_notation intern env ntnvars loc ntn args in
         apply_impargs env loc c []

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -263,6 +263,7 @@ type intern_env = {
   impls: internalization_env;
   binder_block_names: abstraction_kind option (* None = unknown *) option;
   ntn_binding_ids: Id.Set.t; (* subset of ids that are notation variables *)
+  only_in_constr: bool; (* for notations, tell that the current subterm is a constr even in notations for patterns *)
 }
 
 type pattern_intern_env = {
@@ -307,29 +308,31 @@ let error_expect_binder_notation_type ?loc id =
    (Id.print id ++
     str " is expected to occur in binding position in the right-hand side.")
 
-let set_notation_var_scope ?loc id (tmp_scope,subscopes as scopes) ntnbinders ntnvars =
+let set_notation_var_scope ?loc id {tmp_scope;scopes;ntn_binding_ids;only_in_constr} ntnvars =
   try
     let {Genintern.ntnvar_typ=typ} as status = Id.Map.find id ntnvars in
     match typ with
     | Notation_term.NtnInternTypeOnlyBinder -> error_expect_binder_notation_type ?loc id
     | Notation_term.NtnInternTypeAny principal ->
       let () = match status.ntnvar_scopes with
-      | None -> status.ntnvar_scopes <- Some scopes
+      | None -> status.ntnvar_scopes <- Some (tmp_scope, scopes)
       | Some (tmp_scope', subscopes') ->
         let s' = make_current_scope tmp_scope' subscopes' in
-        let s = make_current_scope tmp_scope subscopes in
+        let s = make_current_scope tmp_scope scopes in
         if Option.is_empty principal && not (List.equal String.equal s' s) then
-          warn_inconsistent_scope ?loc (id,s',s)
+          warn_inconsistent_scope ?loc (id,s',s);
+        ()
       in
       let () = match status.ntnvar_binding_ids with
-      | None -> status.ntnvar_binding_ids <- Some ntnbinders
-      | Some ntnbinders' -> status.ntnvar_binding_ids <- Some (Id.Set.inter ntnbinders ntnbinders')
+      | None -> status.ntnvar_binding_ids <- Some ntn_binding_ids
+      | Some ntnbinders' -> status.ntnvar_binding_ids <- Some (Id.Set.inter ntn_binding_ids ntnbinders')
       in
       let () = match status.ntnvar_used with
         | [] -> () (* not recording if notation var is used *)
         | true :: _ -> () (* already marked used *)
         | false :: rest -> status.ntnvar_used <- true :: rest
       in
+      let () = status.ntnvar_is_only_in_constr <- status.ntnvar_is_only_in_constr || only_in_constr in
       ()
  with Not_found ->
     (* Not in a notation *)
@@ -342,6 +345,8 @@ let set_var_is_binder ?loc id ntnvars =
   with Not_found ->
     (* Not in a notation *)
     ()
+
+let set_only_in_constr env = {env with only_in_constr = true}
 
 let set_type_scope env = {env with tmp_scope = Notation.current_type_scope_names ()}
 
@@ -618,7 +623,7 @@ let intern_letin_binder ~dump intern ntnvars env (({loc;v=na} as locna),def,ty) 
 
 let intern_cases_pattern_as_binder ~dump intern test_kind ntnvars env bk (CAst.{v=p;loc} as pv) =
   let p,t,tmp_scope = match p with
-  | CPatCast (p, t) -> (p, Some t, (* Redone later, not nice: *) Notation.compute_glob_type_scope (intern (set_type_scope env) t))
+  | CPatCast (p, t) -> (p, Some t, (* Redone later, not nice: *) Notation.compute_glob_type_scope (intern (set_type_scope (set_only_in_constr env)) t))
   | _ -> (pv, None, []) in
   let il,disjpat =
     let (il, subst_disjpat) = !intern_cases_pattern_fwd test_kind ntnvars (env_for_pattern {env with tmp_scope}) p in
@@ -1134,7 +1139,7 @@ let intern_var env (ltacvars,ntnvars) namedctx loc id us =
   (* Is [id] a notation variable *)
   if Id.Map.mem id ntnvars then
     begin
-      if not (Id.Map.mem id env.impls) then set_notation_var_scope ?loc id (env.tmp_scope,env.scopes) env.ntn_binding_ids ntnvars;
+      if not (Id.Map.mem id env.impls) then set_notation_var_scope ?loc id env ntnvars;
       gvar (loc,id) us
     end
   else
@@ -1476,7 +1481,8 @@ let interp_reference vars r =
       {ids = Id.Set.empty; strict_check = Some true; pattern_mode = false;
        local_univs = empty_local_univs;(* <- doesn't matter here *)
        tmp_scope = []; scopes = []; impls = empty_internalization_env;
-       binder_block_names = None; ntn_binding_ids = Id.Set.empty}
+       binder_block_names = None; ntn_binding_ids = Id.Set.empty;
+       only_in_constr = false}
       Environ.empty_named_context_val
       (vars, Id.Map.empty) None [] r
   in r
@@ -2864,7 +2870,8 @@ let intern_gen kind env sigma
   internalize env {ids = extract_ids env; strict_check; pattern_mode;
                    local_univs = { bound = bound_univs sigma; unb_univs = true };
                    tmp_scope = tmp_scope; scopes = [];
-                   impls; binder_block_names = Some k; ntn_binding_ids = Id.Set.empty}
+                   impls; binder_block_names = Some k; ntn_binding_ids = Id.Set.empty;
+                   only_in_constr = false}
     (ltacvars, Id.Map.empty) c
 
 let intern_unknown_if_term_or_type env sigma c =
@@ -2971,7 +2978,8 @@ let intern_core kind ?(pattern_mode=false) ist c =
     {ids; strict_check = Some ist.strict_check; pattern_mode;
      local_univs = { bound = local_univs; unb_univs = not ist.strict_check };
      tmp_scope; scopes = []; impls;
-     binder_block_names = Some (Some k); ntn_binding_ids = Id.Set.empty}
+     binder_block_names = Some (Some k); ntn_binding_ids = Id.Set.empty;
+     only_in_constr = false}
     (ltacvars, vl) c
 
 let interp_notation_constr env ?(impls=empty_internalization_env) nenv a =
@@ -2982,6 +2990,7 @@ let interp_notation_constr env ?(impls=empty_internalization_env) nenv a =
     ntnvar_used_as_binder = false;
     ntnvar_scopes = scopes;
     ntnvar_binding_ids = None;
+    ntnvar_is_only_in_constr = false;
     ntnvar_typ = typ;
   }
   in
@@ -2993,7 +3002,8 @@ let interp_notation_constr env ?(impls=empty_internalization_env) nenv a =
   let c = internalize env
       {ids; strict_check = Some true; pattern_mode = false;
        local_univs = empty_local_univs;
-       tmp_scope = []; scopes = []; impls; binder_block_names = None; ntn_binding_ids = Id.Set.empty}
+       tmp_scope = []; scopes = []; impls; binder_block_names = None; ntn_binding_ids = Id.Set.empty;
+       only_in_constr = false}
       (empty_ltac_sign, vl) a
   in
   (* Splits variables into those that are binding, bound, or both *)
@@ -3004,8 +3014,12 @@ let interp_notation_constr env ?(impls=empty_internalization_env) nenv a =
   let out_bindings = function None -> Id.Set.empty | Some a -> a in
   let unused = match reversible with NonInjective ids -> ids | _ -> [] in
   let vars = Id.Map.mapi (fun id status ->
-      (status.Genintern.ntnvar_used_as_binder && not (List.mem_f Id.equal id unused),
-       out_scope status.ntnvar_scopes, out_bindings status.ntnvar_binding_ids)) vl in
+      status.Genintern.ntnvar_used_as_binder && not (List.mem_f Id.equal id unused),
+      out_scope status.ntnvar_scopes,
+      out_bindings status.ntnvar_binding_ids,
+      status.ntnvar_is_only_in_constr)
+      vl
+  in
   (* Returns [a] and the ordered list of variables with their scopes *)
   vars, a, reversible
 
@@ -3029,7 +3043,8 @@ let default_internalization_env ids bound_univs impl_env =
    local_univs = { bound = bound_univs; unb_univs = true };
    tmp_scope = []; scopes = []; impls = impl_env;
    binder_block_names = Some (Some AbsPi);
-   ntn_binding_ids = Id.Set.empty}
+   ntn_binding_ids = Id.Set.empty;
+   only_in_constr = false}
 
 let intern_context env ~bound_univs impl_env binders =
   let lvar = (empty_ltac_sign, Id.Map.empty) in

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -193,58 +193,6 @@ let compute_internalization_env env sigma ?(impls=empty_internalization_env) ?fo
 let implicits_of_decl_in_internalization_env id (int_env:internalization_env) =
   let {var_impls=impls} = Id.Map.find id int_env in impls
 
-(**********************************************************************)
-(* Contracting "{ _ }" in notations *)
-
-let rec wildcards ntn n =
-  if Int.equal n (String.length ntn) then []
-  else let l = spaces ntn (n+1) in if ntn.[n] == '_' then n::l else l
-and spaces ntn n =
-  if Int.equal n (String.length ntn) then []
-  else if ntn.[n] == ' ' then wildcards ntn (n+1) else spaces ntn (n+1)
-
-let expand_notation_string ntn n =
-  let pos = List.nth (wildcards ntn 0) n in
-  let hd = if Int.equal pos 0 then "" else String.sub ntn 0 pos in
-  let tl =
-    if Int.equal pos (String.length ntn) then ""
-    else String.sub ntn (pos+1) (String.length ntn - pos -1) in
-  hd ^ "{ _ }" ^ tl
-
-(* This contracts the special case of "{ _ }" for sumbool, sumor notations *)
-(* Remark: expansion of squash at definition is done in metasyntax.ml *)
-let contract_curly_brackets ntn subst =
-  match ntn.ntn_entry with
-  | InCustomEntry _ -> ntn, subst
-  | InConstrEntry ->
-  let ntn' = ref ntn.ntn_key in
-  let rec contract_squash n = function
-    | [] -> []
-    | NtnTypeArg (NtnTypeArgConstr { CAst.v = CNotation (None,{ntn_entry = InConstrEntry; ntn_key = "{ _ }"},[NtnTypeArg (NtnTypeArgConstr a)]) }) :: l ->
-        ntn' := expand_notation_string !ntn' n;
-        contract_squash n (NtnTypeArg (NtnTypeArgConstr a)::l)
-    | a :: l ->
-        a::contract_squash (n+1) l in
-  let subst = contract_squash 0 subst in
-  (* side effect; don't inline *)
-  mk_ntn_in_constr !ntn', subst
-
-let contract_curly_brackets_pat ntn subst =
-  match ntn.ntn_entry with
-  | InCustomEntry _ -> ntn, subst
-  | InConstrEntry ->
-  let ntn' = ref ntn.ntn_key in
-  let rec contract_squash n = function
-    | [] -> []
-    | NtnTypeArg (NtnTypeArgPattern ({ CAst.v = CPatNotation (None,{ntn_entry = InConstrEntry; ntn_key = "{ _ }"},[NtnTypeArg (NtnTypeArgPattern a)],[]) }, Explicit)) :: l ->
-        ntn' := expand_notation_string !ntn' n;
-        contract_squash n (NtnTypeArg (NtnTypeArgPattern a)::l)
-    | a :: l ->
-        a :: contract_squash (n+1) l in
-  let subst = contract_squash 0 subst in
-  (* side effect; don't inline *)
-  mk_ntn_in_constr !ntn', subst
-
 type local_univs = { bound : UnivNames.universe_binders; unb_univs : bool }
 
 let empty_local_univs = { bound = UnivNames.empty_binders; unb_univs = false }

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -214,36 +214,36 @@ let expand_notation_string ntn n =
 (* This contracts the special case of "{ _ }" for sumbool, sumor notations *)
 (* Remark: expansion of squash at definition is done in metasyntax.ml *)
 let contract_curly_brackets ntn subst =
-  match ntn with
-  | InCustomEntry _,_ -> ntn, subst
-  | InConstrEntry, ntn ->
-  let ntn' = ref ntn in
+  match ntn.ntn_entry with
+  | InCustomEntry _ -> ntn, subst
+  | InConstrEntry ->
+  let ntn' = ref ntn.ntn_key in
   let rec contract_squash n = function
     | [] -> []
-    | NtnTypeArg (NtnTypeArgConstr { CAst.v = CNotation (None,(InConstrEntry,"{ _ }"),[NtnTypeArg (NtnTypeArgConstr a)]) }) :: l ->
+    | NtnTypeArg (NtnTypeArgConstr { CAst.v = CNotation (None,{ntn_entry = InConstrEntry; ntn_key = "{ _ }"},[NtnTypeArg (NtnTypeArgConstr a)]) }) :: l ->
         ntn' := expand_notation_string !ntn' n;
         contract_squash n (NtnTypeArg (NtnTypeArgConstr a)::l)
     | a :: l ->
         a::contract_squash (n+1) l in
   let subst = contract_squash 0 subst in
   (* side effect; don't inline *)
-  (InConstrEntry,!ntn'), subst
+  mk_ntn_in_constr !ntn', subst
 
 let contract_curly_brackets_pat ntn subst =
-  match ntn with
-  | InCustomEntry _,_ -> ntn, subst
-  | InConstrEntry, ntn ->
-  let ntn' = ref ntn in
+  match ntn.ntn_entry with
+  | InCustomEntry _ -> ntn, subst
+  | InConstrEntry ->
+  let ntn' = ref ntn.ntn_key in
   let rec contract_squash n = function
     | [] -> []
-    | NtnTypeArg (NtnTypeArgPattern ({ CAst.v = CPatNotation (None,(InConstrEntry,"{ _ }"),[NtnTypeArg (NtnTypeArgPattern a)],[]) }, Explicit)) :: l ->
+    | NtnTypeArg (NtnTypeArgPattern ({ CAst.v = CPatNotation (None,{ntn_entry = InConstrEntry; ntn_key = "{ _ }"},[NtnTypeArg (NtnTypeArgPattern a)],[]) }, Explicit)) :: l ->
         ntn' := expand_notation_string !ntn' n;
         contract_squash n (NtnTypeArg (NtnTypeArgPattern a)::l)
     | a :: l ->
         a :: contract_squash (n+1) l in
   let subst = contract_squash 0 subst in
   (* side effect; don't inline *)
-  (InConstrEntry,!ntn'), subst
+  mk_ntn_in_constr !ntn', subst
 
 type local_univs = { bound : UnivNames.universe_binders; unb_univs : bool }
 
@@ -1871,12 +1871,12 @@ let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
         | Some (g,pl) -> DAst.make ?loc @@ RCPatCstr (g, pl)
         | None -> Loc.raise ?loc (InternalizationError (NotAConstructor qid))
       end
-    | CPatNotation (_,(InConstrEntry,"- _"),[NtnTypeArg (NtnTypeArgPattern (a,Explicit))],[]) when is_non_zero_pat a ->
+    | CPatNotation (_,{ntn_entry = InConstrEntry; ntn_key = "- _"},[NtnTypeArg (NtnTypeArgPattern (a,Explicit))],[]) when is_non_zero_pat a ->
       let p = match a.CAst.v with CPatPrim (Number (_, p)) -> p | _ -> assert false in
       let pat = Notation.interp_prim_token_cases_pattern_expr ?loc
           (check_allowed_ref_in_pat test_kind) (Number (SMinus,p)) scopes in
       rcp_of_glob scopes pat
-    | CPatNotation (_,(InConstrEntry,"( _ )"),[NtnTypeArg (NtnTypeArgPattern (a,Explicit))],[]) ->
+    | CPatNotation (_,{ntn_entry = InConstrEntry; ntn_key = "( _ )"},[NtnTypeArg (NtnTypeArgPattern (a,Explicit))],[]) ->
       in_pat test_kind scopes a
     | CPatNotation (_,ntn,fullargs,extrargs) ->
       let ntn, subst = contract_curly_brackets_pat ntn fullargs in
@@ -2776,10 +2776,10 @@ let cast self genv env lvar ?loc (c1, k, c2) =
 let notation self genv env lvar ?loc (_, ntn, args) =
   let intern env = intern self genv env lvar in
   match ntn, args with
-  | (InConstrEntry,"- _"), [NtnTypeArg (NtnTypeArgConstr a)] when is_non_zero a ->
+  | {ntn_entry = InConstrEntry; ntn_key = "- _"}, [NtnTypeArg (NtnTypeArgConstr a)] when is_non_zero a ->
     let p = match a.CAst.v with CPrim (Number (_, p)) -> p | _ -> assert false in
     intern env (CAst.make ?loc @@ CPrim (Number (SMinus,p)))
-  | (InConstrEntry,"( _ )"), [NtnTypeArg (NtnTypeArgConstr a)] ->
+  | {ntn_entry = InConstrEntry; ntn_key = "( _ )"}, [NtnTypeArg (NtnTypeArgConstr a)] ->
     intern env a
   | ntn, args ->
     let c = intern_notation intern env (snd lvar) loc ntn args in

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -213,37 +213,37 @@ let expand_notation_string ntn n =
 
 (* This contracts the special case of "{ _ }" for sumbool, sumor notations *)
 (* Remark: expansion of squash at definition is done in metasyntax.ml *)
-let contract_curly_brackets ntn (l,ll,bl,bll) =
+let contract_curly_brackets ntn subst =
   match ntn with
-  | InCustomEntry _,_ -> ntn,(l,ll,bl,bll)
+  | InCustomEntry _,_ -> ntn, subst
   | InConstrEntry, ntn ->
   let ntn' = ref ntn in
   let rec contract_squash n = function
     | [] -> []
-    | { CAst.v = CNotation (None,(InConstrEntry,"{ _ }"),([a],[],[],[])) } :: l ->
+    | NtnTypeArg (NtnTypeArgConstr { CAst.v = CNotation (None,(InConstrEntry,"{ _ }"),[NtnTypeArg (NtnTypeArgConstr a)]) }) :: l ->
         ntn' := expand_notation_string !ntn' n;
-        contract_squash n (a::l)
+        contract_squash n (NtnTypeArg (NtnTypeArgConstr a)::l)
     | a :: l ->
         a::contract_squash (n+1) l in
-  let l = contract_squash 0 l in
+  let subst = contract_squash 0 subst in
   (* side effect; don't inline *)
-  (InConstrEntry,!ntn'),(l,ll,bl,bll)
+  (InConstrEntry,!ntn'), subst
 
-let contract_curly_brackets_pat ntn (l,ll,bl) =
+let contract_curly_brackets_pat ntn subst =
   match ntn with
-  | InCustomEntry _,_ -> ntn,(l,ll,bl)
+  | InCustomEntry _,_ -> ntn, subst
   | InConstrEntry, ntn ->
   let ntn' = ref ntn in
   let rec contract_squash n = function
     | [] -> []
-    | { CAst.v = CPatNotation (None,(InConstrEntry,"{ _ }"),([a],[],[]),[]) } :: l ->
+    | NtnTypeArg (NtnTypeArgPattern ({ CAst.v = CPatNotation (None,(InConstrEntry,"{ _ }"),[NtnTypeArg (NtnTypeArgPattern a)],[]) }, Explicit)) :: l ->
         ntn' := expand_notation_string !ntn' n;
-        contract_squash n (a::l)
+        contract_squash n (NtnTypeArg (NtnTypeArgPattern a)::l)
     | a :: l ->
-        a::contract_squash (n+1) l in
-  let l = contract_squash 0 l in
+        a :: contract_squash (n+1) l in
+  let subst = contract_squash 0 subst in
   (* side effect; don't inline *)
-  (InConstrEntry,!ntn'),(l,ll,bl)
+  (InConstrEntry,!ntn'), subst
 
 type local_univs = { bound : UnivNames.universe_binders; unb_univs : bool }
 
@@ -713,18 +713,24 @@ let option_mem_assoc id = function
   | Some (id',c) -> Id.equal id id'
   | None -> false
 
-let find_fresh_name renaming (terms,termlists,binders,binderlists) avoid id =
-  let fold1 _ (c, _) accu = Id.Set.union (free_vars_of_constr_expr c) accu in
-  let fold2 _ (l, _) accu =
-    let fold accu c = Id.Set.union (free_vars_of_constr_expr c) accu in
-    List.fold_left fold accu l
-  in
-  let fold3 _ x accu = Id.Set.add x accu in
-  let fvs1 = Id.Map.fold fold1 terms avoid in
-  let fvs2 = Id.Map.fold fold2 termlists fvs1 in
-  let fvs3 = Id.Map.fold fold3 renaming fvs2 in
+let find_fresh_name renaming subst avoid id =
+  let fold_atom a accu =
+    let ids = match a with
+    | NtnTypeArgConstr c -> free_vars_of_constr_expr c
+    | NtnTypeArgPattern (c,bk) -> free_vars_of_cases_pattern_expr c
+    | NtnTypeArgBinders bl -> free_vars_of_local_binders bl in
+    Id.Set.union ids accu in
+  let rec fold_arg a accu =
+    match a with
+    | NtnTypeArg a -> fold_atom a accu
+    | NtnTypeArgList l -> List.fold_right fold_arg l accu
+    | NtnTypeArgTuple l -> List.fold_right fold_arg l accu in
+  let fold _ (a,_) accu = fold_arg a accu in
+  let fold_renaming _ x accu = Id.Set.add x accu in
+  let fvs1 = Id.Map.fold fold subst avoid in
+  let fvs2 = Id.Map.fold fold_renaming renaming fvs1 in
   (* TODO binders *)
-  next_ident_away_from id (fun id -> Id.Set.mem id fvs3)
+  next_ident_away_from id (fun id -> Id.Set.mem id fvs2)
 
 let is_patvar c =
   match DAst.get c with
@@ -775,21 +781,79 @@ let extract_pattern_from_binder b =
     let pat, na = cook_pattern (patl, id) in
     pat, na, bk, ty
 
-let traverse_binder intern_pat ntnvars (terms,_,binders,_ as subst) binderopt avoid (renaming,env) na ty =
+let check_explicit = function
+  | Explicit -> ()
+  | MaxImplicit | NonMaxImplicit -> user_err (str "Implicit arguments not supported.") (* shouldn't arrive *)
+
+let is_onlyident = function
+  | AsIdent | AsName -> true
+  | AsAnyPattern | AsStrictPattern -> false
+
+let only_ntn_binder_kind = function
+  | NtnBinderParsedAsConstr k -> is_onlyident k
+  | NtnBinderParsedAsBinder -> false
+  | NtnBinderParsedAsSomeBinderKind k -> is_onlyident k
+
+let cases_pattern_of_id {loc;v=id} =
+  CAst.make ?loc (CPatAtom (Some (qualid_of_ident ?loc id)))
+
+let cases_pattern_of_name {loc;v=na} =
+  let atom = match na with Name id -> Some (qualid_of_ident ?loc id) | Anonymous -> None in
+  CAst.make ?loc (CPatAtom atom)
+
+let cases_pattern_of_binder_as_constr a = function
+  | AsAnyPattern | AsStrictPattern -> coerce_to_cases_pattern_expr a
+  | AsIdent -> cases_pattern_of_id (coerce_to_id a)
+  | AsName -> cases_pattern_of_name (coerce_to_name a)
+
+let get_list f = function
+  | NtnTypeArgList l, NtnTypeVarList t -> List.map (fun a -> f (a,t)) l
+  | _ -> raise Not_found
+
+let get_term_opt = function
+  | NtnTypeArg (NtnTypeArgConstr c), NtnTypeVar (scopes, NtnTypeVarConstr _) -> Some (c, scopes)
+  | _ -> None
+
+let get_term v = match get_term_opt v with None -> raise Not_found | Some v -> v
+
+let get_pattern = function
+  | NtnTypeArg (NtnTypeArgPattern (c, bk)), NtnTypeVar (scopes, (NtnTypeVarPattern _ | NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern)) ->
+    check_explicit bk; (c : cases_pattern_expr), scopes
+  | _ -> raise Not_found
+
+let get_binder_opt = function
+  | NtnTypeArg (NtnTypeArgPattern (c, bk)),
+    NtnTypeVar (scopes, NtnTypeVarPattern (NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _ as k)) ->
+    Some ((c, bk), (only_ntn_binder_kind k, scopes))
+  | NtnTypeArg (NtnTypeArgConstr c), NtnTypeVar (scopes, NtnTypeVarPattern NtnBinderParsedAsConstr k) ->
+    Some ((cases_pattern_of_binder_as_constr c k, Explicit), (is_onlyident k, scopes))
+  | _ -> None
+
+let get_binder v = match get_binder_opt v with None -> raise Not_found | Some v -> v
+
+let get_binders = function
+  | NtnTypeArg (NtnTypeArgBinders bl), NtnTypeVar (scopes, NtnTypeVarBinders k) -> bl, scopes
+  | NtnTypeArgList l, NtnTypeVar (scopes, NtnTypeVarBinders (NtnBinderParsedAsConstr k)) ->
+    let bl = List.map (function NtnTypeArg (NtnTypeArgConstr a) -> CLocalPattern (cases_pattern_of_binder_as_constr a k)
+      | _ -> anomaly (str "Ill-typed notation variable.")) l in
+    bl, scopes
+  | _ -> raise Not_found
+
+let traverse_binder intern_pat ntnvars subst binderopt avoid (renaming,env) na ty =
   match na with
   | Anonymous -> (renaming,env), None, Anonymous, Explicit, set_type ty None
   | Name id ->
   let test_kind = test_kind_tolerant in
   try
     (* We instantiate binder name with patterns which may be parsed as terms *)
-    let pat = coerce_to_cases_pattern_expr (fst (Id.Map.find id terms)) in
+    let pat = coerce_to_cases_pattern_expr (fst (get_term (Id.Map.find id subst))) in
     let env,pat,bk,t = intern_pat test_kind ntnvars env Explicit pat in
     let pat, na = cook_pattern pat in
     (renaming,env), pat, na, bk, set_type ty (Some t)
   with Not_found ->
   try
     (* Trying to associate a pattern *)
-    let (pat,bk),(onlyident,scopes) = Id.Map.find id binders in
+    let (pat,bk),(onlyident,((_,scopes),ntn_binding_ids)) = get_binder (Id.Map.find id subst) in
     let env = set_env_scopes env scopes in
     if onlyident then
       (* Do not try to interpret a variable as a constructor *)
@@ -816,7 +880,7 @@ let traverse_binder intern_pat ntnvars (terms,_,binders,_ as subst) binderopt av
 
 type binder_action =
   | AddLetIn of lname * constr_expr * constr_expr option
-  | AddTermIter of (constr_expr * subscopes) Names.Id.Map.t
+  | AddTermIter of (notation_arg_type_expr * notation_var_type) Names.Id.Map.t
   | AddPreBinderIter of Id.t * local_binder_expr (* A binder to be internalized *)
   | AddBinderIter of Id.t * extended_glob_local_binder (* A binder already internalized - used for generalized binders *)
   | AddNList (* Insert a ".. term .." block *)
@@ -843,11 +907,11 @@ let terms_of_binders bl =
     | bnd :: l ->
       let loc = bnd.loc in
       begin match DAst.get bnd with
-      | GLocalAssum (Name id,_,_,_) -> (CAst.make ?loc @@ CRef (qualid_of_ident ?loc id, None)) :: extract_variables l
+      | GLocalAssum (Name id,_,_,_) -> (CAst.make ?loc @@ CRef (qualid_of_ident ?loc id, None), dummy_subscopes) :: extract_variables l
       | GLocalDef (Name id,_,_,_) -> extract_variables l
       | GLocalDef (Anonymous,_,_,_)
       | GLocalAssum (Anonymous,_,_,_) -> user_err Pp.(str "Cannot turn \"_\" into a term.")
-      | GLocalPattern (([u],_),_,_,_) -> term_of_pat u :: extract_variables l
+      | GLocalPattern (([u],_),_,_,_) -> (term_of_pat u,dummy_subscopes) :: extract_variables l
       | GLocalPattern ((_,_),_,_,_) -> error_cannot_coerce_disjunctive_pattern_term ?loc ()
       end
     | [] -> [] in
@@ -883,15 +947,15 @@ let rec adjust_env env = function
   | NRec _ | NSort _ | NProj _ | NInt _ | NFloat _ | NString _ | NArray _
   | NList _ | NBinderList _ -> env (* to be safe, but restart should be ok *)
 
-let subst_var loc intern_pat intern ntnvars binders (terms, binderopt, _terminopt) (renaming, env) id =
+let subst_var loc intern_pat intern ntnvars subst (terms, binderopt, _terminopt) (renaming, env) id =
   (* subst remembers the delimiters stack in the interpretation *)
   (* of the notations *)
   try
-    let (a,scopes) = Id.Map.find id terms in
+    let (a,((_,scopes),_)) = get_term (Id.Map.find id terms) in
     intern (set_env_scopes env scopes) a
   with Not_found ->
   try
-    let (pat,bk),(onlyident,scopes) = Id.Map.find id binders in
+    let (pat,bk),(onlyident,((_,scopes),_)) = get_binder (Id.Map.find id subst) in
     let env = set_env_scopes env scopes in
     let test_kind =
       if onlyident then test_kind_ident_in_notation
@@ -907,7 +971,7 @@ let subst_var loc intern_pat intern ntnvars binders (terms, binderopt, _terminop
     | Some (x,binder) when Id.equal x id ->
       let terms = terms_of_binders [binder] in
       assert (List.length terms = 1);
-      intern env (List.hd terms)
+      intern env (fst (List.hd terms))
     | _ -> raise Not_found
   with Not_found ->
     DAst.make ?loc (
@@ -918,7 +982,6 @@ let subst_var loc intern_pat intern ntnvars binders (terms, binderopt, _terminop
         GVar id)
 
 let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
-  let (terms,termlists,binders,binderlists) = subst in
   (* when called while defining a notation, avoid capturing the private binders
      of the expression by variables bound by the notation (see #3892) *)
   let avoid = Id.Map.domain ntnvars in
@@ -947,31 +1010,31 @@ let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
            DAst.make ?loc (GApp (DAst.make ?loc (GVar ldots_var), [aux_letin env (rest,terminator,iter)]))
         in
         aux_letin env (Option.get iteropt)
-    | NVar id -> subst_var loc intern_pat intern ntnvars binders subst' (renaming, env) id
+    | NVar id -> subst_var loc intern_pat intern ntnvars subst subst' (renaming, env) id
     | NList (x,y,iter,terminator,revert) ->
-      let l,(scopt,subscopes) =
+      let l =
         (* All elements of the list are in scopes (scopt,subscopes) *)
         try
-          let l,scopes = Id.Map.find x termlists in
-          (if revert then List.rev l else l),scopes
+          let l = get_list get_term (Id.Map.find x subst) in
+          if revert then List.rev l else l
         with Not_found ->
         try
-          let (bl,(scopt,subscopes)) = Id.Map.find x binderlists in
+          let (bl,(scopt,subscopes)) = get_binders (Id.Map.find x subst) in
           let env,bl' = List.fold_left (intern_local_binder_aux ~dump:true intern ntnvars) (env,[]) bl in
-          terms_of_binders (if revert then bl' else List.rev bl'),([],[])
+          terms_of_binders (if revert then bl' else List.rev bl')
         with Not_found ->
-          anomaly (Pp.str "Inconsistent substitution of recursive notation.") in
-      let select_iter a =
+          anomaly (Pp.str "Inconsistent substitution of recursive notation2.") in
+      let select_iter (a,scopes) =
         match a.CAst.v with
         | CRef (qid,None) when qualid_is_ident qid && Id.equal (qualid_basename qid) ldots_var -> AddNList
-        | _ -> AddTermIter (Id.Map.add y (a,(scopt,subscopes)) terms) in
+        | _ -> AddTermIter (Id.Map.add y (NtnTypeArg (NtnTypeArgConstr a), NtnTypeVar (scopes,NtnTypeVarConstr (* Does not natter: *) NtnConstrForConstrAndPatternForPattern)) subst) in
       let l = List.map select_iter l in
       aux (terms,None,Some (l,terminator,iter)) subinfos (NVar ldots_var)
     | NHole (knd) ->
       let knd = match knd with
       | GBinderType (Name id as na) ->
         let na =
-          try (coerce_to_name (fst (Id.Map.find id terms))).v
+          try (coerce_to_name (fst (get_term (Id.Map.find id terms)))).v
           with Not_found ->
           try Name (Id.Map.find id renaming)
           with Not_found -> na
@@ -981,12 +1044,12 @@ let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
       in
       DAst.make ?loc @@ GHole (knd)
     | NGenarg arg ->
-      let glob_of_term (c, scopes) =
+      let glob_of_term (c, ((_,scopes),_)) =
         let nenv = set_env_scopes env scopes in
         let gc = intern nenv c in
         gc
       in
-      let glob_of_binder ((c,_bk), (onlyident,(tmp_scope,subscopes))) =
+      let glob_of_binder ((c,_bk), (onlyident,((_,(tmp_scope,subscopes)),_))) =
         let nenv = {env with tmp_scope; scopes = subscopes @ env.scopes} in
         let test_kind =
           if onlyident then test_kind_ident_in_notation
@@ -998,18 +1061,21 @@ let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
         | _ -> error_cannot_coerce_disjunctive_pattern_term ?loc:c.loc ()
       in
       let get_glob id =
-        match Id.Map.find_opt id terms with
-        | Some term -> Some (glob_of_term term)
-        | None -> match Id.Map.find_opt id binders with
-          | Some binder -> Some (glob_of_binder binder)
-          | None -> None
+        match Id.Map.find_opt id subst with
+        | None -> None
+        | Some a ->
+          match get_term_opt a with
+          | Some v -> Some (glob_of_term v)
+          | None -> match get_binder_opt a with
+            | Some v -> Some (glob_of_binder v)
+            | None -> None
       in
       let arg = Genintern.generic_substitute_notation ntnvars get_glob arg in
       DAst.make ?loc @@ GGenarg arg
     | NBinderList (x,y,iter,terminator,revert) ->
       (try
         (* All elements of the list are in scopes (scopt,subscopes) *)
-        let (bl,(scopt,subscopes)) = Id.Map.find x binderlists in
+        let (bl,(scopt,subscopes)) = get_binders (Id.Map.find x subst) in
         (* We flatten binders so that we can interpret them at substitution time *)
         let bl = flatten_binders bl in
         let bl = if revert then List.rev bl else bl in
@@ -1029,100 +1095,14 @@ let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
     | t ->
       glob_constr_of_notation_constr_with_binders ?loc
         (traverse_binder intern_pat ntnvars subst binderopt avoid) (aux subst') ~h:binder_status_fun subinfos t
-  in aux (terms,None,None) infos c
+  in aux (subst,None,None) infos c
 
 (* Turning substitution coming from parsing and based on production
    into a substitution for interpretation and based on binding/constr
    distinction *)
 
-let cases_pattern_of_id {loc;v=id} =
-  CAst.make ?loc (CPatAtom (Some (qualid_of_ident ?loc id)))
-
-let cases_pattern_of_name {loc;v=na} =
-  let atom = match na with Name id -> Some (qualid_of_ident ?loc id) | Anonymous -> None in
-  CAst.make ?loc (CPatAtom atom)
-
-let cases_pattern_of_binder_as_constr a = function
-  | AsAnyPattern | AsStrictPattern -> coerce_to_cases_pattern_expr a
-  | AsIdent -> cases_pattern_of_id (coerce_to_id a)
-  | AsName -> cases_pattern_of_name (coerce_to_name a)
-
-let is_onlyident = function
-  | AsIdent | AsName -> true
-  | AsAnyPattern | AsStrictPattern -> false
-
-let split_by_type ids (subst : constr_notation_substitution) =
-  let bind id scl l s =
-    match l with
-    | [] -> assert false
-    | a::l -> l, Id.Map.add id (a,scl) s in
-  let (terms,termlists,binders,binderlists),subst =
-    List.fold_left (fun ((terms,termlists,binders,binderlists),(terms',termlists',binders',binderlists')) (id,((_,scl),_,typ)) ->
-    match typ with
-    | NtnTypeConstr ->
-       let terms,terms' = bind id scl terms terms' in
-       (terms,termlists,binders,binderlists),(terms',termlists',binders',binderlists')
-    | NtnTypeBinder ntn_binder_kind ->
-       let onlyident,a,terms,binders =
-         match ntn_binder_kind with
-         | NtnBinderParsedAsConstr k ->
-           let a,terms = List.sep_first terms in
-           is_onlyident k, (cases_pattern_of_binder_as_constr a k, Explicit), terms, binders
-         | NtnBinderParsedAsBinder ->
-           let a,binders = List.sep_first binders in
-           false, a, terms, binders
-         | NtnBinderParsedAsSomeBinderKind k ->
-           let a,binders = List.sep_first binders in
-           is_onlyident k, a, terms, binders
-       in
-       let binders' = Id.Map.add id (a,(onlyident,scl)) binders' in
-       (terms,termlists,binders,binderlists),(terms',termlists',binders',binderlists')
-    | NtnTypeConstrList ->
-       let termlists,termlists' = bind id scl termlists termlists' in
-       (terms,termlists,binders,binderlists),(terms',termlists',binders',binderlists')
-    | NtnTypeBinderList ntn_binder_kind ->
-       let l,termlists,binderlists =
-         match ntn_binder_kind with
-         | NtnBinderParsedAsConstr k ->
-           let l,termlists = List.sep_first termlists in
-           List.map (fun a -> CLocalPattern (cases_pattern_of_binder_as_constr a k)) l, termlists, binderlists
-         | NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _ ->
-           let l,binderlists = List.sep_first binderlists in
-           l, termlists, binderlists
-       in
-       let binderlists' = Id.Map.add id (l,scl) binderlists' in
-       (terms,termlists,binders,binderlists),(terms',termlists',binders',binderlists'))
-                   (subst,(Id.Map.empty,Id.Map.empty,Id.Map.empty,Id.Map.empty)) ids in
-  assert (terms = [] && termlists = [] && binders = [] && binderlists = []);
-  subst
-
-let split_by_type_pat ?loc ids subst =
-  let bind id (_,scopes) l s =
-    match l with
-    | [] -> assert false
-    | a::l -> l, Id.Map.add id (a,scopes) s in
-  let bind_binders id (_,scopes) l s =
-    match l with
-    | [] -> assert false
-    | (a,Explicit)::l -> l, Id.Map.add id (a,scopes) s
-    | (a,(MaxImplicit|NonMaxImplicit))::l -> user_err (str "Implicit arguments not supported.") (* shouldn't arrive *)
-  in
-  let (terms,termlists,binders),subst =
-    List.fold_left (fun ((terms,termlists,binders),(terms',termlists')) (id,(scl,_,typ)) ->
-    match typ with
-    | NtnTypeConstr | NtnTypeBinder (NtnBinderParsedAsConstr _) ->
-       let terms,terms' = bind id scl terms terms' in
-       (terms,termlists,binders),(terms',termlists')
-    | NtnTypeConstrList ->
-       let termlists,termlists' = bind id scl termlists termlists' in
-       (terms,termlists,binders),(terms',termlists')
-    | NtnTypeBinder (NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _) ->
-       let binders,terms' = bind_binders id scl binders terms' in
-       (terms,termlists,binders),(terms',termlists')
-    | NtnTypeBinderList _ -> error_invalid_pattern_notation ?loc ())
-                   (subst,(Id.Map.empty,Id.Map.empty)) ids in
-  assert (terms = [] && termlists = [] && binders = []);
-  subst
+let split_by_type ids subst =
+  List.fold_left2 (fun subst (id,typ) arg -> Id.Map.add id (arg,typ) subst) Id.Map.empty ids subst
 
 let intern_notation intern env ntnvars loc ntn fullargs =
   (* Adjust to parsing of { } *)
@@ -1371,7 +1351,7 @@ let intern_qualid ?(no_secvar=false) qid intern env ntnvars us args =
       if List.length args < nids then error_not_enough_arguments ?loc;
       let args1,args2 = List.chop nids args in
       check_no_explicitation args1;
-      let subst = split_by_type ids (List.map fst args1,[],[],[]) in
+      let subst = split_by_type ids (List.map (fun (a,_) -> NtnTypeArg (NtnTypeArgConstr a)) args1) in
       let infos = (Id.Map.empty, env) in
       let c = instantiate_notation_constr loc intern (intern_cases_pattern_as_binder ~dump:true intern) ntnvars subst infos c in
       let loc = c.loc in
@@ -1424,7 +1404,7 @@ let intern_qualid_for_pattern test_global intern_not qid pats =
         let nvars = List.length vars in
         if List.length pats < nvars then error_not_enough_arguments ?loc:qid.loc;
         let pats1,pats2 = List.chop nvars pats in
-        let subst = split_by_type_pat vars (pats1,[],[]) in
+        let subst = split_by_type vars (List.map (fun c -> NtnTypeArg (NtnTypeArgPattern (c, Explicit))) pats1) in
         let args = List.map (intern_not subst) args in
         Some (g, Some args, pats2)
       | _ -> None in
@@ -1885,18 +1865,18 @@ let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
         | Some (g,pl) -> DAst.make ?loc @@ RCPatCstr (g, pl)
         | None -> Loc.raise ?loc (InternalizationError (NotAConstructor qid))
       end
-    | CPatNotation (_,(InConstrEntry,"- _"),([a],[],[]),[]) when is_non_zero_pat a ->
+    | CPatNotation (_,(InConstrEntry,"- _"),[NtnTypeArg (NtnTypeArgPattern (a,Explicit))],[]) when is_non_zero_pat a ->
       let p = match a.CAst.v with CPatPrim (Number (_, p)) -> p | _ -> assert false in
       let pat = Notation.interp_prim_token_cases_pattern_expr ?loc
           (check_allowed_ref_in_pat test_kind) (Number (SMinus,p)) scopes in
       rcp_of_glob scopes pat
-    | CPatNotation (_,(InConstrEntry,"( _ )"),([a],[],[]),[]) ->
+    | CPatNotation (_,(InConstrEntry,"( _ )"),[NtnTypeArg (NtnTypeArgPattern (a,Explicit))],[]) ->
       in_pat test_kind scopes a
     | CPatNotation (_,ntn,fullargs,extrargs) ->
-      let ntn,(terms,termlists,binders) = contract_curly_brackets_pat ntn fullargs in
+      let ntn, subst = contract_curly_brackets_pat ntn fullargs in
       let ((ids',c),df) = Notation.interp_notation ?loc ntn scopes in
-      let subst = split_by_type_pat ?loc ids' (terms,termlists,binders) in
-      Dumpglob.dump_notation_location (patntn_loc ?loc fullargs ntn) ntn df;
+      let subst = split_by_type ids' subst in
+      Dumpglob.dump_notation_location (ntn_loc ?loc fullargs ntn) ntn df;
       in_not test_kind loc scopes subst extrargs c
     | CPatDelimiters (depth, key, e) ->
       let sc = find_delimiters_scope ?loc key in
@@ -1971,14 +1951,14 @@ let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
     | _, _, [], [] -> []
     | _ -> assert false in
     ntnpats_with_letin @ aux imps subscopes tags pats
-  and in_not test_kind loc scopes (terms,termlists as fullsubst) args = function
+  and in_not test_kind loc scopes subst args = function
     | NVar id ->
       begin
         (* subst remembers the delimiters stack in the interpretation *)
         (* of the notations *)
         try
-          let (a,(scopt,subscopes)) = Id.Map.find id terms in
-          in_pat test_kind (scopt,subscopes@snd scopes) (mkAppPattern ?loc a args)
+          let pat,((_,(scopt,subscopes)),_) = get_pattern (Id.Map.find id subst) in
+          in_pat test_kind (scopt,subscopes@snd scopes) (mkAppPattern ?loc pat args)
         with Not_found ->
           if Id.equal id ldots_var then
             if List.is_empty args then
@@ -1995,7 +1975,7 @@ let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
       DAst.make ?loc @@ RCPatCstr (g, in_patargs ?loc scopes g ~expanded:true ~no_impl:false [] args)
     | NApp (NRef (g,_),ntnpl) ->
       ensure_kind test_kind ?loc g;
-      let ntnpl = List.map (in_not test_kind_inner loc scopes fullsubst []) ntnpl in
+      let ntnpl = List.map (in_not test_kind_inner loc scopes subst []) ntnpl in
       let no_impl =
         (* Convention: if notation is @f, encoded as NApp(Nref g,[]), then
            implicit arguments are not inherited *)
@@ -2006,11 +1986,11 @@ let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
         (strbrk "Application of arguments to a recursive notation not supported in patterns.");
       (try
          (* All elements of the list are in scopes (scopt,subscopes) *)
-         let (l,(scopt,subscopes)) = Id.Map.find x termlists in
-         let termin = in_not test_kind_inner loc scopes fullsubst [] terminator in
-         List.fold_right (fun a t ->
-           let nterms = Id.Map.add y (a, (scopt, subscopes)) terms in
-           let u = in_not test_kind_inner loc scopes (nterms, termlists) [] iter in
+         let l = get_list get_pattern (Id.Map.find x subst) in
+         let termin = in_not test_kind_inner loc scopes subst [] terminator in
+         List.fold_right (fun (a, scl) t ->
+           let subst = Id.Map.add y (NtnTypeArg (NtnTypeArgPattern (a, Explicit)), NtnTypeVar (scl, NtnTypeVarPattern (NtnBinderParsedAsConstr AsAnyPattern))) subst in
+           let u = in_not test_kind_inner loc scopes subst [] iter in
            subst_pat_iterator ldots_var t u)
            (if revert then List.rev l else l) termin
        with Not_found ->
@@ -2186,7 +2166,7 @@ module Interner = struct
   ; evar : t -> (Glob_term.existential_name CAst.t * (lident * constr_expr) list) fn
   ; sort : t -> sort_expr fn
   ; cast : t -> (constr_expr * Constr.cast_kind option * constr_expr) fn
-  ; notation : t -> (notation_with_optional_scope option * notation * constr_notation_substitution) fn
+  ; notation : t -> (notation_with_optional_scope option * notation * notation_substitution) fn
   ; generalization : t -> (Glob_term.binding_kind * constr_expr) fn
   ; prim : t -> prim_token fn
   ; delimiters : t -> (delimiter_depth * string * constr_expr) fn
@@ -2790,10 +2770,10 @@ let cast self genv env lvar ?loc (c1, k, c2) =
 let notation self genv env lvar ?loc (_, ntn, args) =
   let intern env = intern self genv env lvar in
   match ntn, args with
-  | (InConstrEntry,"- _"), ([a],[],[],[]) when is_non_zero a ->
+  | (InConstrEntry,"- _"), [NtnTypeArg (NtnTypeArgConstr a)] when is_non_zero a ->
     let p = match a.CAst.v with CPrim (Number (_, p)) -> p | _ -> assert false in
     intern env (CAst.make ?loc @@ CPrim (Number (SMinus,p)))
-  | (InConstrEntry,"( _ )"), ([a],[],[],[]) ->
+  | (InConstrEntry,"( _ )"), [NtnTypeArg (NtnTypeArgConstr a)] ->
     intern env a
   | ntn, args ->
     let c = intern_notation intern env (snd lvar) loc ntn args in

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -263,6 +263,7 @@ type intern_env = {
   impls: internalization_env;
   binder_block_names: abstraction_kind option (* None = unknown *) option;
   ntn_binding_ids: Id.Set.t; (* subset of ids that are notation variables *)
+  only_in_constr: bool; (* for notations, tell that the current subterm is a constr even in notations for patterns *)
 }
 
 type pattern_intern_env = {
@@ -309,29 +310,31 @@ let error_expect_binder_notation_type ?loc id =
    (Id.print id ++
     str " is expected to occur in binding position in the right-hand side.")
 
-let set_notation_var_scope ?loc id (tmp_scope,subscopes as scopes) ntnbinders ntnvars =
+let set_notation_var_scope ?loc id {tmp_scope;scopes;ntn_binding_ids;only_in_constr} ntnvars =
   try
     let {Genintern.ntnvar_typ=typ} as status = Id.Map.find id ntnvars in
     match typ with
     | Notation_term.NtnInternTypeOnlyBinder -> error_expect_binder_notation_type ?loc id
     | Notation_term.NtnInternTypeAny principal ->
       let () = match status.ntnvar_scopes with
-      | None -> status.ntnvar_scopes <- Some scopes
+      | None -> status.ntnvar_scopes <- Some (tmp_scope, scopes)
       | Some (tmp_scope', subscopes') ->
         let s' = make_current_scope tmp_scope' subscopes' in
-        let s = make_current_scope tmp_scope subscopes in
+        let s = make_current_scope tmp_scope scopes in
         if Option.is_empty principal && not (List.equal String.equal s' s) then
-          warn_inconsistent_scope ?loc (id,s',s)
+          warn_inconsistent_scope ?loc (id,s',s);
+        ()
       in
       let () = match status.ntnvar_binding_ids with
-      | None -> status.ntnvar_binding_ids <- Some ntnbinders
-      | Some ntnbinders' -> status.ntnvar_binding_ids <- Some (Id.Set.inter ntnbinders ntnbinders')
+      | None -> status.ntnvar_binding_ids <- Some ntn_binding_ids
+      | Some ntnbinders' -> status.ntnvar_binding_ids <- Some (Id.Set.inter ntn_binding_ids ntnbinders')
       in
       let () = match status.ntnvar_used with
         | [] -> () (* not recording if notation var is used *)
         | true :: _ -> () (* already marked used *)
         | false :: rest -> status.ntnvar_used <- true :: rest
       in
+      let () = status.ntnvar_is_only_in_constr <- status.ntnvar_is_only_in_constr || only_in_constr in
       ()
  with Not_found ->
     (* Not in a notation *)
@@ -344,6 +347,8 @@ let set_var_is_binder ?loc id ntnvars =
   with Not_found ->
     (* Not in a notation *)
     ()
+
+let set_only_in_constr env = {env with only_in_constr = true}
 
 let set_type_scope env = {env with tmp_scope = Notation.current_type_scope_names ()}
 
@@ -620,7 +625,7 @@ let intern_letin_binder ~dump intern ntnvars env (({loc;v=na} as locna),def,ty) 
 
 let intern_cases_pattern_as_binder ~dump intern test_kind ntnvars env bk (CAst.{v=p;loc} as pv) =
   let p,t,tmp_scope = match p with
-  | CPatCast (p, t) -> (p, Some t, (* Redone later, not nice: *) Notation.compute_glob_type_scope (intern (set_type_scope env) t))
+  | CPatCast (p, t) -> (p, Some t, (* Redone later, not nice: *) Notation.compute_glob_type_scope (intern (set_type_scope (set_only_in_constr env)) t))
   | _ -> (pv, None, []) in
   let il,disjpat =
     let (il, subst_disjpat) = !intern_cases_pattern_fwd test_kind ntnvars (env_for_pattern {env with tmp_scope}) p in
@@ -1136,7 +1141,7 @@ let intern_var env (ltacvars,ntnvars) namedctx loc id us =
   (* Is [id] a notation variable *)
   if Id.Map.mem id ntnvars then
     begin
-      if not (Id.Map.mem id env.impls) then set_notation_var_scope ?loc id (intern_subscopes env) env.ntn_binding_ids ntnvars;
+      if not (Id.Map.mem id env.impls) then set_notation_var_scope ?loc id env ntnvars;
       gvar (loc,id) us
     end
   else
@@ -1478,7 +1483,8 @@ let interp_reference vars r =
       {ids = Id.Set.empty; strict_check = Some true; pattern_mode = false;
        local_univs = empty_local_univs;(* <- doesn't matter here *)
        tmp_scope = []; scopes = []; impls = empty_internalization_env;
-       binder_block_names = None; ntn_binding_ids = Id.Set.empty}
+       binder_block_names = None; ntn_binding_ids = Id.Set.empty;
+       only_in_constr = false}
       Environ.empty_named_context_val
       (vars, Id.Map.empty) None [] r
   in r
@@ -2887,7 +2893,8 @@ let intern_gen ?self kind env sigma
   internalize ?self env {ids = extract_ids env; strict_check; pattern_mode;
                    local_univs = { bound = bound_univs sigma; unb_univs = true };
                    tmp_scope = tmp_scope; scopes = [];
-                   impls; binder_block_names = Some k; ntn_binding_ids = Id.Set.empty}
+                   impls; binder_block_names = Some k; ntn_binding_ids = Id.Set.empty;
+                   only_in_constr = false}
     (ltacvars, Id.Map.empty) c
 
 let intern_unknown_if_term_or_type env sigma c =
@@ -2994,7 +3001,8 @@ let intern_core kind ?(pattern_mode=false) ist c =
     {ids; strict_check = Some ist.strict_check; pattern_mode;
      local_univs = { bound = local_univs; unb_univs = not ist.strict_check };
      tmp_scope; scopes = []; impls;
-     binder_block_names = Some (Some k); ntn_binding_ids = Id.Set.empty}
+     binder_block_names = Some (Some k); ntn_binding_ids = Id.Set.empty;
+     only_in_constr = false}
     (ltacvars, vl) c
 
 let interp_notation_constr env ?(impls=empty_internalization_env) nenv a =
@@ -3005,6 +3013,7 @@ let interp_notation_constr env ?(impls=empty_internalization_env) nenv a =
     ntnvar_used_as_binder = false;
     ntnvar_scopes = scopes;
     ntnvar_binding_ids = None;
+    ntnvar_is_only_in_constr = false;
     ntnvar_typ = typ;
   }
   in
@@ -3016,7 +3025,8 @@ let interp_notation_constr env ?(impls=empty_internalization_env) nenv a =
   let c = internalize env
       {ids; strict_check = Some true; pattern_mode = false;
        local_univs = empty_local_univs;
-       tmp_scope = []; scopes = []; impls; binder_block_names = None; ntn_binding_ids = Id.Set.empty}
+       tmp_scope = []; scopes = []; impls; binder_block_names = None; ntn_binding_ids = Id.Set.empty;
+       only_in_constr = false}
       (empty_ltac_sign, vl) a
   in
   (* Splits variables into those that are binding, bound, or both *)
@@ -3027,8 +3037,12 @@ let interp_notation_constr env ?(impls=empty_internalization_env) nenv a =
   let out_bindings = function None -> Id.Set.empty | Some a -> a in
   let unused = match reversible with NonInjective ids -> ids | _ -> [] in
   let vars = Id.Map.mapi (fun id status ->
-      (status.Genintern.ntnvar_used_as_binder && not (List.mem_f Id.equal id unused),
-       out_scope status.ntnvar_scopes, out_bindings status.ntnvar_binding_ids)) vl in
+      status.Genintern.ntnvar_used_as_binder && not (List.mem_f Id.equal id unused),
+      out_scope status.ntnvar_scopes,
+      out_bindings status.ntnvar_binding_ids,
+      status.ntnvar_is_only_in_constr)
+      vl
+  in
   (* Returns [a] and the ordered list of variables with their scopes *)
   vars, a, reversible
 
@@ -3052,7 +3066,8 @@ let default_internalization_env ids bound_univs impl_env =
    local_univs = { bound = bound_univs; unb_univs = true };
    tmp_scope = []; scopes = []; impls = impl_env;
    binder_block_names = Some (Some AbsPi);
-   ntn_binding_ids = Id.Set.empty}
+   ntn_binding_ids = Id.Set.empty;
+   only_in_constr = false}
 
 let intern_context env ~bound_univs impl_env binders =
   let lvar = (empty_ltac_sign, Id.Map.empty) in

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -214,36 +214,36 @@ let expand_notation_string ntn n =
 (* This contracts the special case of "{ _ }" for sumbool, sumor notations *)
 (* Remark: expansion of squash at definition is done in metasyntax.ml *)
 let contract_curly_brackets ntn subst =
-  match ntn with
-  | InCustomEntry _,_ -> ntn, subst
-  | InConstrEntry, ntn ->
-  let ntn' = ref ntn in
+  match ntn.ntn_entry with
+  | InCustomEntry _ -> ntn, subst
+  | InConstrEntry ->
+  let ntn' = ref ntn.ntn_key in
   let rec contract_squash n = function
     | [] -> []
-    | NtnTypeArg (NtnTypeArgConstr { CAst.v = CNotation (None,(InConstrEntry,"{ _ }"),[NtnTypeArg (NtnTypeArgConstr a)]) }) :: l ->
+    | NtnTypeArg (NtnTypeArgConstr { CAst.v = CNotation (None,{ntn_entry = InConstrEntry; ntn_key = "{ _ }"},[NtnTypeArg (NtnTypeArgConstr a)]) }) :: l ->
         ntn' := expand_notation_string !ntn' n;
         contract_squash n (NtnTypeArg (NtnTypeArgConstr a)::l)
     | a :: l ->
         a::contract_squash (n+1) l in
   let subst = contract_squash 0 subst in
   (* side effect; don't inline *)
-  (InConstrEntry,!ntn'), subst
+  mk_ntn_in_constr !ntn', subst
 
 let contract_curly_brackets_pat ntn subst =
-  match ntn with
-  | InCustomEntry _,_ -> ntn, subst
-  | InConstrEntry, ntn ->
-  let ntn' = ref ntn in
+  match ntn.ntn_entry with
+  | InCustomEntry _ -> ntn, subst
+  | InConstrEntry ->
+  let ntn' = ref ntn.ntn_key in
   let rec contract_squash n = function
     | [] -> []
-    | NtnTypeArg (NtnTypeArgPattern ({ CAst.v = CPatNotation (None,(InConstrEntry,"{ _ }"),[NtnTypeArg (NtnTypeArgPattern a)],[]) }, Explicit)) :: l ->
+    | NtnTypeArg (NtnTypeArgPattern ({ CAst.v = CPatNotation (None,{ntn_entry = InConstrEntry; ntn_key = "{ _ }"},[NtnTypeArg (NtnTypeArgPattern a)],[]) }, Explicit)) :: l ->
         ntn' := expand_notation_string !ntn' n;
         contract_squash n (NtnTypeArg (NtnTypeArgPattern a)::l)
     | a :: l ->
         a :: contract_squash (n+1) l in
   let subst = contract_squash 0 subst in
   (* side effect; don't inline *)
-  (InConstrEntry,!ntn'), subst
+  mk_ntn_in_constr !ntn', subst
 
 type local_univs = { bound : UnivNames.universe_binders; unb_univs : bool }
 
@@ -1873,12 +1873,12 @@ let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
         | Some (g,pl) -> DAst.make ?loc @@ RCPatCstr (g, pl)
         | None -> Loc.raise ?loc (InternalizationError (NotAConstructor qid))
       end
-    | CPatNotation (_,(InConstrEntry,"- _"),[NtnTypeArg (NtnTypeArgPattern (a,Explicit))],[]) when is_non_zero_pat a ->
+    | CPatNotation (_,{ntn_entry = InConstrEntry; ntn_key = "- _"},[NtnTypeArg (NtnTypeArgPattern (a,Explicit))],[]) when is_non_zero_pat a ->
       let p = match a.CAst.v with CPatPrim (Number (_, p)) -> p | _ -> assert false in
       let pat = Notation.interp_prim_token_cases_pattern_expr ?loc
           (check_allowed_ref_in_pat test_kind) (Number (SMinus,p)) scopes in
       rcp_of_glob scopes pat
-    | CPatNotation (_,(InConstrEntry,"( _ )"),[NtnTypeArg (NtnTypeArgPattern (a,Explicit))],[]) ->
+    | CPatNotation (_,{ntn_entry = InConstrEntry; ntn_key = "( _ )"},[NtnTypeArg (NtnTypeArgPattern (a,Explicit))],[]) ->
       in_pat test_kind scopes a
     | CPatNotation (_,ntn,fullargs,extrargs) ->
       let ntn, subst = contract_curly_brackets_pat ntn fullargs in
@@ -2799,10 +2799,10 @@ let cast self genv env lvar ?loc (c1, k, c2) =
 let notation self genv env lvar ?loc (_, ntn, args) =
   let intern env = intern self genv env lvar in
   match ntn, args with
-  | (InConstrEntry,"- _"), [NtnTypeArg (NtnTypeArgConstr a)] when is_non_zero a ->
+  | {ntn_entry = InConstrEntry; ntn_key = "- _"}, [NtnTypeArg (NtnTypeArgConstr a)] when is_non_zero a ->
     let p = match a.CAst.v with CPrim (Number (_, p)) -> p | _ -> assert false in
     intern env (CAst.make ?loc @@ CPrim (Number (SMinus,p)))
-  | (InConstrEntry,"( _ )"), [NtnTypeArg (NtnTypeArgConstr a)] ->
+  | {ntn_entry = InConstrEntry; ntn_key = "( _ )"}, [NtnTypeArg (NtnTypeArgConstr a)] ->
     intern env a
   | ntn, args ->
     let c = intern_notation intern env (snd lvar) loc ntn args in

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -213,37 +213,37 @@ let expand_notation_string ntn n =
 
 (* This contracts the special case of "{ _ }" for sumbool, sumor notations *)
 (* Remark: expansion of squash at definition is done in metasyntax.ml *)
-let contract_curly_brackets ntn (l,ll,bl,bll) =
+let contract_curly_brackets ntn subst =
   match ntn with
-  | InCustomEntry _,_ -> ntn,(l,ll,bl,bll)
+  | InCustomEntry _,_ -> ntn, subst
   | InConstrEntry, ntn ->
   let ntn' = ref ntn in
   let rec contract_squash n = function
     | [] -> []
-    | { CAst.v = CNotation (None,(InConstrEntry,"{ _ }"),([a],[],[],[])) } :: l ->
+    | NtnTypeArg (NtnTypeArgConstr { CAst.v = CNotation (None,(InConstrEntry,"{ _ }"),[NtnTypeArg (NtnTypeArgConstr a)]) }) :: l ->
         ntn' := expand_notation_string !ntn' n;
-        contract_squash n (a::l)
+        contract_squash n (NtnTypeArg (NtnTypeArgConstr a)::l)
     | a :: l ->
         a::contract_squash (n+1) l in
-  let l = contract_squash 0 l in
+  let subst = contract_squash 0 subst in
   (* side effect; don't inline *)
-  (InConstrEntry,!ntn'),(l,ll,bl,bll)
+  (InConstrEntry,!ntn'), subst
 
-let contract_curly_brackets_pat ntn (l,ll,bl) =
+let contract_curly_brackets_pat ntn subst =
   match ntn with
-  | InCustomEntry _,_ -> ntn,(l,ll,bl)
+  | InCustomEntry _,_ -> ntn, subst
   | InConstrEntry, ntn ->
   let ntn' = ref ntn in
   let rec contract_squash n = function
     | [] -> []
-    | { CAst.v = CPatNotation (None,(InConstrEntry,"{ _ }"),([a],[],[]),[]) } :: l ->
+    | NtnTypeArg (NtnTypeArgPattern ({ CAst.v = CPatNotation (None,(InConstrEntry,"{ _ }"),[NtnTypeArg (NtnTypeArgPattern a)],[]) }, Explicit)) :: l ->
         ntn' := expand_notation_string !ntn' n;
-        contract_squash n (a::l)
+        contract_squash n (NtnTypeArg (NtnTypeArgPattern a)::l)
     | a :: l ->
-        a::contract_squash (n+1) l in
-  let l = contract_squash 0 l in
+        a :: contract_squash (n+1) l in
+  let subst = contract_squash 0 subst in
   (* side effect; don't inline *)
-  (InConstrEntry,!ntn'),(l,ll,bl)
+  (InConstrEntry,!ntn'), subst
 
 type local_univs = { bound : UnivNames.universe_binders; unb_univs : bool }
 
@@ -715,18 +715,24 @@ let option_mem_assoc id = function
   | Some (id',c) -> Id.equal id id'
   | None -> false
 
-let find_fresh_name renaming (terms,termlists,binders,binderlists) avoid id =
-  let fold1 _ (c, _) accu = Id.Set.union (free_vars_of_constr_expr c) accu in
-  let fold2 _ (l, _) accu =
-    let fold accu c = Id.Set.union (free_vars_of_constr_expr c) accu in
-    List.fold_left fold accu l
-  in
-  let fold3 _ x accu = Id.Set.add x accu in
-  let fvs1 = Id.Map.fold fold1 terms avoid in
-  let fvs2 = Id.Map.fold fold2 termlists fvs1 in
-  let fvs3 = Id.Map.fold fold3 renaming fvs2 in
+let find_fresh_name renaming subst avoid id =
+  let fold_atom a accu =
+    let ids = match a with
+    | NtnTypeArgConstr c -> free_vars_of_constr_expr c
+    | NtnTypeArgPattern (c,bk) -> free_vars_of_cases_pattern_expr c
+    | NtnTypeArgBinders bl -> free_vars_of_local_binders bl in
+    Id.Set.union ids accu in
+  let rec fold_arg a accu =
+    match a with
+    | NtnTypeArg a -> fold_atom a accu
+    | NtnTypeArgList l -> List.fold_right fold_arg l accu
+    | NtnTypeArgTuple l -> List.fold_right fold_arg l accu in
+  let fold _ (a,_) accu = fold_arg a accu in
+  let fold_renaming _ x accu = Id.Set.add x accu in
+  let fvs1 = Id.Map.fold fold subst avoid in
+  let fvs2 = Id.Map.fold fold_renaming renaming fvs1 in
   (* TODO binders *)
-  next_ident_away_from id (fun id -> Id.Set.mem id fvs3)
+  next_ident_away_from id (fun id -> Id.Set.mem id fvs2)
 
 let is_patvar c =
   match DAst.get c with
@@ -777,21 +783,79 @@ let extract_pattern_from_binder b =
     let pat, na = cook_pattern (patl, id) in
     pat, na, bk, ty
 
-let traverse_binder intern_pat ntnvars (terms,_,binders,_ as subst) binderopt avoid (renaming,env) na ty =
+let check_explicit = function
+  | Explicit -> ()
+  | MaxImplicit | NonMaxImplicit -> user_err (str "Implicit arguments not supported.") (* shouldn't arrive *)
+
+let is_onlyident = function
+  | AsIdent | AsName -> true
+  | AsAnyPattern | AsStrictPattern -> false
+
+let only_ntn_binder_kind = function
+  | NtnBinderParsedAsConstr k -> is_onlyident k
+  | NtnBinderParsedAsBinder -> false
+  | NtnBinderParsedAsSomeBinderKind k -> is_onlyident k
+
+let cases_pattern_of_id {loc;v=id} =
+  CAst.make ?loc (CPatAtom (Some (qualid_of_ident ?loc id)))
+
+let cases_pattern_of_name {loc;v=na} =
+  let atom = match na with Name id -> Some (qualid_of_ident ?loc id) | Anonymous -> None in
+  CAst.make ?loc (CPatAtom atom)
+
+let cases_pattern_of_binder_as_constr a = function
+  | AsAnyPattern | AsStrictPattern -> coerce_to_cases_pattern_expr a
+  | AsIdent -> cases_pattern_of_id (coerce_to_id a)
+  | AsName -> cases_pattern_of_name (coerce_to_name a)
+
+let get_list f = function
+  | NtnTypeArgList l, NtnTypeVarList t -> List.map (fun a -> f (a,t)) l
+  | _ -> raise Not_found
+
+let get_term_opt = function
+  | NtnTypeArg (NtnTypeArgConstr c), NtnTypeVar (scopes, NtnTypeVarConstr _) -> Some (c, scopes)
+  | _ -> None
+
+let get_term v = match get_term_opt v with None -> raise Not_found | Some v -> v
+
+let get_pattern = function
+  | NtnTypeArg (NtnTypeArgPattern (c, bk)), NtnTypeVar (scopes, (NtnTypeVarPattern _ | NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern)) ->
+    check_explicit bk; (c : cases_pattern_expr), scopes
+  | _ -> raise Not_found
+
+let get_binder_opt = function
+  | NtnTypeArg (NtnTypeArgPattern (c, bk)),
+    NtnTypeVar (scopes, NtnTypeVarPattern (NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _ as k)) ->
+    Some ((c, bk), (only_ntn_binder_kind k, scopes))
+  | NtnTypeArg (NtnTypeArgConstr c), NtnTypeVar (scopes, NtnTypeVarPattern NtnBinderParsedAsConstr k) ->
+    Some ((cases_pattern_of_binder_as_constr c k, Explicit), (is_onlyident k, scopes))
+  | _ -> None
+
+let get_binder v = match get_binder_opt v with None -> raise Not_found | Some v -> v
+
+let get_binders = function
+  | NtnTypeArg (NtnTypeArgBinders bl), NtnTypeVar (scopes, NtnTypeVarBinders k) -> bl, scopes
+  | NtnTypeArgList l, NtnTypeVar (scopes, NtnTypeVarBinders (NtnBinderParsedAsConstr k)) ->
+    let bl = List.map (function NtnTypeArg (NtnTypeArgConstr a) -> CLocalPattern (cases_pattern_of_binder_as_constr a k)
+      | _ -> anomaly (str "Ill-typed notation variable.")) l in
+    bl, scopes
+  | _ -> raise Not_found
+
+let traverse_binder intern_pat ntnvars subst binderopt avoid (renaming,env) na ty =
   match na with
   | Anonymous -> (renaming,env), None, Anonymous, Explicit, set_type ty None
   | Name id ->
   let test_kind = test_kind_tolerant in
   try
     (* We instantiate binder name with patterns which may be parsed as terms *)
-    let pat = coerce_to_cases_pattern_expr (fst (Id.Map.find id terms)) in
+    let pat = coerce_to_cases_pattern_expr (fst (get_term (Id.Map.find id subst))) in
     let env,pat,bk,t = intern_pat test_kind ntnvars env Explicit pat in
     let pat, na = cook_pattern pat in
     (renaming,env), pat, na, bk, set_type ty (Some t)
   with Not_found ->
   try
     (* Trying to associate a pattern *)
-    let (pat,bk),(onlyident,scopes) = Id.Map.find id binders in
+    let (pat,bk),(onlyident,((_,scopes),ntn_binding_ids)) = get_binder (Id.Map.find id subst) in
     let env = set_env_scopes env scopes in
     if onlyident then
       (* Do not try to interpret a variable as a constructor *)
@@ -818,7 +882,7 @@ let traverse_binder intern_pat ntnvars (terms,_,binders,_ as subst) binderopt av
 
 type binder_action =
   | AddLetIn of lname * constr_expr * constr_expr option
-  | AddTermIter of (constr_expr * subscopes) Names.Id.Map.t
+  | AddTermIter of (notation_arg_type_expr * notation_var_type) Names.Id.Map.t
   | AddPreBinderIter of Id.t * local_binder_expr (* A binder to be internalized *)
   | AddBinderIter of Id.t * extended_glob_local_binder (* A binder already internalized - used for generalized binders *)
   | AddNList (* Insert a ".. term .." block *)
@@ -845,11 +909,11 @@ let terms_of_binders bl =
     | bnd :: l ->
       let loc = bnd.loc in
       begin match DAst.get bnd with
-      | GLocalAssum (Name id,_,_,_) -> (CAst.make ?loc @@ CRef (qualid_of_ident ?loc id, None)) :: extract_variables l
+      | GLocalAssum (Name id,_,_,_) -> (CAst.make ?loc @@ CRef (qualid_of_ident ?loc id, None), dummy_subscopes) :: extract_variables l
       | GLocalDef (Name id,_,_,_) -> extract_variables l
       | GLocalDef (Anonymous,_,_,_)
       | GLocalAssum (Anonymous,_,_,_) -> user_err Pp.(str "Cannot turn \"_\" into a term.")
-      | GLocalPattern (([u],_),_,_,_) -> term_of_pat u :: extract_variables l
+      | GLocalPattern (([u],_),_,_,_) -> (term_of_pat u,dummy_subscopes) :: extract_variables l
       | GLocalPattern ((_,_),_,_,_) -> error_cannot_coerce_disjunctive_pattern_term ?loc ()
       end
     | [] -> [] in
@@ -885,15 +949,15 @@ let rec adjust_env env = function
   | NRec _ | NSort _ | NProj _ | NInt _ | NFloat _ | NString _ | NArray _
   | NList _ | NBinderList _ -> env (* to be safe, but restart should be ok *)
 
-let subst_var loc intern_pat intern ntnvars binders (terms, binderopt, _terminopt) (renaming, env) id =
+let subst_var loc intern_pat intern ntnvars subst (terms, binderopt, _terminopt) (renaming, env) id =
   (* subst remembers the delimiters stack in the interpretation *)
   (* of the notations *)
   try
-    let (a,scopes) = Id.Map.find id terms in
+    let (a,((_,scopes),_)) = get_term (Id.Map.find id terms) in
     intern (set_env_scopes env scopes) a
   with Not_found ->
   try
-    let (pat,bk),(onlyident,scopes) = Id.Map.find id binders in
+    let (pat,bk),(onlyident,((_,scopes),_)) = get_binder (Id.Map.find id subst) in
     let env = set_env_scopes env scopes in
     let test_kind =
       if onlyident then test_kind_ident_in_notation
@@ -909,7 +973,7 @@ let subst_var loc intern_pat intern ntnvars binders (terms, binderopt, _terminop
     | Some (x,binder) when Id.equal x id ->
       let terms = terms_of_binders [binder] in
       assert (List.length terms = 1);
-      intern env (List.hd terms)
+      intern env (fst (List.hd terms))
     | _ -> raise Not_found
   with Not_found ->
     DAst.make ?loc (
@@ -920,7 +984,6 @@ let subst_var loc intern_pat intern ntnvars binders (terms, binderopt, _terminop
         GVar id)
 
 let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
-  let (terms,termlists,binders,binderlists) = subst in
   (* when called while defining a notation, avoid capturing the private binders
      of the expression by variables bound by the notation (see #3892) *)
   let avoid = Id.Map.domain ntnvars in
@@ -949,31 +1012,31 @@ let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
            DAst.make ?loc (GApp (DAst.make ?loc (GVar ldots_var), [aux_letin env (rest,terminator,iter)]))
         in
         aux_letin env (Option.get iteropt)
-    | NVar id -> subst_var loc intern_pat intern ntnvars binders subst' (renaming, env) id
+    | NVar id -> subst_var loc intern_pat intern ntnvars subst subst' (renaming, env) id
     | NList (x,y,iter,terminator,revert) ->
-      let l,(scopt,subscopes) =
+      let l =
         (* All elements of the list are in scopes (scopt,subscopes) *)
         try
-          let l,scopes = Id.Map.find x termlists in
-          (if revert then List.rev l else l),scopes
+          let l = get_list get_term (Id.Map.find x subst) in
+          if revert then List.rev l else l
         with Not_found ->
         try
-          let (bl,(scopt,subscopes)) = Id.Map.find x binderlists in
+          let (bl,(scopt,subscopes)) = get_binders (Id.Map.find x subst) in
           let env,bl' = List.fold_left (intern_local_binder_aux ~dump:true intern ntnvars) (env,[]) bl in
-          terms_of_binders (if revert then bl' else List.rev bl'),([],[])
+          terms_of_binders (if revert then bl' else List.rev bl')
         with Not_found ->
-          anomaly (Pp.str "Inconsistent substitution of recursive notation.") in
-      let select_iter a =
+          anomaly (Pp.str "Inconsistent substitution of recursive notation2.") in
+      let select_iter (a,scopes) =
         match a.CAst.v with
         | CRef (qid,None) when qualid_is_ident qid && Id.equal (qualid_basename qid) ldots_var -> AddNList
-        | _ -> AddTermIter (Id.Map.add y (a,(scopt,subscopes)) terms) in
+        | _ -> AddTermIter (Id.Map.add y (NtnTypeArg (NtnTypeArgConstr a), NtnTypeVar (scopes,NtnTypeVarConstr (* Does not natter: *) NtnConstrForConstrAndPatternForPattern)) subst) in
       let l = List.map select_iter l in
       aux (terms,None,Some (l,terminator,iter)) subinfos (NVar ldots_var)
     | NHole (knd) ->
       let knd = match knd with
       | GBinderType (Name id as na) ->
         let na =
-          try (coerce_to_name (fst (Id.Map.find id terms))).v
+          try (coerce_to_name (fst (get_term (Id.Map.find id terms)))).v
           with Not_found ->
           try Name (Id.Map.find id renaming)
           with Not_found -> na
@@ -983,12 +1046,12 @@ let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
       in
       DAst.make ?loc @@ GHole (knd)
     | NGenarg arg ->
-      let glob_of_term (c, scopes) =
+      let glob_of_term (c, ((_,scopes),_)) =
         let nenv = set_env_scopes env scopes in
         let gc = intern nenv c in
         gc
       in
-      let glob_of_binder ((c,_bk), (onlyident,(tmp_scope,subscopes))) =
+      let glob_of_binder ((c,_bk), (onlyident,((_,(tmp_scope,subscopes)),_))) =
         let nenv = {env with tmp_scope; scopes = subscopes @ env.scopes} in
         let test_kind =
           if onlyident then test_kind_ident_in_notation
@@ -1000,18 +1063,21 @@ let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
         | _ -> error_cannot_coerce_disjunctive_pattern_term ?loc:c.loc ()
       in
       let get_glob id =
-        match Id.Map.find_opt id terms with
-        | Some term -> Some (glob_of_term term)
-        | None -> match Id.Map.find_opt id binders with
-          | Some binder -> Some (glob_of_binder binder)
-          | None -> None
+        match Id.Map.find_opt id subst with
+        | None -> None
+        | Some a ->
+          match get_term_opt a with
+          | Some v -> Some (glob_of_term v)
+          | None -> match get_binder_opt a with
+            | Some v -> Some (glob_of_binder v)
+            | None -> None
       in
       let arg = Genintern.generic_substitute_notation ntnvars get_glob arg in
       DAst.make ?loc @@ GGenarg arg
     | NBinderList (x,y,iter,terminator,revert) ->
       (try
         (* All elements of the list are in scopes (scopt,subscopes) *)
-        let (bl,(scopt,subscopes)) = Id.Map.find x binderlists in
+        let (bl,(scopt,subscopes)) = get_binders (Id.Map.find x subst) in
         (* We flatten binders so that we can interpret them at substitution time *)
         let bl = flatten_binders bl in
         let bl = if revert then List.rev bl else bl in
@@ -1031,100 +1097,14 @@ let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
     | t ->
       glob_constr_of_notation_constr_with_binders ?loc
         (traverse_binder intern_pat ntnvars subst binderopt avoid) (aux subst') ~h:binder_status_fun subinfos t
-  in aux (terms,None,None) infos c
+  in aux (subst,None,None) infos c
 
 (* Turning substitution coming from parsing and based on production
    into a substitution for interpretation and based on binding/constr
    distinction *)
 
-let cases_pattern_of_id {loc;v=id} =
-  CAst.make ?loc (CPatAtom (Some (qualid_of_ident ?loc id)))
-
-let cases_pattern_of_name {loc;v=na} =
-  let atom = match na with Name id -> Some (qualid_of_ident ?loc id) | Anonymous -> None in
-  CAst.make ?loc (CPatAtom atom)
-
-let cases_pattern_of_binder_as_constr a = function
-  | AsAnyPattern | AsStrictPattern -> coerce_to_cases_pattern_expr a
-  | AsIdent -> cases_pattern_of_id (coerce_to_id a)
-  | AsName -> cases_pattern_of_name (coerce_to_name a)
-
-let is_onlyident = function
-  | AsIdent | AsName -> true
-  | AsAnyPattern | AsStrictPattern -> false
-
-let split_by_type ids (subst : constr_notation_substitution) =
-  let bind id scl l s =
-    match l with
-    | [] -> assert false
-    | a::l -> l, Id.Map.add id (a,scl) s in
-  let (terms,termlists,binders,binderlists),subst =
-    List.fold_left (fun ((terms,termlists,binders,binderlists),(terms',termlists',binders',binderlists')) (id,((_,scl),_,typ)) ->
-    match typ with
-    | NtnTypeConstr ->
-       let terms,terms' = bind id scl terms terms' in
-       (terms,termlists,binders,binderlists),(terms',termlists',binders',binderlists')
-    | NtnTypeBinder ntn_binder_kind ->
-       let onlyident,a,terms,binders =
-         match ntn_binder_kind with
-         | NtnBinderParsedAsConstr k ->
-           let a,terms = List.sep_first terms in
-           is_onlyident k, (cases_pattern_of_binder_as_constr a k, Explicit), terms, binders
-         | NtnBinderParsedAsBinder ->
-           let a,binders = List.sep_first binders in
-           false, a, terms, binders
-         | NtnBinderParsedAsSomeBinderKind k ->
-           let a,binders = List.sep_first binders in
-           is_onlyident k, a, terms, binders
-       in
-       let binders' = Id.Map.add id (a,(onlyident,scl)) binders' in
-       (terms,termlists,binders,binderlists),(terms',termlists',binders',binderlists')
-    | NtnTypeConstrList ->
-       let termlists,termlists' = bind id scl termlists termlists' in
-       (terms,termlists,binders,binderlists),(terms',termlists',binders',binderlists')
-    | NtnTypeBinderList ntn_binder_kind ->
-       let l,termlists,binderlists =
-         match ntn_binder_kind with
-         | NtnBinderParsedAsConstr k ->
-           let l,termlists = List.sep_first termlists in
-           List.map (fun a -> CLocalPattern (cases_pattern_of_binder_as_constr a k)) l, termlists, binderlists
-         | NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _ ->
-           let l,binderlists = List.sep_first binderlists in
-           l, termlists, binderlists
-       in
-       let binderlists' = Id.Map.add id (l,scl) binderlists' in
-       (terms,termlists,binders,binderlists),(terms',termlists',binders',binderlists'))
-                   (subst,(Id.Map.empty,Id.Map.empty,Id.Map.empty,Id.Map.empty)) ids in
-  assert (terms = [] && termlists = [] && binders = [] && binderlists = []);
-  subst
-
-let split_by_type_pat ?loc ids subst =
-  let bind id (_,scopes) l s =
-    match l with
-    | [] -> assert false
-    | a::l -> l, Id.Map.add id (a,scopes) s in
-  let bind_binders id (_,scopes) l s =
-    match l with
-    | [] -> assert false
-    | (a,Explicit)::l -> l, Id.Map.add id (a,scopes) s
-    | (a,(MaxImplicit|NonMaxImplicit))::l -> user_err (str "Implicit arguments not supported.") (* shouldn't arrive *)
-  in
-  let (terms,termlists,binders),subst =
-    List.fold_left (fun ((terms,termlists,binders),(terms',termlists')) (id,(scl,_,typ)) ->
-    match typ with
-    | NtnTypeConstr | NtnTypeBinder (NtnBinderParsedAsConstr _) ->
-       let terms,terms' = bind id scl terms terms' in
-       (terms,termlists,binders),(terms',termlists')
-    | NtnTypeConstrList ->
-       let termlists,termlists' = bind id scl termlists termlists' in
-       (terms,termlists,binders),(terms',termlists')
-    | NtnTypeBinder (NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _) ->
-       let binders,terms' = bind_binders id scl binders terms' in
-       (terms,termlists,binders),(terms',termlists')
-    | NtnTypeBinderList _ -> error_invalid_pattern_notation ?loc ())
-                   (subst,(Id.Map.empty,Id.Map.empty)) ids in
-  assert (terms = [] && termlists = [] && binders = []);
-  subst
+let split_by_type ids subst =
+  List.fold_left2 (fun subst (id,typ) arg -> Id.Map.add id (arg,typ) subst) Id.Map.empty ids subst
 
 let intern_notation intern env ntnvars loc ntn fullargs =
   (* Adjust to parsing of { } *)
@@ -1373,7 +1353,7 @@ let intern_qualid ?(no_secvar=false) qid intern env ntnvars us args =
       if List.length args < nids then error_not_enough_arguments ?loc;
       let args1,args2 = List.chop nids args in
       check_no_explicitation args1;
-      let subst = split_by_type ids (List.map fst args1,[],[],[]) in
+      let subst = split_by_type ids (List.map (fun (a,_) -> NtnTypeArg (NtnTypeArgConstr a)) args1) in
       let infos = (Id.Map.empty, env) in
       let c = instantiate_notation_constr loc intern (intern_cases_pattern_as_binder ~dump:true intern) ntnvars subst infos c in
       let loc = c.loc in
@@ -1426,7 +1406,7 @@ let intern_qualid_for_pattern test_global intern_not qid pats =
         let nvars = List.length vars in
         if List.length pats < nvars then error_not_enough_arguments ?loc:qid.loc;
         let pats1,pats2 = List.chop nvars pats in
-        let subst = split_by_type_pat vars (pats1,[],[]) in
+        let subst = split_by_type vars (List.map (fun c -> NtnTypeArg (NtnTypeArgPattern (c, Explicit))) pats1) in
         let args = List.map (intern_not subst) args in
         Some (g, Some args, pats2)
       | _ -> None in
@@ -1887,18 +1867,18 @@ let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
         | Some (g,pl) -> DAst.make ?loc @@ RCPatCstr (g, pl)
         | None -> Loc.raise ?loc (InternalizationError (NotAConstructor qid))
       end
-    | CPatNotation (_,(InConstrEntry,"- _"),([a],[],[]),[]) when is_non_zero_pat a ->
+    | CPatNotation (_,(InConstrEntry,"- _"),[NtnTypeArg (NtnTypeArgPattern (a,Explicit))],[]) when is_non_zero_pat a ->
       let p = match a.CAst.v with CPatPrim (Number (_, p)) -> p | _ -> assert false in
       let pat = Notation.interp_prim_token_cases_pattern_expr ?loc
           (check_allowed_ref_in_pat test_kind) (Number (SMinus,p)) scopes in
       rcp_of_glob scopes pat
-    | CPatNotation (_,(InConstrEntry,"( _ )"),([a],[],[]),[]) ->
+    | CPatNotation (_,(InConstrEntry,"( _ )"),[NtnTypeArg (NtnTypeArgPattern (a,Explicit))],[]) ->
       in_pat test_kind scopes a
     | CPatNotation (_,ntn,fullargs,extrargs) ->
-      let ntn,(terms,termlists,binders) = contract_curly_brackets_pat ntn fullargs in
+      let ntn, subst = contract_curly_brackets_pat ntn fullargs in
       let ((ids',c),df) = Notation.interp_notation ?loc ntn scopes in
-      let subst = split_by_type_pat ?loc ids' (terms,termlists,binders) in
-      Dumpglob.dump_notation_location (patntn_loc ?loc fullargs ntn) ntn df;
+      let subst = split_by_type ids' subst in
+      Dumpglob.dump_notation_location (ntn_loc ?loc fullargs ntn) ntn df;
       in_not test_kind loc scopes subst extrargs c
     | CPatDelimiters (depth, key, e) ->
       let sc = find_delimiters_scope ?loc key in
@@ -1973,14 +1953,14 @@ let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
     | _, _, [], [] -> []
     | _ -> assert false in
     ntnpats_with_letin @ aux imps subscopes tags pats
-  and in_not test_kind loc scopes (terms,termlists as fullsubst) args = function
+  and in_not test_kind loc scopes subst args = function
     | NVar id ->
       begin
         (* subst remembers the delimiters stack in the interpretation *)
         (* of the notations *)
         try
-          let (a,(scopt,subscopes)) = Id.Map.find id terms in
-          in_pat test_kind (scopt,subscopes@snd scopes) (mkAppPattern ?loc a args)
+          let pat,((_,(scopt,subscopes)),_) = get_pattern (Id.Map.find id subst) in
+          in_pat test_kind (scopt,subscopes@snd scopes) (mkAppPattern ?loc pat args)
         with Not_found ->
           if Id.equal id ldots_var then
             if List.is_empty args then
@@ -1997,7 +1977,7 @@ let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
       DAst.make ?loc @@ RCPatCstr (g, in_patargs ?loc scopes g ~expanded:true ~no_impl:false [] args)
     | NApp (NRef (g,_),ntnpl) ->
       ensure_kind test_kind ?loc g;
-      let ntnpl = List.map (in_not test_kind_inner loc scopes fullsubst []) ntnpl in
+      let ntnpl = List.map (in_not test_kind_inner loc scopes subst []) ntnpl in
       let no_impl =
         (* Convention: if notation is @f, encoded as NApp(Nref g,[]), then
            implicit arguments are not inherited *)
@@ -2008,11 +1988,11 @@ let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
         (strbrk "Application of arguments to a recursive notation not supported in patterns.");
       (try
          (* All elements of the list are in scopes (scopt,subscopes) *)
-         let (l,(scopt,subscopes)) = Id.Map.find x termlists in
-         let termin = in_not test_kind_inner loc scopes fullsubst [] terminator in
-         List.fold_right (fun a t ->
-           let nterms = Id.Map.add y (a, (scopt, subscopes)) terms in
-           let u = in_not test_kind_inner loc scopes (nterms, termlists) [] iter in
+         let l = get_list get_pattern (Id.Map.find x subst) in
+         let termin = in_not test_kind_inner loc scopes subst [] terminator in
+         List.fold_right (fun (a, scl) t ->
+           let subst = Id.Map.add y (NtnTypeArg (NtnTypeArgPattern (a, Explicit)), NtnTypeVar (scl, NtnTypeVarPattern (NtnBinderParsedAsConstr AsAnyPattern))) subst in
+           let u = in_not test_kind_inner loc scopes subst [] iter in
            subst_pat_iterator ldots_var t u)
            (if revert then List.rev l else l) termin
        with Not_found ->
@@ -2188,7 +2168,7 @@ module Interner = struct
   ; evar : t -> (Glob_term.existential_name CAst.t * (lident * constr_expr) list) fn
   ; sort : t -> sort_expr fn
   ; cast : t -> (constr_expr * Constr.cast_kind option * constr_expr) fn
-  ; notation : t -> (notation_with_optional_scope option * notation * constr_notation_substitution) fn
+  ; notation : t -> (notation_with_optional_scope option * notation * notation_substitution) fn
   ; generalization : t -> (Glob_term.binding_kind * constr_expr) fn
   ; prim : t -> prim_token fn
   ; delimiters : t -> (delimiter_depth * string * constr_expr) fn
@@ -2813,10 +2793,10 @@ let cast self genv env lvar ?loc (c1, k, c2) =
 let notation self genv env lvar ?loc (_, ntn, args) =
   let intern env = intern self genv env lvar in
   match ntn, args with
-  | (InConstrEntry,"- _"), ([a],[],[],[]) when is_non_zero a ->
+  | (InConstrEntry,"- _"), [NtnTypeArg (NtnTypeArgConstr a)] when is_non_zero a ->
     let p = match a.CAst.v with CPrim (Number (_, p)) -> p | _ -> assert false in
     intern env (CAst.make ?loc @@ CPrim (Number (SMinus,p)))
-  | (InConstrEntry,"( _ )"), ([a],[],[],[]) ->
+  | (InConstrEntry,"( _ )"), [NtnTypeArg (NtnTypeArgConstr a)] ->
     intern env a
   | ntn, args ->
     let c = intern_notation intern env (snd lvar) loc ntn args in

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -194,7 +194,7 @@ val is_global : Id.t -> bool
     guaranteed to have the same domain as the input one. *)
 val interp_notation_constr : env -> ?impls:internalization_env ->
   notation_interp_env -> constr_expr ->
-  (bool * subscopes * Id.Set.t) Id.Map.t * notation_constr * reversibility_status
+  (bool * subscopes * Id.Set.t * bool) Id.Map.t * notation_constr * reversibility_status
 
 (** Idem but to glob_constr (weaker check of binders) *)
 

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -124,7 +124,7 @@ module Interner : sig
   ; evar : t -> (Glob_term.existential_name CAst.t * (lident * constr_expr) list) fn
   ; sort : t -> sort_expr fn
   ; cast : t -> (constr_expr * Constr.cast_kind option * constr_expr) fn
-  ; notation : t -> (notation_with_optional_scope option * notation * constr_notation_substitution) fn
+  ; notation : t -> (notation_with_optional_scope option * notation * notation_substitution) fn
   ; generalization : t -> (Glob_term.binding_kind * constr_expr) fn
   ; prim : t -> prim_token fn
   ; delimiters : t -> (delimiter_depth * string * constr_expr) fn

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -238,7 +238,7 @@ val is_global : Id.t -> bool
     guaranteed to have the same domain as the input one. *)
 val interp_notation_constr : env -> ?impls:internalization_env ->
   notation_interp_env -> constr_expr ->
-  (bool * subscopes * Id.Set.t) Id.Map.t * notation_constr * reversibility_status
+  (bool * subscopes * Id.Set.t * bool) Id.Map.t * notation_constr * reversibility_status
 
 (** Typically used to internalize a term inside a tactic. *)
 val intern_core : typing_constraint -> ?pattern_mode:bool ->

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -239,7 +239,7 @@ val is_global : Id.t -> bool
     guaranteed to have the same domain as the input one. *)
 val interp_notation_constr : env -> ?impls:internalization_env ->
   notation_interp_env -> constr_expr ->
-  (bool * subscopes * Id.Set.t) Id.Map.t * notation_constr * reversibility_status
+  (bool * subscopes * Id.Set.t * bool) Id.Map.t * notation_constr * reversibility_status
 
 (** Typically used to internalize a term inside a tactic. *)
 val intern_core : typing_constraint -> ?pattern_mode:bool ->

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -108,7 +108,7 @@ module Interner : sig
   ; evar : t -> (Glob_term.existential_name CAst.t * (lident * constr_expr) list) fn
   ; sort : t -> sort_expr fn
   ; cast : t -> (constr_expr * Constr.cast_kind option * constr_expr) fn
-  ; notation : t -> (notation_with_optional_scope option * notation * constr_notation_substitution) fn
+  ; notation : t -> (notation_with_optional_scope option * notation * notation_substitution) fn
   ; generalization : t -> (Glob_term.binding_kind * constr_expr) fn
   ; prim : t -> prim_token fn
   ; delimiters : t -> (delimiter_depth * string * constr_expr) fn

--- a/interp/dumpglob.ml
+++ b/interp/dumpglob.ml
@@ -190,7 +190,7 @@ let dump_modref ?loc mp ty =
 let dump_libref ?loc dp ty =
   dump_ref ?loc (Names.DirPath.to_string dp) "<>" "<>" ty
 
-let cook_notation (from,df) sc =
+let cook_notation Constrexpr.{ ntn_entry = from; ntn_key = df } sc =
   (* We encode notations so that they are space-free and still human-readable *)
   (* - all spaces are replaced by _                                           *)
   (* - all _ denoting a non-terminal symbol are replaced by x                 *)

--- a/interp/dumpglob.ml
+++ b/interp/dumpglob.ml
@@ -208,7 +208,7 @@ let dump_modref ?loc mp ty =
 let dump_libref ?loc dp ty =
   dump_ref ?loc (Names.DirPath.to_string dp) "<>" "<>" ty
 
-let cook_notation (from,df) sc =
+let cook_notation Constrexpr.{ ntn_entry = from; ntn_key = df } sc =
   (* We encode notations so that they are space-free and still human-readable *)
   (* - all spaces are replaced by _                                           *)
   (* - all _ denoting a non-terminal symbol are replaced by x                 *)

--- a/interp/genintern.ml
+++ b/interp/genintern.ml
@@ -18,6 +18,7 @@ type ntnvar_status = {
   mutable ntnvar_used_as_binder : bool;
   mutable ntnvar_scopes : Notation_term.subscopes option;
   mutable ntnvar_binding_ids : Notation_term.notation_var_binders option;
+  mutable ntnvar_is_only_in_constr: bool;
   ntnvar_typ : Notation_term.notation_var_internalization_type;
 }
 

--- a/interp/genintern.mli
+++ b/interp/genintern.mli
@@ -19,6 +19,7 @@ type ntnvar_status = {
   mutable ntnvar_used_as_binder : bool;
   mutable ntnvar_scopes : Notation_term.subscopes option;
   mutable ntnvar_binding_ids : Notation_term.notation_var_binders option;
+  mutable ntnvar_is_only_in_constr: bool;
   ntnvar_typ : Notation_term.notation_var_internalization_type;
 }
 

--- a/interp/implicit_quantifiers.ml
+++ b/interp/implicit_quantifiers.ml
@@ -92,9 +92,6 @@ let free_vars_of_constr_expr c ?(bound=Id.Set.empty) l =
   let rec aux bdvars l c = match CAst.(c.v) with
     | CRef (qid,_) when qualid_is_ident qid ->
       found c.CAst.loc (qualid_basename qid) bdvars l
-    | CNotation (_,(InConstrEntry,"{ _ : _ | _ }"), ({ CAst.v = CRef (qid,_) } :: _, [], [], [])) when
-        qualid_is_ident qid && not (Id.Set.mem (qualid_basename qid) bdvars) ->
-        Constrexpr_ops.fold_constr_expr_with_binders (fun a l -> Id.Set.add a l) aux (Id.Set.add (qualid_basename qid) bdvars) l c
     | _ -> Constrexpr_ops.fold_constr_expr_with_binders (fun a l -> Id.Set.add a l) aux bdvars l c
   in aux bound l c
 

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -2325,9 +2325,9 @@ let rec raw_analyze_anonymous_notation_tokens = function
 (* Interpret notations with a recursive component *)
 
 type notation_symbols = {
-  recvars : (Id.t * Id.t) list; (* pairs (x,y) as in [ x ; .. ; y ] *)
-  mainvars : Id.t list; (* variables non involved in a recursive pattern *)
-  symbols : symbol list; (* the decomposition of the notation into terminals and nonterminals *)
+  mainvars : Id.t list; (* names of "toplevel" non-terminals *)
+  maintypes : Id.t notation_raw_type list; (* types of "toplevel" non-terminals *)
+  symbols : symbol list; (* the decomposition of the notation into terminals and nonterminals; there, recursive patterns refer to the left-hand variable *)
 }
 
 let out_nt = function NonTerminal x -> x | _ -> assert false
@@ -2352,36 +2352,33 @@ let rec find_pattern nt xl = function
   | ((SProdList _ | NonTerminal _) :: _), _ | _, (SProdList _ :: _) ->
       anomaly (Pp.str "Only Terminal or Break expected on left, non-SProdList on right.")
 
-let rec interp_list_parser hd = function
-  | [] -> [], List.rev hd
+let rec interp_list_parser hdvars hd = function
+  | [] -> List.rev hdvars, List.rev hd
   | NonTerminal id :: tl when Id.equal id Notation_ops.ldots_var ->
       if List.is_empty hd then user_err Pp.(str msg_expected_form_of_recursive_notation);
       let hd = List.rev hd in
       let ((x,y,sl),tl') = find_pattern (List.hd hd) [] (List.tl hd,tl) in
-      let xyl,tl'' = interp_list_parser [] tl' in
+      let xyl, tl'' = interp_list_parser [] [] tl' in
       (* We remember each pair of variable denoting a recursive part to *)
       (* remove the second copy of it afterwards *)
-      (x,y)::xyl, SProdList (x,sl) :: tl''
+      (x, NtnRawTypeVarList (NtnRawTypeVar (x, y))) :: xyl, SProdList (x,sl) :: tl''
   | (Terminal _ | Break _) as s :: tl ->
       if List.is_empty hd then
-        let yl,tl' = interp_list_parser [] tl in
+        let yl,tl' = interp_list_parser [] [] tl in
         yl, s :: tl'
       else
-        interp_list_parser (s::hd) tl
-  | NonTerminal _ as x :: tl ->
-      let xyl,tl' = interp_list_parser [x] tl in
-      xyl, List.rev_append hd tl'
+        interp_list_parser hdvars (s::hd) tl
+  | NonTerminal id as x :: tl ->
+      let xyl,tl' = interp_list_parser [id, NtnRawTypeVar id] [x] tl in
+      List.rev_append hdvars xyl, List.rev_append hd tl'
   | SProdList _ :: _ -> anomaly (Pp.str "Unexpected SProdList in interp_list_parser.")
-
-let get_notation_vars l =
-  List.map_filter (function NonTerminal id | SProdList (id,_) -> Some id | _ -> None) l
 
 let decompose_raw_notation ntn =
   let l = split_notation_string ntn in
   let symbols = raw_analyze_notation_tokens l in
-  let recvars, symbols = interp_list_parser [] symbols in
-  let mainvars = get_notation_vars symbols in
-  {recvars; mainvars; symbols}
+  let mainvartyps, symbols = interp_list_parser [] [] symbols in
+  let mainvars, maintypes = List.split mainvartyps in
+  {mainvars; maintypes; symbols}
 
 let interpret_notation_string ntn =
   (* We collect the possible interpretations of a notation string depending on whether it is
@@ -2398,7 +2395,7 @@ let interpret_notation_string ntn =
       (* Includes the case of only a subset of tokens or an "x 'U' y"-style format *)
       raw_analyze_notation_tokens toks
   in
-  let _,toks = interp_list_parser [] toks in
+  let _,toks = interp_list_parser [] [] toks in
   let _,ntn' = make_notation_key None toks in
   ntn'
 
@@ -2418,8 +2415,8 @@ let is_approximation ntn ntn' =
     | NonTerminal _ :: toks1, [] -> aux' toks1 l2full l2full toks2 || aux toks1 toks2
     | _ -> false
   in
-  let _,toks = interp_list_parser [] (raw_analyze_anonymous_notation_tokens (split_notation_string ntn)) in
-  let _,toks' = interp_list_parser [] (raw_analyze_anonymous_notation_tokens (split_notation_string ntn')) in
+  let _,toks = interp_list_parser [] [] (raw_analyze_anonymous_notation_tokens (split_notation_string ntn)) in
+  let _,toks' = interp_list_parser [] [] (raw_analyze_anonymous_notation_tokens (split_notation_string ntn')) in
   aux toks toks'
 
 let match_notation_key strict ntn ntn' =
@@ -2494,7 +2491,11 @@ let interp_notation_as_global_reference_expanded ?loc ~head test ntn sc =
 let interp_notation_as_global_reference ?loc ~head test ntn sc =
   let _,_,_,_,ref = interp_notation_as_global_reference_expanded ?loc ~head test ntn sc in ref
 
-let pr_id_infos (id, ((level,(tmp_scopes, scopes)), under_binders, kind)) =
+let pr_id_infos (id, var_type) =
+  match var_type with
+  | NtnTypeVarList _ | NtnTypeVarTuple _ -> None (* TODO *)
+  | NtnTypeVar (((level,(tmp_scopes, scopes)), under_binders), kind) ->
+  (* XXX level? kind? *)
   let scopes = List.map (fun x -> "_"^x) tmp_scopes @ scopes in
   match scopes with
   | [] -> None
@@ -2526,7 +2527,7 @@ let locate_notation prglob ntn scope =
     prlist_with_sep fnl (fun (ntn,l) ->
       let scope = find_default ntn scopes in
       prlist_with_sep fnl
-        (fun (sc,(on_parsing,on_printing,{ not_interp  = (ids, r); not_location = ((libpath,secpath), df) })) ->
+        (fun (sc,(on_parsing,on_printing,{ not_interp = (ids, r); not_location = ((libpath,secpath), df) })) ->
           let full_path = DirPath.make (DirPath.repr secpath @ DirPath.repr libpath) in
           hov 2 (
             str "Notation" ++ spc() ++

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -52,7 +52,7 @@ let notation_cat = Libobject.create_category "notations"
     expression, set this scope to be the current scope
 *)
 
-let pr_notation (from,ntn) = qstring ntn ++ match from with InConstrEntry -> mt () | InCustomEntry s -> str " in custom " ++ str s
+let pr_notation ntn = qstring ntn.ntn_key ++ match ntn.ntn_entry with InConstrEntry -> mt () | InCustomEntry s -> str " in custom " ++ str s
 
 module NotationOrd =
   struct
@@ -1473,10 +1473,12 @@ let find_notation ntn sc =
   | OnlyParsingData (true,data) | ParsingAndPrintingData (true,_,data) -> data
   | _ -> raise Not_found
 
-let notation_of_prim_token = function
-  | Constrexpr.Number (SPlus,n) -> InConstrEntry, NumTok.Unsigned.sprint n
-  | Constrexpr.Number (SMinus,n) -> InConstrEntry, "- "^NumTok.Unsigned.sprint n
-  | String s -> InConstrEntry, String.quote_coq_string s
+let notation_of_prim_token p =
+  let k = match p with
+    | Constrexpr.Number (SPlus,n) -> NumTok.Unsigned.sprint n
+    | Constrexpr.Number (SMinus,n) -> "- "^NumTok.Unsigned.sprint n
+    | Constrexpr.String s -> String.quote_coq_string s in
+  Constrexpr.{ ntn_entry = InConstrEntry; ntn_key = k }
 
 let find_prim_token check_allowed ?loc p sc =
   (* Try for a user-defined numerical notation *)
@@ -1501,7 +1503,8 @@ let find_prim_token check_allowed ?loc p sc =
 
 let interp_prim_token_gen ?loc g p local_scopes =
   let scopes = make_current_scopes local_scopes in
-  let p_as_ntn = try notation_of_prim_token p with Not_found -> InConstrEntry,"" in
+  let p_as_ntn = try notation_of_prim_token p with Not_found ->
+    Constrexpr.{ ntn_entry = InConstrEntry; ntn_key = "" } in
   try
     let pat, sc = find_interpretation p_as_ntn (find_prim_token ?loc g p) scopes in
     pat, sc
@@ -2112,8 +2115,8 @@ let rec string_of_symbol = function
      let l = List.flatten (List.map string_of_symbol l) in "_"::l@".."::l@["_"]
   | Break _ -> []
 
-let make_notation_key from symbols =
-  (from,String.concat " " (List.flatten (List.map string_of_symbol symbols)))
+let make_notation_key ntn_entry symbols =
+  Constrexpr.{ ntn_entry; ntn_key = String.concat " " (List.flatten (List.map string_of_symbol symbols)) }
 
 let decompose_notation_pure_key s =
   let len = String.length s in
@@ -2142,8 +2145,8 @@ let decompose_notation_pure_key s =
   in
     decomp_ntn [] 0
 
-let decompose_notation_key (from,s) =
-  from, decompose_notation_pure_key s
+let decompose_notation_key ntn =
+  ntn.ntn_entry, decompose_notation_pure_key ntn.ntn_key
 
 let is_prim_token_constant_in_constr (entry, symbs) =
   match entry, List.filter (function Break _ -> false | _ -> true) symbs with
@@ -2156,7 +2159,7 @@ let is_prim_token_constant_in_constr (entry, symbs) =
 let level_of_notation ntn =
   if is_prim_token_constant_in_constr (decompose_notation_key ntn) then
     (* A primitive notation *)
-    ({ notation_entry = fst ntn; notation_level = 0}, []) (* TODO: string notations*)
+    ({ notation_entry = ntn.ntn_entry; notation_level = 0}, []) (* TODO: string notations*)
   else
     NotationMap.find ntn !notation_level_map
 
@@ -2396,8 +2399,8 @@ let interpret_notation_string ntn =
       raw_analyze_notation_tokens toks
   in
   let _,toks = interp_list_parser [] [] toks in
-  let _,ntn' = make_notation_key None toks in
-  ntn'
+  let ntn' = make_notation_key InConstrEntry toks in
+  ntn'.ntn_key
 
 (* Tell if a non-recursive notation is an instance of a recursive one *)
 let is_approximation ntn ntn' =
@@ -2432,7 +2435,7 @@ let match_notation_key strict ntn ntn' =
 
 let browse_notation strict ntn map =
   let ntn = interpret_notation_string ntn in
-  let find (from,ntn') = match_notation_key strict ntn ntn' in
+  let find ntn' = match_notation_key strict ntn ntn'.ntn_key in
   let l =
     String.Map.fold
       (fun scope_name sc ->
@@ -2441,7 +2444,7 @@ let browse_notation strict ntn map =
           then List.map (fun d -> (ntn,scope_name,d)) (extract_notation_data data) @ l
           else l) sc.notations)
       map [] in
-  List.sort (fun x y -> String.compare (snd (pi1 x)) (snd (pi1 y))) l
+  List.sort (fun x y -> String.compare (pi1 x).ntn_key (pi1 y).ntn_key) l
 
 let global_reference_of_notation ~head test (ntn,sc,(on_parsing,on_printing,{not_interp = (_,c as interp); not_location = (_, df)})) =
   match c with
@@ -2667,17 +2670,18 @@ let toggle_notations_in_scope ~on found inscope ntn_pattern ntns =
     (* shortcut *)
     List.fold_right (fun ntn_entry ntns ->
       try
-        NotationMap.add (ntn_entry, ntn)
+        let ntn = Constrexpr.{ ntn_entry; ntn_key = ntn } in
+        NotationMap.add ntn
           (toggle_notations_by_interpretation ~on found ntn_pattern
-             (inscope,(ntn_entry,ntn))
-             (NotationMap.find (ntn_entry, ntn) ntns))
+             (inscope, ntn)
+             (NotationMap.find ntn ntns))
           ntns
       with Not_found -> ntns)
         ntn_entries ntns
     (* Deal with full notations *)
   | ntn_entries, ntn_rule -> (* This is the table of notations, not of abbreviations *)
-    NotationMap.mapi (fun (ntn_entry,ntn_key' as ntn') data ->
-        if match_notation_entry ntn_entries ntn_entry && match_notation_rule ntn_rule ntn_key' then
+    NotationMap.mapi (fun ntn' data ->
+        if match_notation_entry ntn_entries ntn'.ntn_entry && match_notation_rule ntn_rule ntn'.ntn_key then
           toggle_notations_by_interpretation ~on found ntn_pattern
             (inscope,ntn')
             data
@@ -2752,7 +2756,7 @@ let toggle_notations ~on ~all ?(verbose=true) prglob ntn_pattern =
           str ":" ++ fnl () ++
           prlist_with_sep fnl (fun (kind, (vars,a as i)) ->
             match kind with
-            | Inl (l, (sc, (entry, _))) ->
+            | Inl (l, (sc, { ntn_entry = entry })) ->
               let sc = match sc with NotationInScope sc -> sc | LastLonelyNotation -> default_scope in
               let data = { not_interp = i; not_location = l; not_user_warns = None } in
               hov 0 (str "Notation " ++ pr_notation_data prglob (Some true,Some true,data) ++

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -44,7 +44,7 @@ let notation_cat = Libobject.create_category "notations"
     expression, set this scope to be the current scope
 *)
 
-let pr_notation (from,ntn) = qstring ntn ++ match from with InConstrEntry -> mt () | InCustomEntry s -> str " in custom " ++ Nametab.CustomEntries.pr s
+let pr_notation ntn = qstring ntn.ntn_key ++ match ntn.ntn_entry with InConstrEntry -> mt () | InCustomEntry s -> str " in custom " ++ Nametab.CustomEntries.pr s
 
 module NotationOrd =
   struct
@@ -509,10 +509,12 @@ let find_notation ntn sc =
   | OnlyParsingData (true,data) | ParsingAndPrintingData (true,_,data) -> data
   | _ -> raise Not_found
 
-let notation_of_prim_token = function
-  | Constrexpr.Number (SPlus,n) -> InConstrEntry, NumTok.Unsigned.sprint n
-  | Constrexpr.Number (SMinus,n) -> InConstrEntry, "- "^NumTok.Unsigned.sprint n
-  | String s -> InConstrEntry, String.quote_coq_string s
+let notation_of_prim_token p =
+  let k = match p with
+    | Constrexpr.Number (SPlus,n) -> NumTok.Unsigned.sprint n
+    | Constrexpr.Number (SMinus,n) -> "- "^NumTok.Unsigned.sprint n
+    | Constrexpr.String s -> String.quote_coq_string s in
+  Constrexpr.{ ntn_entry = InConstrEntry; ntn_key = k }
 
 let find_prim_token check_allowed ?loc p sc =
   (* Try for a user-defined numerical notation *)
@@ -532,7 +534,8 @@ let find_prim_token check_allowed ?loc p sc =
 
 let interp_prim_token_gen ?loc g p local_scopes =
   let scopes = make_current_scopes local_scopes in
-  let p_as_ntn = try notation_of_prim_token p with Not_found -> InConstrEntry,"" in
+  let p_as_ntn = try notation_of_prim_token p with Not_found ->
+    Constrexpr.{ ntn_entry = InConstrEntry; ntn_key = "" } in
   try
     let pat, sc = find_interpretation p_as_ntn (find_prim_token ?loc g p) scopes in
     pat
@@ -1180,8 +1183,8 @@ let rec string_of_symbol = function
      let l = List.flatten (List.map string_of_symbol l) in "_"::l@".."::l@["_"]
   | Break _ -> []
 
-let make_notation_key from symbols =
-  (from,String.concat " " (List.flatten (List.map string_of_symbol symbols)))
+let make_notation_key ntn_entry symbols =
+  Constrexpr.{ ntn_entry; ntn_key = String.concat " " (List.flatten (List.map string_of_symbol symbols)) }
 
 let decompose_notation_pure_key s =
   let len = String.length s in
@@ -1210,8 +1213,8 @@ let decompose_notation_pure_key s =
   in
     decomp_ntn [] 0
 
-let decompose_notation_key (from,s) =
-  from, decompose_notation_pure_key s
+let decompose_notation_key ntn =
+  ntn.ntn_entry, decompose_notation_pure_key ntn.ntn_key
 
 let is_prim_token_constant_in_constr (entry, symbs) =
   match entry, List.filter (function Break _ -> false | _ -> true) symbs with
@@ -1224,7 +1227,7 @@ let is_prim_token_constant_in_constr (entry, symbs) =
 let level_of_notation ntn =
   if is_prim_token_constant_in_constr (decompose_notation_key ntn) then
     (* A primitive notation *)
-    ({ notation_entry = fst ntn; notation_level = 0}, []) (* TODO: string notations*)
+    ({ notation_entry = ntn.ntn_entry; notation_level = 0}, []) (* TODO: string notations*)
   else
     NotationMap.find ntn !notation_level_map
 
@@ -1464,8 +1467,8 @@ let interpret_notation_string ntn =
       raw_analyze_notation_tokens toks
   in
   let _,toks = interp_list_parser [] [] toks in
-  let _,ntn' = make_notation_key None toks in
-  ntn'
+  let ntn' = make_notation_key InConstrEntry toks in
+  ntn'.ntn_key
 
 (* Tell if a non-recursive notation is an instance of a recursive one *)
 let is_approximation ntn ntn' =
@@ -1500,7 +1503,7 @@ let match_notation_key strict ntn ntn' =
 
 let browse_notation strict ntn map =
   let ntn = interpret_notation_string ntn in
-  let find (from,ntn') = match_notation_key strict ntn ntn' in
+  let find ntn' = match_notation_key strict ntn ntn'.ntn_key in
   let l =
     String.Map.fold
       (fun scope_name sc ->
@@ -1509,7 +1512,7 @@ let browse_notation strict ntn map =
           then List.map (fun d -> (ntn,scope_name,d)) (extract_notation_data data) @ l
           else l) sc.notations)
       map [] in
-  List.sort (fun x y -> String.compare (snd (pi1 x)) (snd (pi1 y))) l
+  List.sort (fun x y -> String.compare (pi1 x).ntn_key (pi1 y).ntn_key) l
 
 let global_reference_of_notation ~head test (ntn,sc,(on_parsing,on_printing,{not_interp = (_,c as interp); not_location = (_, df)})) =
   match c with
@@ -1758,17 +1761,18 @@ let toggle_notations_in_scope ~on found inscope ntn_pattern ntns =
     (* shortcut *)
     List.fold_right (fun ntn_entry ntns ->
       try
-        NotationMap.add (ntn_entry, ntn)
+        let ntn = Constrexpr.{ ntn_entry; ntn_key = ntn } in
+        NotationMap.add ntn
           (toggle_notations_by_interpretation ~on found ntn_pattern
-             (inscope,(ntn_entry,ntn))
-             (NotationMap.find (ntn_entry, ntn) ntns))
+             (inscope, ntn)
+             (NotationMap.find ntn ntns))
           ntns
       with Not_found -> ntns)
         ntn_entries ntns
     (* Deal with full notations *)
   | ntn_entries, ntn_rule -> (* This is the table of notations, not of abbreviations *)
-    NotationMap.mapi (fun (ntn_entry,ntn_key' as ntn') data ->
-        if match_notation_entry ntn_entries ntn_entry && match_notation_rule ntn_rule ntn_key' then
+    NotationMap.mapi (fun ntn' data ->
+        if match_notation_entry ntn_entries ntn'.ntn_entry && match_notation_rule ntn_rule ntn'.ntn_key then
           toggle_notations_by_interpretation ~on found ntn_pattern
             (inscope,ntn')
             data
@@ -1845,7 +1849,7 @@ let toggle_notations ~on ~all ?(verbose=true) prglob ntn_pattern =
           str ":" ++ fnl () ++
           prlist_with_sep fnl (fun (kind, (vars,a as i)) ->
             match kind with
-            | Inl (l, (sc, (entry, _))) ->
+            | Inl (l, (sc, { ntn_entry = entry })) ->
               let sc = match sc with NotationInScope sc -> sc | LastLonelyNotation -> default_scope in
               let data = { not_interp = i; not_location = l; not_user_warns = None } in
               hov 0

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1393,9 +1393,9 @@ let rec raw_analyze_anonymous_notation_tokens = function
 (* Interpret notations with a recursive component *)
 
 type notation_symbols = {
-  recvars : (Id.t * Id.t) list; (* pairs (x,y) as in [ x ; .. ; y ] *)
-  mainvars : Id.t list; (* variables non involved in a recursive pattern *)
-  symbols : symbol list; (* the decomposition of the notation into terminals and nonterminals *)
+  mainvars : Id.t list; (* names of "toplevel" non-terminals *)
+  maintypes : Id.t notation_raw_type list; (* types of "toplevel" non-terminals *)
+  symbols : symbol list; (* the decomposition of the notation into terminals and nonterminals; there, recursive patterns refer to the left-hand variable *)
 }
 
 let out_nt = function NonTerminal x -> x | _ -> assert false
@@ -1420,36 +1420,33 @@ let rec find_pattern nt xl = function
   | ((SProdList _ | NonTerminal _) :: _), _ | _, (SProdList _ :: _) ->
       anomaly (Pp.str "Only Terminal or Break expected on left, non-SProdList on right.")
 
-let rec interp_list_parser hd = function
-  | [] -> [], List.rev hd
+let rec interp_list_parser hdvars hd = function
+  | [] -> List.rev hdvars, List.rev hd
   | NonTerminal id :: tl when Id.equal id Notation_ops.ldots_var ->
       if List.is_empty hd then user_err Pp.(str msg_expected_form_of_recursive_notation);
       let hd = List.rev hd in
       let ((x,y,sl),tl') = find_pattern (List.hd hd) [] (List.tl hd,tl) in
-      let xyl,tl'' = interp_list_parser [] tl' in
+      let xyl, tl'' = interp_list_parser [] [] tl' in
       (* We remember each pair of variable denoting a recursive part to *)
       (* remove the second copy of it afterwards *)
-      (x,y)::xyl, SProdList (x,sl) :: tl''
+      (x, NtnRawTypeVarList (NtnRawTypeVar (x, y))) :: xyl, SProdList (x,sl) :: tl''
   | (Terminal _ | Break _) as s :: tl ->
       if List.is_empty hd then
-        let yl,tl' = interp_list_parser [] tl in
+        let yl,tl' = interp_list_parser [] [] tl in
         yl, s :: tl'
       else
-        interp_list_parser (s::hd) tl
-  | NonTerminal _ as x :: tl ->
-      let xyl,tl' = interp_list_parser [x] tl in
-      xyl, List.rev_append hd tl'
+        interp_list_parser hdvars (s::hd) tl
+  | NonTerminal id as x :: tl ->
+      let xyl,tl' = interp_list_parser [id, NtnRawTypeVar id] [x] tl in
+      List.rev_append hdvars xyl, List.rev_append hd tl'
   | SProdList _ :: _ -> anomaly (Pp.str "Unexpected SProdList in interp_list_parser.")
-
-let get_notation_vars l =
-  List.map_filter (function NonTerminal id | SProdList (id,_) -> Some id | _ -> None) l
 
 let decompose_raw_notation ntn =
   let l = split_notation_string ntn in
   let symbols = raw_analyze_notation_tokens l in
-  let recvars, symbols = interp_list_parser [] symbols in
-  let mainvars = get_notation_vars symbols in
-  {recvars; mainvars; symbols}
+  let mainvartyps, symbols = interp_list_parser [] [] symbols in
+  let mainvars, maintypes = List.split mainvartyps in
+  {mainvars; maintypes; symbols}
 
 let interpret_notation_string ntn =
   (* We collect the possible interpretations of a notation string depending on whether it is
@@ -1466,7 +1463,7 @@ let interpret_notation_string ntn =
       (* Includes the case of only a subset of tokens or an "x 'U' y"-style format *)
       raw_analyze_notation_tokens toks
   in
-  let _,toks = interp_list_parser [] toks in
+  let _,toks = interp_list_parser [] [] toks in
   let _,ntn' = make_notation_key None toks in
   ntn'
 
@@ -1486,8 +1483,8 @@ let is_approximation ntn ntn' =
     | NonTerminal _ :: toks1, [] -> aux' toks1 l2full l2full toks2 || aux toks1 toks2
     | _ -> false
   in
-  let _,toks = interp_list_parser [] (raw_analyze_anonymous_notation_tokens (split_notation_string ntn)) in
-  let _,toks' = interp_list_parser [] (raw_analyze_anonymous_notation_tokens (split_notation_string ntn')) in
+  let _,toks = interp_list_parser [] [] (raw_analyze_anonymous_notation_tokens (split_notation_string ntn)) in
+  let _,toks' = interp_list_parser [] [] (raw_analyze_anonymous_notation_tokens (split_notation_string ntn')) in
   aux toks toks'
 
 let match_notation_key strict ntn ntn' =
@@ -1562,7 +1559,11 @@ let interp_notation_as_global_reference_expanded ?loc ~head test ntn sc =
 let interp_notation_as_global_reference ?loc ~head test ntn sc =
   let _,_,_,_,ref = interp_notation_as_global_reference_expanded ?loc ~head test ntn sc in ref
 
-let pr_id_infos (id, ((level,(tmp_scopes, scopes)), under_binders, kind)) =
+let pr_id_infos (id, var_type) =
+  match var_type with
+  | NtnTypeVarList _ | NtnTypeVarTuple _ -> None (* TODO *)
+  | NtnTypeVar (((level,(tmp_scopes, scopes)), under_binders), kind) ->
+  (* XXX level? kind? *)
   let scopes = List.map (fun x -> "_"^x) tmp_scopes @ scopes in
   match scopes with
   | [] -> None
@@ -1614,7 +1615,7 @@ let locate_notation prglob ntn scope =
     prlist_with_sep fnl (fun (ntn,l) ->
       let scope = find_default ntn scopes in
       prlist_with_sep fnl
-        (fun (sc,(on_parsing,on_printing,{ not_interp  = (ids, r); not_location = ((libpath,secpath,loc), df) })) ->
+        (fun (sc,(on_parsing,on_printing,{ not_interp = (ids, r); not_location = ((libpath,secpath,loc), df) })) ->
           let full_path = DirPath.make (DirPath.repr secpath @ DirPath.repr libpath) in
           hov 2 (
             str "Notation" ++ spc() ++

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -333,9 +333,9 @@ val make_notation_key : notation_entry -> symbol list -> notation
 val decompose_notation_key : notation -> notation_entry * symbol list
 
 type notation_symbols = {
-  recvars : (Id.t * Id.t) list; (* pairs (x,y) as in [ x ; .. ; y ] *)
-  mainvars : Id.t list; (* variables non involved in a recursive pattern *)
-  symbols : symbol list; (* the decomposition of the notation into terminals and nonterminals *)
+  mainvars : Id.t list; (* names of "toplevel" non-terminals *)
+  maintypes : Id.t notation_raw_type list; (* types of "toplevel" non-terminals *)
+  symbols : symbol list; (* the decomposition of the notation into terminals and nonterminals; there, recursive patterns refer to the left-hand variable *)
 }
 
 val is_prim_token_constant_in_constr :

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -288,7 +288,7 @@ val interp_notation_as_global_reference : ?loc:Loc.t -> head:bool ->
 (** Same together with the full notation *)
 val interp_notation_as_global_reference_expanded : ?loc:Loc.t -> head:bool ->
       (GlobRef.t -> bool) -> notation_key -> delimiters option ->
-  (notation_entry * notation_key) * notation_key * notation_with_optional_scope * interpretation * GlobRef.t
+  notation * notation_key * notation_with_optional_scope * interpretation * GlobRef.t
 
 (** Declares and looks for scopes associated to arguments of a global ref *)
 val declare_arguments_scope :

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -183,7 +183,7 @@ val interp_notation_as_global_reference : ?loc:Loc.t -> head:bool ->
 (** Same together with the full notation *)
 val interp_notation_as_global_reference_expanded : ?loc:Loc.t -> head:bool ->
       (GlobRef.t -> bool) -> notation_key -> delimiters option ->
-  (notation_entry * notation_key) * notation_key * notation_with_optional_scope * interpretation * GlobRef.t
+  notation * notation_key * notation_with_optional_scope * interpretation * GlobRef.t
 
 (** Declares and looks for scopes associated to arguments of a global ref *)
 val declare_arguments_scope :

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -228,9 +228,9 @@ val make_notation_key : notation_entry -> symbol list -> notation
 val decompose_notation_key : notation -> notation_entry * symbol list
 
 type notation_symbols = {
-  recvars : (Id.t * Id.t) list; (* pairs (x,y) as in [ x ; .. ; y ] *)
-  mainvars : Id.t list; (* variables non involved in a recursive pattern *)
-  symbols : symbol list; (* the decomposition of the notation into terminals and nonterminals *)
+  mainvars : Id.t list; (* names of "toplevel" non-terminals *)
+  maintypes : Id.t notation_raw_type list; (* types of "toplevel" non-terminals *)
+  symbols : symbol list; (* the decomposition of the notation into terminals and nonterminals; there, recursive patterns refer to the left-hand variable *)
 }
 
 val is_prim_token_constant_in_constr : notation_entry * symbol list -> bool

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -227,6 +227,16 @@ val symbol_eq : symbol -> symbol -> bool
 val make_notation_key : notation_entry -> symbol list -> notation
 val decompose_notation_key : notation -> notation_entry * symbol list
 
+(** This is the output of decomposing a notation declaration:
+    [mainvars] include all notation variables, keeping only one for
+      each pair (typically the first one) in case of a recursive pattern
+      (e.g. in ``Notation "[ x ; y ; .. ; z ]" := ...'', the mainvars
+      are [x;y]);
+    [maintypes] describes the structure of the pattern, e.g.,
+      for the same notation, it is
+      [[NtnRawTypeVar "x"; NtnRawTypeVarList (NtnRawTypeVar ("y", "z"))]]
+    [symbols] describes the parsing rule, e.g. for the same notation, it is
+      [[Terminal "["; NonTerminal "x"; SProdList ("y",[Terminal ";"]); Terminal "]"]] *)
 type notation_symbols = {
   mainvars : Id.t list; (* names of "toplevel" non-terminals *)
   maintypes : Id.t notation_raw_type list; (* types of "toplevel" non-terminals *)

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -13,7 +13,6 @@ open CErrors
 open Util
 open Names
 open Nameops
-open Constr
 open Globnames
 open Glob_term
 open Glob_ops
@@ -995,31 +994,25 @@ let rec push_context_binders vars = function
     | GLocalDef (na,_,_,_) -> Termops.add_vname vars na in
     push_context_binders vars bl
 
-let is_term_meta id metas =
-  try match Id.List.assoc id metas with NtnTypeVar (_, NtnTypeVarConstr _) -> true | _ -> false
-  with Not_found -> false
+let is_term_meta = function
+  | NtnTypeVar (_, NtnTypeVarConstr _) -> true
+  | _ -> false
 
-let is_onlybinding_strict_meta id metas =
-  try match Id.List.assoc id metas with NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind AsStrictPattern)) -> true | _ -> false
-  with Not_found -> false
+let is_onlybinding_pattern_like_meta ~strict ~binder ~isvar = function
+  | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsConstr (AsAnyPattern | AsStrictPattern))) -> true
+  | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind AsStrictPattern)) -> strict
+  | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsBinder)) -> binder
+  | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind AsAnyPattern)) -> true
+  | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind (AsIdent | AsName))) -> isvar
+  | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsConstr (AsIdent | AsName))) -> isvar
+  | NtnTypeVar (_, (NtnTypeVarConstr _ | NtnTypeVarBinders _)) | NtnTypeVarList _ | NtnTypeVarTuple _ -> false
 
-let is_onlybinding_meta id metas =
-  try match Id.List.assoc id metas with NtnTypeVar (_, NtnTypeVarPattern _) -> true | _ -> false
-  with Not_found -> false
+let is_bindinglist_meta = function
+  | NtnTypeVar (_, NtnTypeVarBinders _) -> true
+  | _ -> false
 
-let is_onlybinding_pattern_like_meta ~strict ~isvar id metas =
-  try match Id.List.assoc id metas with
-    | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsConstr (AsAnyPattern | AsStrictPattern))) -> true
-    | NtnTypeVar (_, NtnTypeVarPattern ((NtnBinderParsedAsSomeBinderKind AsStrictPattern | NtnBinderParsedAsBinder))) -> strict
-    | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind AsAnyPattern)) -> true
-    | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind (AsIdent | AsName))) -> isvar
-    | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsConstr (AsIdent | AsName))) -> isvar
-    | NtnTypeVar (_, (NtnTypeVarConstr _ | NtnTypeVarBinders _)) | NtnTypeVarList _ | NtnTypeVarTuple _ -> false
-  with Not_found -> false
-
-let is_bindinglist_meta id metas =
-  try match Id.List.assoc id metas with NtnTypeVar (_, NtnTypeVarBinders _) -> true | _ -> false
-  with Not_found -> false
+let is_bindinglist_meta_var id metas =
+  try is_bindinglist_meta (Id.List.assoc id metas) with Not_found -> false
 
 exception No_match
 
@@ -1253,26 +1246,6 @@ let bind_termlist_env alp sigma var vl =
     add_termlist_env alp' sigma var vl
   with Not_found -> add_termlist_env alp sigma var vl
 
-let bind_ident_as_binding_env alp sigma var id =
-  try
-    (* If already bound to a term, unify the binder and the term *)
-    let vars', _alp', v' = get_term (Id.Map.find var sigma) in
-    match DAst.get v' with
-    | GVar id' | GRef (GlobRef.VarRef id',None) ->
-       let {actualvars;staticbinders;renaming} = alp in
-       let vars = Id.Set.add id' actualvars in
-       let renaming = if not (Id.equal id id') then (id,id')::renaming else renaming in
-       {actualvars = Id.Set.union vars' vars; staticbinders; renaming}, sigma
-    | t ->
-       (* The term is a non-variable pattern *)
-       raise No_match
-  with Not_found ->
-    let alp = {alp with actualvars = Id.Set.add id alp.actualvars} in
-    (* The matching against a term allowing to find the instance has not been found yet *)
-    (* If it will be a different name, we shall unfortunately fail *)
-    (* TODO: look at the consequences for alp *)
-    alp, add_env alp sigma var (DAst.make @@ GVar id)
-
 let bind_singleton_bindinglist_as_term_env alp sigma var c =
   try
     (* If already bound to a binder, unify the term and the binder *)
@@ -1364,39 +1337,62 @@ let match_opt f sigma t1 t2 = match (t1,t2) with
   | Some t1, Some t2 -> f sigma t1 t2
   | _ -> raise No_match
 
-let match_names metas (alp,sigma) na1 na2 = match (na1,na2) with
-  | (na1,Name id2) when is_onlybinding_strict_meta id2 metas (* strict pattern = not a variable *) ->
-      raise No_match
-  | (na1,Name id2) when is_onlybinding_meta id2 metas ->
-      bind_binding_env alp sigma id2 [DAst.make (PatVar na1)]
-  | (Name id1,Name id2) when is_term_meta id2 metas ->
-      (* We let the non-binding occurrence define the rhs and hence reason up to *)
-      (* alpha-conversion for the given occurrence of the name (see #4592)) *)
-      bind_ident_as_binding_env alp sigma id2 id1
-  | (Anonymous,Name id2) when is_term_meta id2 metas ->
-      (* We let the non-binding occurrence define the rhs *)
-      alp, sigma
-  | (na1,Name id2) ->
-      {alp with staticbinders = (na1,id2)::alp.staticbinders},sigma
+let is_meta_variable_name na metas =
+  match na with
+  | Name id -> (try Some (id, Id.List.assoc id metas) with Not_found -> None)
+  | Anonymous -> None
+
+let is_meta_variable_pat pat metas =
+  match pat with
+  | PatVar (Name id) -> (try Some (id, Id.List.assoc id metas) with Not_found -> None)
+  | _ -> None
+
+let is_meta_variable_term term metas =
+  match term with
+  | NVar id -> (try Some (id, Id.List.assoc id metas) with Not_found -> None)
+  | _ -> None
+
+let match_names_var (alp,sigma) na1 id2 typ =
+  if is_onlybinding_pattern_like_meta ~strict:false ~binder:true ~isvar:true typ then
+    bind_binding_env alp sigma id2 [DAst.make (PatVar na1)]
+  else
+    raise No_match
+
+let match_names_non_var (alp,sigma) na1 na2 =
+  match na1, na2 with
+  | (na1,Name id2) -> {alp with staticbinders = (na1,id2)::alp.staticbinders},sigma
   | (Anonymous,Anonymous) -> alp,sigma
   | _ -> raise No_match
+
+let match_names metas acc na1 na2 =
+  match is_meta_variable_name na2 metas with
+  | Some (id2, typ) -> match_names_var acc na1 id2 typ
+  | None -> match_names_non_var acc na1 na2
 
 let isPatVar = function PatVar _ -> true | _ -> false
 
 let rec match_cases_pattern_binders allow_catchall metas (alp,sigma as acc) pat1 pat2 =
-  match DAst.get pat1, DAst.get pat2 with
-  | pat, PatVar (Name id2) when is_onlybinding_pattern_like_meta ~strict:(not (isPatVar pat)) ~isvar:(isPatVar pat) id2 metas ->
+  let pat = DAst.get pat1 in
+  let pat2 = DAst.get pat2 in
+  match is_meta_variable_pat pat2 metas with
+  | Some (id2, typ) ->
+    if is_onlybinding_pattern_like_meta ~strict:(not (isPatVar pat)) ~binder:false ~isvar:(isPatVar pat) typ then
       bind_binding_env alp sigma id2 [pat1]
-  | PatVar id1, PatVar (Name id2) when is_bindinglist_meta id2 metas ->
-      let t1 = DAst.make @@ GHole(GBinderType id1) in
-      bind_bindinglist_env alp sigma id2 [DAst.make @@ GLocalAssum (id1,None,Explicit,t1)]
-  | _, PatVar (Name id2) when is_bindinglist_meta id2 metas ->
+    else if is_bindinglist_meta typ then
+      match pat with
+      | PatVar id1 ->
+        let t1 = DAst.make @@ GHole(GBinderType id1) in
+        bind_bindinglist_env alp sigma id2 [DAst.make @@ GLocalAssum (id1,None,Explicit,t1)]
+      | _ ->
       (* dummy data; should not be used anyway *)
       let id1 = Namegen.next_ident_away (Id.of_string "x") Id.Set.empty in
       let t1 = DAst.make @@ GHole(GBinderType (Name id1)) in
       let ids1 = [] in
       bind_bindinglist_env alp sigma id2 [DAst.make @@ GLocalPattern (([pat1],ids1),id1,Explicit,t1)]
-  | PatVar na1, PatVar na2 -> match_names metas acc na1 na2
+    else raise No_match
+  | None ->
+  match pat, pat2 with
+  | PatVar na1, PatVar na2 -> match_names_non_var acc na1 na2
   | _, PatVar Anonymous when allow_catchall -> acc
   | PatCstr (c1,patl1,na1), PatCstr (c2,patl2,na2)
       when Construct.CanOrd.equal c1 c2 && Int.equal (List.length patl1) (List.length patl2) ->
@@ -1475,7 +1471,7 @@ let match_termlist flags match_fun alp metas sigma rest x y iter termin revert =
       alp, acc, match_fun alp metas sigma rest termin in
   let alp,l,sigma = aux alp sigma [] rest in
   let l = if revert then l else List.rev l in
-  if is_bindinglist_meta x metas then
+  if is_bindinglist_meta_var x metas then
     (* This is a recursive pattern for both bindings and terms; it is *)
     (* registered for binders *)
     bind_bindinglist_as_termlist_env alp sigma x l
@@ -1508,12 +1504,16 @@ let is_var_term = function
 let rec match_ inner u alp metas sigma a1 a2 =
   let open CAst in
   let loc = a1.loc in
-  match DAst.get a1, a2 with
+  let r1 = DAst.get a1 in
   (* Matching notation variable *)
-  | r1, NVar id2 when is_term_meta id2 metas -> bind_term_env alp sigma id2 a1
-  | r1, NVar id2 when is_onlybinding_pattern_like_meta ~strict:true ~isvar:(is_var_term r1) id2 metas -> bind_binding_as_term_env alp sigma id2 a1
-  | r1, NVar id2 when is_bindinglist_meta id2 metas -> bind_singleton_bindinglist_as_term_env alp sigma id2 a1
-
+  match is_meta_variable_term a2 metas with
+  | Some (id2, typ) ->
+    if is_term_meta typ then bind_term_env alp sigma id2 a1 else
+    if is_onlybinding_pattern_like_meta ~strict:true ~binder:true ~isvar:(is_var_term r1) typ then bind_binding_as_term_env alp sigma id2 a1 else
+    if is_bindinglist_meta typ then bind_singleton_bindinglist_as_term_env alp sigma id2 a1 else
+      raise No_match
+  | None ->
+  match r1, a2 with
   (* Matching recursive notations for terms *)
   | r1, NList (x,y,iter,termin,revert) ->
       match_termlist u (match_hd u) alp metas sigma a1 x y iter termin revert
@@ -1636,7 +1636,7 @@ let rec match_ inner u alp metas sigma a1 a2 =
       | Some (NVar id2) -> bind_term_env alp sigma id2 t1
       | _ -> assert false in
       let (alp,sigma) =
-        if is_bindinglist_meta id metas then
+        if is_bindinglist_meta_var id metas then
           bind_bindinglist_env alp sigma id [DAst.make @@ GLocalAssum (Name id',None,Explicit,t1)]
         else
           match_names metas (alp,sigma) (Name id') na in
@@ -1667,35 +1667,40 @@ and match_binders u alp metas na1 na2 sigma b1 b2 =
   match_in u alp metas sigma b1 b2
 
 and match_extended_binders ?loc isprod u alp metas na1 na2 bk t sigma b1 b2 =
-  (* Match binders which can be substituted by a pattern *)
-  let store, get = set_temporary_memory () in
-  match na1, DAst.get b1, na2 with
-  (* Matching individual binders as part of a recursive pattern *)
-  | Name p, GCases (Constr.LetPatternStyle,None,[(e,_)],(_::_ as eqns)), Name id
-       when is_gvar p e && is_bindinglist_meta id metas && List.length (store (Detyping.factorize_eqns eqns)) = 1 ->
-    (match get () with
-     | [{CAst.v=(ids,disj_of_patl,b1)}] ->
-     let disjpat = List.map (function [pat] -> pat | _ -> assert false) disj_of_patl in
-     let disjpat = if occur_glob_constr p b1 then List.map (set_pat_alias p) disjpat else disjpat in
-     let alp,sigma = bind_bindinglist_env alp sigma id [DAst.make ?loc @@ GLocalPattern ((disjpat,ids),p,bk,t)] in
-     match_in u alp metas sigma b1 b2
-     | _ -> assert false)
-  | Name p, GCases (LetPatternStyle,None,[(e,_)],(_::_ as eqns)), Name id
-       when is_gvar p e && is_onlybinding_pattern_like_meta ~strict:true ~isvar:false id metas && List.length (store (Detyping.factorize_eqns eqns)) = 1 ->
-    (match get () with
-     | [{CAst.v=(ids,disj_of_patl,b1)}] ->
-     let disjpat = List.map (function [pat] -> pat | _ -> assert false) disj_of_patl in
-     let disjpat = if occur_glob_constr p b1 then List.map (set_pat_alias p) disjpat else disjpat in
-     let alp,sigma = bind_binding_env alp sigma id disjpat in
-     match_in u alp metas sigma b1 b2
-     | _ -> assert false)
-  | _, _, Name id when is_bindinglist_meta id metas ->
-      if (isprod && na1 = Anonymous) then raise No_match (* prefer using "A -> B" for anonymous forall *);
-      let alp,sigma = bind_bindinglist_env alp sigma id [DAst.make ?loc @@ GLocalAssum (na1,None,bk,t)] in
-      match_in u alp metas sigma b1 b2
-  | _, _, _ ->
-     let (alp,sigma) = match_names metas (alp,sigma) na1 na2 in
-     match_in u alp metas sigma b1 b2
+  (* Match binders which can be substituted by a pattern: *)
+  (* that is, try to extract a pattern part in b2 that can be bound to na2 *)
+  match is_meta_variable_name na2 metas with
+  | Some (id2, typ) ->
+    (let store, get = set_temporary_memory () in
+    (* Matching individual binders as part of a recursive pattern *)
+    match na1, DAst.get b1 with
+    | Name p, GCases (Constr.LetPatternStyle,None,[(e,_)],(_::_ as eqns))
+      when is_gvar p e && (is_bindinglist_meta typ || is_onlybinding_pattern_like_meta ~strict:true ~binder:true ~isvar:false typ)
+           && List.length (store (Detyping.factorize_eqns eqns)) = 1 ->
+      (match get () with
+       | [{CAst.v=(ids,disj_of_patl,b1)}] ->
+         let disjpat = List.map (function [pat] -> pat | _ -> assert false) disj_of_patl in
+         let disjpat = if occur_glob_constr p b1 then List.map (set_pat_alias p) disjpat else disjpat in
+         let alp,sigma =
+           if is_bindinglist_meta typ then
+             bind_bindinglist_env alp sigma id2 [DAst.make ?loc @@ GLocalPattern ((disjpat,ids),p,bk,t)]
+           else
+             (* bk, t? *)
+             bind_binding_env alp sigma id2 disjpat in
+         match_in u alp metas sigma b1 b2
+       | _ -> assert false)
+    | _ ->
+      if is_bindinglist_meta typ then
+        begin
+          if (isprod && na1 = Anonymous) then raise No_match (* prefer using "A -> B" for anonymous forall *);
+          let alp,sigma = bind_bindinglist_env alp sigma id2 [DAst.make ?loc @@ GLocalAssum (na1,None,bk,t)] in
+          match_in u alp metas sigma b1 b2
+        end
+      else
+        let (alp,sigma) = match_names_var (alp,sigma) na1 id2 typ in
+        match_in u alp metas sigma b1 b2)
+  | None ->
+    match_binders u alp metas na1 na2 sigma b1 b2
 
 and match_equations u alp metas sigma {CAst.v=(ids,patl1,rhs1)} (patl2,rhs2) rest1 rest2 =
   (* patl1 and patl2 have the same length because they respectively

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -978,7 +978,7 @@ let rec push_context_binders vars = function
     push_context_binders vars bl
 
 let is_term_meta id metas =
-  try match Id.List.assoc id metas with NtnTypeConstr | NtnTypeConstrList -> true | _ -> false
+  try match Id.List.assoc id metas with NtnTypeConstr -> true | _ -> false
   with Not_found -> false
 
 let is_onlybinding_strict_meta id metas =

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -998,7 +998,7 @@ let is_term_meta = function
   | NtnTypeVar (_, NtnTypeVarConstr _) -> true
   | _ -> false
 
-let is_onlybinding_pattern_like_meta ~strict ~binder ~isvar = function
+let is_pattern_meta ~strict ~binder ~isvar = function
   | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsConstr (AsAnyPattern | AsStrictPattern))) -> true
   | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind AsStrictPattern)) -> strict
   | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsBinder)) -> binder
@@ -1007,12 +1007,12 @@ let is_onlybinding_pattern_like_meta ~strict ~binder ~isvar = function
   | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsConstr (AsIdent | AsName))) -> isvar
   | NtnTypeVar (_, (NtnTypeVarConstr _ | NtnTypeVarBinders _)) | NtnTypeVarList _ | NtnTypeVarTuple _ -> false
 
-let is_bindinglist_meta = function
+let is_binders_meta = function
   | NtnTypeVar (_, NtnTypeVarBinders _) -> true
   | _ -> false
 
-let is_bindinglist_meta_var id metas =
-  try is_bindinglist_meta (Id.List.assoc id metas) with Not_found -> false
+let is_binders_meta_var id metas =
+  try is_binders_meta (Id.List.assoc id metas) with Not_found -> false
 
 exception No_match
 
@@ -1023,7 +1023,7 @@ let alpha_rename renaming v =
 let static_binder_escape staticbinders v =
   List.exists (function (Name id,_) -> occur_glob_constr id v | (Anonymous,_) -> false) staticbinders
 
-let add_env {actualvars;staticbinders;renaming} sigma var v =
+let add_term_env {actualvars;staticbinders;renaming} sigma var v =
   (* Check that no capture of binding variables occur *)
   (* [staticbinders] is used when matching a pattern "fun x => ... x ... ?var ... x ..."
      with an actual term "fun z => ... z ..." when "x" is not bound in the
@@ -1058,11 +1058,11 @@ let add_termlist_env {actualvars;staticbinders;renaming} sigma var vl =
   let vl = List.map (fun c -> NtnTypeArg (NtnTypeArgConstr (actualvars,staticbinders,c))) vl in
   Id.Map.add var (NtnTypeArgList vl) sigma
 
-let add_binding_env {actualvars;staticbinders} sigma var v =
+let add_pattern_env {actualvars;staticbinders} sigma var v =
   (* TODO: handle the case of multiple occs in different scopes *)
   Id.Map.add var (NtnTypeArg (NtnTypeArgPattern (actualvars,staticbinders,v))) sigma
 
-let add_bindinglist_env {actualvars;staticbinders} sigma var bl =
+let add_binders_env {actualvars;staticbinders} sigma var bl =
   Id.Map.add var (NtnTypeArg (NtnTypeArgBinders (actualvars,staticbinders,bl))) sigma
 
 let rec map_cases_pattern_name_left f = DAst.map (function
@@ -1230,8 +1230,8 @@ let bind_term_env alp sigma var v =
     if v'' == v' then sigma else
       let sigma = Id.Map.remove var sigma in
       let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
-      add_env alp' sigma var v
-  with Not_found -> add_env alp sigma var v
+      add_term_env alp' sigma var v
+  with Not_found -> add_term_env alp sigma var v
 
 let bind_termlist_env alp sigma var vl =
   try
@@ -1246,7 +1246,7 @@ let bind_termlist_env alp sigma var vl =
     add_termlist_env alp' sigma var vl
   with Not_found -> add_termlist_env alp sigma var vl
 
-let bind_singleton_bindinglist_as_term_env alp sigma var c =
+let bind_singleton_binders_as_term_env alp sigma var c =
   try
     (* If already bound to a binder, unify the term and the binder *)
     let vars, _, patl' = get_binders (Id.Map.find var sigma) in
@@ -1255,12 +1255,12 @@ let bind_singleton_bindinglist_as_term_env alp sigma var c =
     else
       let sigma = Id.Map.remove var sigma in
       let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
-      add_bindinglist_env alp' sigma var patl''
+      add_binders_env alp' sigma var patl''
   with Not_found ->
     (* A term-as-binder occurs in the scope of a binder which is already bound *)
     anomaly (Pp.str "Unbound term as binder.")
 
-let bind_binding_as_term_env alp sigma var c =
+let bind_pattern_as_term_env alp sigma var c =
   let env = Global.env () in
   let pat = try cases_pattern_of_glob_constr env Anonymous c with Not_found -> raise No_match in
   try
@@ -1271,10 +1271,10 @@ let bind_binding_as_term_env alp sigma var c =
     else
       let sigma = Id.Map.remove var sigma  in
       let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
-      add_binding_env alp' sigma var disjpatl''
-  with Not_found -> add_binding_env alp sigma var [pat]
+      add_pattern_env alp' sigma var disjpatl''
+  with Not_found -> add_pattern_env alp sigma var [pat]
 
-let bind_binding_env alp sigma var disjpat =
+let bind_pattern_env alp sigma var disjpat =
   try
     (* If already bound to a binder possibly *)
     (* generating an alpha-renaming from unifying the new binder *)
@@ -1284,14 +1284,14 @@ let bind_binding_env alp sigma var disjpat =
     let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
     let alp, disjpat = List.fold_left2_map unify_pat_upto alp disjpat disjpat' in
     let sigma = Id.Map.remove var sigma in
-    alp, add_binding_env alp' sigma var disjpat
+    alp, add_pattern_env alp' sigma var disjpat
   with Not_found ->
     (* Note: all patterns of the disjunction are supposed to have the same
        variables, thus one is enough *)
     let alp = {alp with actualvars = push_pattern_binders alp.actualvars (List.hd disjpat)} in
-    alp, add_binding_env alp sigma var disjpat
+    alp, add_pattern_env alp sigma var disjpat
 
-let bind_bindinglist_env alp sigma var bl =
+let bind_binders_env alp sigma var bl =
   let bl = List.rev bl in
   try
     (* If already bound to a list of binders possibly *)
@@ -1303,19 +1303,19 @@ let bind_bindinglist_env alp sigma var bl =
     let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
     let alp, bl = unify_binders_upto alp bl bl' in
     let sigma = Id.Map.remove var sigma in
-    alp, add_bindinglist_env alp' sigma var bl
+    alp, add_binders_env alp' sigma var bl
   with Not_found ->
     let alp = {alp with actualvars = push_context_binders alp.actualvars bl} in
-    alp, add_bindinglist_env alp sigma var bl
+    alp, add_binders_env alp sigma var bl
 
-let bind_bindinglist_as_termlist_env alp sigma var cl =
+let bind_binders_as_termlist_env alp sigma var cl =
   try
     (* If already bound to a list of binders, unify the terms and binders *)
     let vars, _, bl' = get_binders (Id.Map.find var sigma) in
     let bl = unify_terms_binders alp.renaming cl bl' in
     let alp = {alp with actualvars = Id.Set.union vars alp.actualvars} in
     let sigma = Id.Map.remove var sigma in
-    add_bindinglist_env alp sigma var bl
+    add_binders_env alp sigma var bl
   with Not_found ->
     anomaly (str "There should be a binder list bindings this list of terms.")
 
@@ -1353,8 +1353,8 @@ let is_meta_variable_term term metas =
   | _ -> None
 
 let match_names_var (alp,sigma) na1 id2 typ =
-  if is_onlybinding_pattern_like_meta ~strict:false ~binder:true ~isvar:true typ then
-    bind_binding_env alp sigma id2 [DAst.make (PatVar na1)]
+  if is_pattern_meta ~strict:false ~binder:true ~isvar:true typ then
+    bind_pattern_env alp sigma id2 [DAst.make (PatVar na1)]
   else
     raise No_match
 
@@ -1376,19 +1376,19 @@ let rec match_cases_pattern_binders allow_catchall metas (alp,sigma as acc) pat1
   let pat2 = DAst.get pat2 in
   match is_meta_variable_pat pat2 metas with
   | Some (id2, typ) ->
-    if is_onlybinding_pattern_like_meta ~strict:(not (isPatVar pat)) ~binder:false ~isvar:(isPatVar pat) typ then
-      bind_binding_env alp sigma id2 [pat1]
-    else if is_bindinglist_meta typ then
+    if is_pattern_meta ~strict:(not (isPatVar pat)) ~binder:false ~isvar:(isPatVar pat) typ then
+      bind_pattern_env alp sigma id2 [pat1]
+    else if is_binders_meta typ then
       match pat with
       | PatVar id1 ->
         let t1 = DAst.make @@ GHole(GBinderType id1) in
-        bind_bindinglist_env alp sigma id2 [DAst.make @@ GLocalAssum (id1,None,Explicit,t1)]
+        bind_binders_env alp sigma id2 [DAst.make @@ GLocalAssum (id1,None,Explicit,t1)]
       | _ ->
       (* dummy data; should not be used anyway *)
       let id1 = Namegen.next_ident_away (Id.of_string "x") Id.Set.empty in
       let t1 = DAst.make @@ GHole(GBinderType (Name id1)) in
       let ids1 = [] in
-      bind_bindinglist_env alp sigma id2 [DAst.make @@ GLocalPattern (([pat1],ids1),id1,Explicit,t1)]
+      bind_binders_env alp sigma id2 [DAst.make @@ GLocalPattern (([pat1],ids1),id1,Explicit,t1)]
     else raise No_match
   | None ->
   match pat, pat2 with
@@ -1404,7 +1404,7 @@ let dummy_subscopes = ((constr_some_level,([],[])),Id.Set.empty)
 
 let add_ldots_var metas = (ldots_var,NtnTypeVar (dummy_subscopes, NtnTypeVarConstr (* Dummy: *)  NtnConstrForConstrAndPatternForPattern))::metas
 
-let add_meta_bindinglist x metas = (x,NtnTypeVar ((*arbitrary:*) dummy_subscopes, NtnTypeVarBinders NtnBinderParsedAsBinder))::metas
+let add_meta_binders x metas = (x,NtnTypeVar ((*arbitrary:*) dummy_subscopes, NtnTypeVarBinders NtnBinderParsedAsBinder))::metas
 
 (* This tells if letins in the middle of binders should be included in
    the sequence of binders *)
@@ -1419,7 +1419,7 @@ exception OnlyTrailingLetIns
 let match_binderlist match_iter_fun match_termin_fun alp metas sigma rest x y iter termin revert =
   let rec aux trailing_letins alp sigma bl rest =
     try
-      let metas = add_ldots_var (add_meta_bindinglist y metas) in
+      let metas = add_ldots_var (add_meta_binders y metas) in
       let sigma = match_iter_fun alp metas sigma rest iter in
       let _,newstaticbinders,rest = get_term (Id.Map.find ldots_var sigma) in
       let _, _, b = get_binders (Id.Map.find y sigma) in
@@ -1444,7 +1444,7 @@ let match_binderlist match_iter_fun match_termin_fun alp metas sigma rest x y it
        if not (List.is_empty bl) then alp, bl, rest, sigma else raise No_match in
   let alp,bl,rest,sigma = aux false alp sigma [] rest in
   let bl = if revert then List.rev bl else bl in
-  let alp,sigma = bind_bindinglist_env alp sigma x bl in
+  let alp,sigma = bind_binders_env alp sigma x bl in
   match_termin_fun alp metas sigma rest termin
 
 let add_meta_term x metas = (x,NtnTypeVar (dummy_subscopes, NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern))::metas
@@ -1471,10 +1471,10 @@ let match_termlist flags match_fun alp metas sigma rest x y iter termin revert =
       alp, acc, match_fun alp metas sigma rest termin in
   let alp,l,sigma = aux alp sigma [] rest in
   let l = if revert then l else List.rev l in
-  if is_bindinglist_meta_var x metas then
+  if is_binders_meta_var x metas then
     (* This is a recursive pattern for both bindings and terms; it is *)
     (* registered for binders *)
-    bind_bindinglist_as_termlist_env alp sigma x l
+    bind_binders_as_termlist_env alp sigma x l
   else
     bind_termlist_env alp sigma x l
 
@@ -1509,8 +1509,8 @@ let rec match_ inner u alp metas sigma a1 a2 =
   match is_meta_variable_term a2 metas with
   | Some (id2, typ) ->
     if is_term_meta typ then bind_term_env alp sigma id2 a1 else
-    if is_onlybinding_pattern_like_meta ~strict:true ~binder:true ~isvar:(is_var_term r1) typ then bind_binding_as_term_env alp sigma id2 a1 else
-    if is_bindinglist_meta typ then bind_singleton_bindinglist_as_term_env alp sigma id2 a1 else
+    if is_pattern_meta ~strict:true ~binder:true ~isvar:(is_var_term r1) typ then bind_pattern_as_term_env alp sigma id2 a1 else
+    if is_binders_meta typ then bind_singleton_binders_as_term_env alp sigma id2 a1 else
       raise No_match
   | None ->
   match r1, a2 with
@@ -1636,8 +1636,8 @@ let rec match_ inner u alp metas sigma a1 a2 =
       | Some (NVar id2) -> bind_term_env alp sigma id2 t1
       | _ -> assert false in
       let (alp,sigma) =
-        if is_bindinglist_meta_var id metas then
-          bind_bindinglist_env alp sigma id [DAst.make @@ GLocalAssum (Name id',None,Explicit,t1)]
+        if is_binders_meta_var id metas then
+          bind_binders_env alp sigma id [DAst.make @@ GLocalAssum (Name id',None,Explicit,t1)]
         else
           match_names metas (alp,sigma) (Name id') na in
       match_in u alp metas sigma (mkGApp a1 [DAst.make @@ GVar id']) b2
@@ -1675,25 +1675,25 @@ and match_extended_binders ?loc isprod u alp metas na1 na2 bk t sigma b1 b2 =
     (* Matching individual binders as part of a recursive pattern *)
     match na1, DAst.get b1 with
     | Name p, GCases (Constr.LetPatternStyle,None,[(e,_)],(_::_ as eqns))
-      when is_gvar p e && (is_bindinglist_meta typ || is_onlybinding_pattern_like_meta ~strict:true ~binder:true ~isvar:false typ)
+      when is_gvar p e && (is_binders_meta typ || is_pattern_meta ~strict:true ~binder:true ~isvar:false typ)
            && List.length (store (Detyping.factorize_eqns eqns)) = 1 ->
       (match get () with
        | [{CAst.v=(ids,disj_of_patl,b1)}] ->
          let disjpat = List.map (function [pat] -> pat | _ -> assert false) disj_of_patl in
          let disjpat = if occur_glob_constr p b1 then List.map (set_pat_alias p) disjpat else disjpat in
          let alp,sigma =
-           if is_bindinglist_meta typ then
-             bind_bindinglist_env alp sigma id2 [DAst.make ?loc @@ GLocalPattern ((disjpat,ids),p,bk,t)]
+           if is_binders_meta typ then
+             bind_binders_env alp sigma id2 [DAst.make ?loc @@ GLocalPattern ((disjpat,ids),p,bk,t)]
            else
              (* bk, t? *)
-             bind_binding_env alp sigma id2 disjpat in
+             bind_pattern_env alp sigma id2 disjpat in
          match_in u alp metas sigma b1 b2
        | _ -> assert false)
     | _ ->
-      if is_bindinglist_meta typ then
+      if is_binders_meta typ then
         begin
           if (isprod && na1 = Anonymous) then raise No_match (* prefer using "A -> B" for anonymous forall *);
-          let alp,sigma = bind_bindinglist_env alp sigma id2 [DAst.make ?loc @@ GLocalAssum (na1,None,bk,t)] in
+          let alp,sigma = bind_binders_env alp sigma id2 [DAst.make ?loc @@ GLocalAssum (na1,None,bk,t)] in
           match_in u alp metas sigma b1 b2
         end
       else

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -19,6 +19,7 @@ open Glob_term
 open Glob_ops
 open Mod_subst
 open Notation_term
+open Constrexpr
 
 (** Constr default entry *)
 
@@ -718,12 +719,25 @@ let notation_constr_and_vars_of_glob_constr recvars a =
   (* Side effect *)
   t, !found, !forgetful
 
+let rec make_iterated_pairs : type s. (s -> Id.t list) -> s notation_raw_type -> Id.t list =
+  fun f -> function
+  | NtnRawTypeVar x -> f x
+  | NtnRawTypeVarList typ -> make_iterated_pairs (fun (x,y) -> f x @ f y) typ
+  | NtnRawTypeVarTuple typs -> List.map_append (make_iterated_pairs f) typs
+
+let rec pairs_of_notation = function
+  | NtnRawTypeVar _ -> []
+  | NtnRawTypeVarList typ -> make_iterated_pairs (fun (x,y) -> [x;y]) typ
+  | NtnRawTypeVarTuple l -> List.map_append pairs_of_notation l
+
 let check_variables_and_reversibility nenv
   { vars = found; recursive_term_vars = foundrec; recursive_binders_vars = foundrecbinding } =
   let injective = ref [] in
-  let recvars = nenv.ninterp_rec_vars in
-  let fold _ y accu = Id.Set.add y accu in
-  let useless_vars = Id.Map.fold fold recvars Id.Set.empty in
+  let recvars = List.map pairs_of_notation nenv.ninterp_raw_types in
+  (* We have iterated tuples (pairs, pairs of pairs, etc.) where the first name is the reference *)
+  let recvars = List.filter (fun l -> not (List.is_empty l)) recvars in
+  let fold l accu = List.fold_right Id.Set.add (List.tl l) accu in
+  let useless_vars = List.fold_right fold recvars Id.Set.empty in
   let filter y _ = not (Id.Set.mem y useless_vars) in
   let vars = Id.Map.filter filter nenv.ninterp_var_type in
   let check_recvar x =
@@ -750,6 +764,8 @@ let check_variables_and_reversibility nenv
       user_err  (strbrk "in the right-hand side, " ++ Id.print x ++
         str " and " ++ Id.print y ++ strbrk " should appear in " ++ str s ++
         str " position as part of a recursive pattern.") in
+  (* TEMPORARY : no iteration *)
+  let recvars = Id.Map.of_list (List.map (fun l -> (List.hd l, List.hd (List.tl l))) recvars) in
   let check_type x typ =
     match typ with
     | NtnInternTypeAny _ ->
@@ -769,7 +785,9 @@ let[@warning "+9"] is_forgetful { forget_ltac; forget_volatile_cast } =
   forget_ltac || forget_volatile_cast
 
 let notation_constr_of_glob_constr nenv a =
-  let recvars = Id.Map.bindings nenv.ninterp_rec_vars in
+  let recvars = List.map pairs_of_notation nenv.ninterp_raw_types in
+  (* TEMPORARY : no iteration *)
+  let recvars = List.map (fun l -> (List.hd l, List.hd (List.tl l))) (List.filter (fun l -> not (List.is_empty l)) recvars) in
   let a, found, forgetful = notation_constr_and_vars_of_glob_constr recvars a in
   let injective = check_variables_and_reversibility nenv found in
   let status = if is_forgetful forgetful then Forgetful forgetful
@@ -788,7 +806,7 @@ let notation_constr_of_constr avoid t =
   let t = Detyping.detype Detyping.Now ~avoid env evd t in
   let nenv = {
     ninterp_var_type = Id.Map.empty;
-    ninterp_rec_vars = Id.Map.empty;
+    ninterp_raw_types = [];
   } in
   notation_constr_of_glob_constr nenv t
 
@@ -978,33 +996,29 @@ let rec push_context_binders vars = function
     push_context_binders vars bl
 
 let is_term_meta id metas =
-  try match Id.List.assoc id metas with NtnTypeConstr -> true | _ -> false
+  try match Id.List.assoc id metas with NtnTypeVar (_, NtnTypeVarConstr _) -> true | _ -> false
   with Not_found -> false
 
 let is_onlybinding_strict_meta id metas =
-  try match Id.List.assoc id metas with NtnTypeBinder (NtnBinderParsedAsSomeBinderKind AsStrictPattern) -> true | _ -> false
+  try match Id.List.assoc id metas with NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind AsStrictPattern)) -> true | _ -> false
   with Not_found -> false
 
 let is_onlybinding_meta id metas =
-  try match Id.List.assoc id metas with NtnTypeBinder _ -> true | _ -> false
+  try match Id.List.assoc id metas with NtnTypeVar (_, NtnTypeVarPattern _) -> true | _ -> false
   with Not_found -> false
 
-let is_onlybindinglist_meta id metas =
-  try match Id.List.assoc id metas with NtnTypeBinderList _ -> true | _ -> false
-  with Not_found -> false
-
-let is_onlybinding_pattern_like_meta isvar id metas =
+let is_onlybinding_pattern_like_meta ~strict ~isvar id metas =
   try match Id.List.assoc id metas with
-    | NtnTypeBinder (NtnBinderParsedAsConstr (AsAnyPattern | AsStrictPattern)) -> true
-    | NtnTypeBinder (NtnBinderParsedAsSomeBinderKind AsStrictPattern | NtnBinderParsedAsBinder) -> not isvar
-    | NtnTypeBinder (NtnBinderParsedAsSomeBinderKind AsAnyPattern) -> true
-    | NtnTypeBinder (NtnBinderParsedAsSomeBinderKind (AsIdent | AsName)) -> false
-    | NtnTypeBinder (NtnBinderParsedAsConstr (AsIdent | AsName)) -> false
-    | NtnTypeBinderList _ | NtnTypeConstr | NtnTypeConstrList -> false
+    | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsConstr (AsAnyPattern | AsStrictPattern))) -> true
+    | NtnTypeVar (_, NtnTypeVarPattern ((NtnBinderParsedAsSomeBinderKind AsStrictPattern | NtnBinderParsedAsBinder))) -> strict
+    | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind AsAnyPattern)) -> true
+    | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind (AsIdent | AsName))) -> isvar
+    | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsConstr (AsIdent | AsName))) -> isvar
+    | NtnTypeVar (_, (NtnTypeVarConstr _ | NtnTypeVarBinders _)) | NtnTypeVarList _ | NtnTypeVarTuple _ -> false
   with Not_found -> false
 
 let is_bindinglist_meta id metas =
-  try match Id.List.assoc id metas with NtnTypeBinderList _ -> true | _ -> false
+  try match Id.List.assoc id metas with NtnTypeVar (_, NtnTypeVarBinders _) -> true | _ -> false
   with Not_found -> false
 
 exception No_match
@@ -1016,7 +1030,7 @@ let alpha_rename renaming v =
 let static_binder_escape staticbinders v =
   List.exists (function (Name id,_) -> occur_glob_constr id v | (Anonymous,_) -> false) staticbinders
 
-let add_env {actualvars;staticbinders;renaming} (terms,termlists,binders,binderlists) var v =
+let add_env {actualvars;staticbinders;renaming} sigma var v =
   (* Check that no capture of binding variables occur *)
   (* [staticbinders] is used when matching a pattern "fun x => ... x ... ?var ... x ..."
      with an actual term "fun z => ... z ..." when "x" is not bound in the
@@ -1043,19 +1057,20 @@ let add_env {actualvars;staticbinders;renaming} (terms,termlists,binders,binderl
      refinement *)
   let v = alpha_rename renaming v in
   (* TODO: handle the case of multiple occs in different scopes *)
-  ((var,(actualvars,staticbinders,v))::terms,termlists,binders,binderlists)
+  Id.Map.add var (Constrexpr.NtnTypeArg (NtnTypeArgConstr (actualvars,staticbinders,v))) sigma
 
-let add_termlist_env {actualvars;staticbinders;renaming} (terms,termlists,binders,binderlists) var vl =
+let add_termlist_env {actualvars;staticbinders;renaming} sigma var vl =
   if List.exists (static_binder_escape staticbinders) vl then raise No_match;
   let vl = List.map (alpha_rename renaming) vl in
-  (terms,(var,(actualvars,vl))::termlists,binders,binderlists)
+  let vl = List.map (fun c -> NtnTypeArg (NtnTypeArgConstr (actualvars,staticbinders,c))) vl in
+  Id.Map.add var (NtnTypeArgList vl) sigma
 
-let add_binding_env {actualvars} (terms,termlists,binders,binderlists) var v =
+let add_binding_env {actualvars;staticbinders} sigma var v =
   (* TODO: handle the case of multiple occs in different scopes *)
-  (terms,termlists,(var,(actualvars,v))::binders,binderlists)
+  Id.Map.add var (NtnTypeArg (NtnTypeArgPattern (actualvars,staticbinders,v))) sigma
 
-let add_bindinglist_env {actualvars} (terms,termlists,binders,binderlists) var bl =
-  (terms,termlists,binders,(var,(actualvars,bl))::binderlists)
+let add_bindinglist_env {actualvars;staticbinders} sigma var bl =
+  Id.Map.add var (NtnTypeArg (NtnTypeArgBinders (actualvars,staticbinders,bl))) sigma
 
 let rec map_cases_pattern_name_left f = DAst.map (function
   | PatVar na -> PatVar (f na)
@@ -1196,33 +1211,52 @@ let rec unify_terms_binders renaming cl bl' =
      end
   | _ -> raise No_match
 
-let bind_term_env alp (terms,termlists,binders,binderlists as sigma) var v =
+let get_term = function
+  | Constrexpr.NtnTypeArg (NtnTypeArgConstr c) -> c
+  | _ -> raise Not_found
+
+let get_list f = function
+  | Constrexpr.NtnTypeArgList l -> List.map f l
+  | _ -> raise Not_found
+
+let get_pattern = function
+  | Constrexpr.NtnTypeArg (NtnTypeArgPattern b) -> b
+  | _ -> raise Not_found
+
+let get_binders = function
+  | Constrexpr.NtnTypeArg (NtnTypeArgBinders bl) -> bl
+  | _ -> raise Not_found
+
+let bind_term_env alp sigma var v =
   try
     (* If already bound to a term, unify with the new term *)
-    let vars,_alp',v' = Id.List.assoc var terms in
+    let vars, _ntnbinders', v' = get_term (Id.Map.find var sigma) in
     (* Note: at Notation definition time, it should have been checked that v and v' are
        in the same static context, i.e. alp.staticbinders = _alp'.staticbinders *)
     let v'' = unify_term alp.renaming v v' in
     if v'' == v' then sigma else
-      let sigma = (Id.List.remove_assoc var terms,termlists,binders,binderlists) in
+      let sigma = Id.Map.remove var sigma in
       let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
       add_env alp' sigma var v
   with Not_found -> add_env alp sigma var v
 
-let bind_termlist_env alp (terms,termlists,binders,binderlists as sigma) var vl =
+let bind_termlist_env alp sigma var vl =
   try
     (* If already bound to a list of term, unify with the new terms *)
-    let vars,vl' = Id.List.assoc var termlists in
+    let vl' = get_list get_term (Id.Map.find var sigma) in
+    let vars, varsl = List.sep_first (List.map pi1 vl') in
+    assert (List.for_all (Id.Set.equal vars) varsl);
+    let vl' = List.map pi3 vl' in
     let vl = unify_terms alp.renaming vl vl' in
-    let sigma = (terms,Id.List.remove_assoc var termlists,binders,binderlists) in
+    let sigma = Id.Map.remove var sigma in
     let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
     add_termlist_env alp' sigma var vl
   with Not_found -> add_termlist_env alp sigma var vl
 
-let bind_term_as_binding_env alp (terms,termlists,binders,binderlists as sigma) var id =
+let bind_ident_as_binding_env alp sigma var id =
   try
     (* If already bound to a term, unify the binder and the term *)
-    let vars',_alp',v' = Id.List.assoc var terms in
+    let vars', _alp', v' = get_term (Id.Map.find var sigma) in
     match DAst.get v' with
     | GVar id' | GRef (GlobRef.VarRef id',None) ->
        let {actualvars;staticbinders;renaming} = alp in
@@ -1239,44 +1273,44 @@ let bind_term_as_binding_env alp (terms,termlists,binders,binderlists as sigma) 
     (* TODO: look at the consequences for alp *)
     alp, add_env alp sigma var (DAst.make @@ GVar id)
 
-let bind_singleton_bindinglist_as_term_env alp (terms,termlists,binders,binderlists as sigma) var c =
+let bind_singleton_bindinglist_as_term_env alp sigma var c =
   try
     (* If already bound to a binder, unify the term and the binder *)
-    let vars,patl' = Id.List.assoc var binderlists in
+    let vars, _, patl' = get_binders (Id.Map.find var sigma) in
     let patl'' = unify_terms_binders alp.renaming [c] patl' in
     if patl' == patl'' then sigma
     else
-      let sigma = (terms,termlists,binders,Id.List.remove_assoc var binderlists) in
+      let sigma = Id.Map.remove var sigma in
       let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
       add_bindinglist_env alp' sigma var patl''
   with Not_found ->
     (* A term-as-binder occurs in the scope of a binder which is already bound *)
     anomaly (Pp.str "Unbound term as binder.")
 
-let bind_binding_as_term_env alp (terms,termlists,binders,binderlists as sigma) var c =
+let bind_binding_as_term_env alp sigma var c =
   let env = Global.env () in
   let pat = try cases_pattern_of_glob_constr env Anonymous c with Not_found -> raise No_match in
   try
     (* If already bound to a binder, unify the term and the binder *)
-    let vars,patl' = Id.List.assoc var binders in
-    let patl'' = List.map2 (unify_pat alp.renaming) [pat] patl' in
-    if patl' == patl'' then sigma
+    let vars, _, disjpatl' = get_pattern (Id.Map.find var sigma) in
+    let disjpatl'' = List.map2 (unify_pat alp.renaming) [pat] disjpatl' in
+    if disjpatl' == disjpatl'' then sigma
     else
-      let sigma = (terms,termlists,Id.List.remove_assoc var binders,binderlists) in
+      let sigma = Id.Map.remove var sigma  in
       let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
-      add_binding_env alp' sigma var patl''
+      add_binding_env alp' sigma var disjpatl''
   with Not_found -> add_binding_env alp sigma var [pat]
 
-let bind_binding_env alp (terms,termlists,binders,binderlists as sigma) var disjpat =
+let bind_binding_env alp sigma var disjpat =
   try
     (* If already bound to a binder possibly *)
     (* generating an alpha-renaming from unifying the new binder *)
-    let vars,disjpat' = Id.List.assoc var binders in
+    let vars, _, disjpat' = get_pattern (Id.Map.find var sigma) in
     (* if, maybe, there is eventually casts in patterns, the common types have *)
     (* to exclude the spine of variable from the two locations they occur *)
     let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
     let alp, disjpat = List.fold_left2_map unify_pat_upto alp disjpat disjpat' in
-    let sigma = (terms,termlists,Id.List.remove_assoc var binders,binderlists) in
+    let sigma = Id.Map.remove var sigma in
     alp, add_binding_env alp' sigma var disjpat
   with Not_found ->
     (* Note: all patterns of the disjunction are supposed to have the same
@@ -1284,30 +1318,30 @@ let bind_binding_env alp (terms,termlists,binders,binderlists as sigma) var disj
     let alp = {alp with actualvars = push_pattern_binders alp.actualvars (List.hd disjpat)} in
     alp, add_binding_env alp sigma var disjpat
 
-let bind_bindinglist_env alp (terms,termlists,binders,binderlists as sigma) var bl =
+let bind_bindinglist_env alp sigma var bl =
   let bl = List.rev bl in
   try
     (* If already bound to a list of binders possibly *)
     (* generating an alpha-renaming from unifying the new binders *)
-    let vars, bl' = Id.List.assoc var binderlists in
+    let vars, _, bl' = get_binders (Id.Map.find var sigma) in
     (* The shared subterm can be under two different spines of *)
     (* variables (themselves bound in the notation), so we take the *)
     (* union of both locations *)
     let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
     let alp, bl = unify_binders_upto alp bl bl' in
-    let sigma = (terms,termlists,binders,Id.List.remove_assoc var binderlists) in
+    let sigma = Id.Map.remove var sigma in
     alp, add_bindinglist_env alp' sigma var bl
   with Not_found ->
     let alp = {alp with actualvars = push_context_binders alp.actualvars bl} in
     alp, add_bindinglist_env alp sigma var bl
 
-let bind_bindinglist_as_termlist_env alp (terms,termlists,binders,binderlists) var cl =
+let bind_bindinglist_as_termlist_env alp sigma var cl =
   try
     (* If already bound to a list of binders, unify the terms and binders *)
-    let vars,bl' = Id.List.assoc var binderlists in
+    let vars, _, bl' = get_binders (Id.Map.find var sigma) in
     let bl = unify_terms_binders alp.renaming cl bl' in
     let alp = {alp with actualvars = Id.Set.union vars alp.actualvars} in
-    let sigma = (terms,termlists,binders,Id.List.remove_assoc var binderlists) in
+    let sigma = Id.Map.remove var sigma in
     add_bindinglist_env alp sigma var bl
   with Not_found ->
     anomaly (str "There should be a binder list bindings this list of terms.")
@@ -1331,14 +1365,14 @@ let match_opt f sigma t1 t2 = match (t1,t2) with
   | _ -> raise No_match
 
 let match_names metas (alp,sigma) na1 na2 = match (na1,na2) with
-  | (na1,Name id2) when is_onlybinding_strict_meta id2 metas ->
+  | (na1,Name id2) when is_onlybinding_strict_meta id2 metas (* strict pattern = not a variable *) ->
       raise No_match
   | (na1,Name id2) when is_onlybinding_meta id2 metas ->
       bind_binding_env alp sigma id2 [DAst.make (PatVar na1)]
   | (Name id1,Name id2) when is_term_meta id2 metas ->
       (* We let the non-binding occurrence define the rhs and hence reason up to *)
       (* alpha-conversion for the given occurrence of the name (see #4592)) *)
-      bind_term_as_binding_env alp sigma id2 id1
+      bind_ident_as_binding_env alp sigma id2 id1
   | (Anonymous,Name id2) when is_term_meta id2 metas ->
       (* We let the non-binding occurrence define the rhs *)
       alp, sigma
@@ -1347,16 +1381,16 @@ let match_names metas (alp,sigma) na1 na2 = match (na1,na2) with
   | (Anonymous,Anonymous) -> alp,sigma
   | _ -> raise No_match
 
+let isPatVar = function PatVar _ -> true | _ -> false
+
 let rec match_cases_pattern_binders allow_catchall metas (alp,sigma as acc) pat1 pat2 =
   match DAst.get pat1, DAst.get pat2 with
-  | PatVar _, PatVar (Name id2) when is_onlybinding_pattern_like_meta true id2 metas ->
+  | pat, PatVar (Name id2) when is_onlybinding_pattern_like_meta ~strict:(not (isPatVar pat)) ~isvar:(isPatVar pat) id2 metas ->
       bind_binding_env alp sigma id2 [pat1]
-  | PatVar id1, PatVar (Name id2) when is_onlybindinglist_meta id2 metas ->
+  | PatVar id1, PatVar (Name id2) when is_bindinglist_meta id2 metas ->
       let t1 = DAst.make @@ GHole(GBinderType id1) in
       bind_bindinglist_env alp sigma id2 [DAst.make @@ GLocalAssum (id1,None,Explicit,t1)]
-  | _, PatVar (Name id2) when is_onlybinding_pattern_like_meta false id2 metas ->
-      bind_binding_env alp sigma id2 [pat1]
-  | _, PatVar (Name id2) when is_onlybindinglist_meta id2 metas ->
+  | _, PatVar (Name id2) when is_bindinglist_meta id2 metas ->
       (* dummy data; should not be used anyway *)
       let id1 = Namegen.next_ident_away (Id.of_string "x") Id.Set.empty in
       let t1 = DAst.make @@ GHole(GBinderType (Name id1)) in
@@ -1370,15 +1404,11 @@ let rec match_cases_pattern_binders allow_catchall metas (alp,sigma as acc) pat1
         (match_names metas acc na1 na2) patl1 patl2
   | _ -> raise No_match
 
-let remove_sigma x (terms,termlists,binders,binderlists) =
-  (Id.List.remove_assoc x terms,termlists,binders,binderlists)
+let dummy_subscopes = ((constr_some_level,([],[])),Id.Set.empty)
 
-let remove_bindinglist_sigma x (terms,termlists,binders,binderlists) =
-  (terms,termlists,binders,Id.List.remove_assoc x binderlists)
+let add_ldots_var metas = (ldots_var,NtnTypeVar (dummy_subscopes, NtnTypeVarConstr (* Dummy: *)  NtnConstrForConstrAndPatternForPattern))::metas
 
-let add_ldots_var metas = (ldots_var,NtnTypeConstr)::metas
-
-let add_meta_bindinglist x metas = (x,NtnTypeBinderList (*arbitrary:*) NtnBinderParsedAsBinder)::metas
+let add_meta_bindinglist x metas = (x,NtnTypeVar ((*arbitrary:*) dummy_subscopes, NtnTypeVarBinders NtnBinderParsedAsBinder))::metas
 
 (* This tells if letins in the middle of binders should be included in
    the sequence of binders *)
@@ -1394,14 +1424,11 @@ let match_binderlist match_iter_fun match_termin_fun alp metas sigma rest x y it
   let rec aux trailing_letins alp sigma bl rest =
     try
       let metas = add_ldots_var (add_meta_bindinglist y metas) in
-      let (terms,_,_,binderlists as sigma) = match_iter_fun alp metas sigma rest iter in
-      let _,newstaticbinders,rest = Id.List.assoc ldots_var terms in
-      let b =
-        match Id.List.assoc y binderlists with _,[b] -> b | _ ->assert false
-      in
-      let sigma = remove_bindinglist_sigma y (remove_sigma ldots_var sigma) in
-      (* In case y is bound not only to a binder but also to a term *)
-      let sigma = remove_sigma y sigma in
+      let sigma = match_iter_fun alp metas sigma rest iter in
+      let _,newstaticbinders,rest = get_term (Id.Map.find ldots_var sigma) in
+      let _, _, b = get_binders (Id.Map.find y sigma) in
+      let b = match b with [b] -> b | _ -> assert false in
+      let sigma = Id.Map.remove y (Id.Map.remove ldots_var sigma) in
       let alp' = {alp with staticbinders = newstaticbinders} in
       aux false alp' sigma (b::bl) rest
     with No_match ->
@@ -1424,7 +1451,7 @@ let match_binderlist match_iter_fun match_termin_fun alp metas sigma rest x y it
   let alp,sigma = bind_bindinglist_env alp sigma x bl in
   match_termin_fun alp metas sigma rest termin
 
-let add_meta_term x metas = (x,NtnTypeConstr)::metas
+let add_meta_term x metas = (x,NtnTypeVar (dummy_subscopes, NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern))::metas
 
 type match_flags = {
   print_parentheses : bool;
@@ -1435,10 +1462,10 @@ let match_termlist flags match_fun alp metas sigma rest x y iter termin revert =
   let rec aux alp sigma acc rest =
     try
       let metas = add_ldots_var (add_meta_term y metas) in
-      let (terms,_,_,_ as sigma) = match_fun alp metas sigma rest iter in
-      let _,newstaticbinders,rest = Id.List.assoc ldots_var terms in
-      let vars,_,t = Id.List.assoc y terms in
-      let sigma = remove_sigma y (remove_sigma ldots_var sigma) in
+      let sigma = match_fun alp metas sigma rest iter in
+      let _,newstaticbinders,rest = get_term (Id.Map.find ldots_var sigma) in
+      let vars,_,t = get_term (Id.Map.find y sigma) in
+      let sigma = Id.Map.remove y (Id.Map.remove ldots_var sigma) in
       if flags.print_parentheses && not (List.is_empty acc) then raise No_match;
       (* The union is overkill at the current time because each term matches *)
       (* at worst the same binder metavariable of the same pattern *)
@@ -1446,7 +1473,7 @@ let match_termlist flags match_fun alp metas sigma rest x y iter termin revert =
       aux alp' sigma (t::acc) rest
     with No_match when not (List.is_empty acc) ->
       alp, acc, match_fun alp metas sigma rest termin in
-  let alp,l,(terms,termlists,binders,binderlists as sigma) = aux alp sigma [] rest in
+  let alp,l,sigma = aux alp sigma [] rest in
   let l = if revert then l else List.rev l in
   if is_bindinglist_meta x metas then
     (* This is a recursive pattern for both bindings and terms; it is *)
@@ -1484,10 +1511,7 @@ let rec match_ inner u alp metas sigma a1 a2 =
   match DAst.get a1, a2 with
   (* Matching notation variable *)
   | r1, NVar id2 when is_term_meta id2 metas -> bind_term_env alp sigma id2 a1
-  | r1, NVar id2 when is_var_term r1 && is_onlybinding_pattern_like_meta true id2 metas -> bind_binding_as_term_env alp sigma id2 a1
-  | r1, NVar id2 when is_onlybinding_pattern_like_meta false id2 metas -> bind_binding_as_term_env alp sigma id2 a1
-  | r1, NVar id2 when is_var_term r1 && is_onlybinding_strict_meta id2 metas -> raise No_match
-  | r1, NVar id2 when is_var_term r1 && is_onlybinding_meta id2 metas -> bind_binding_as_term_env alp sigma id2 a1
+  | r1, NVar id2 when is_onlybinding_pattern_like_meta ~strict:true ~isvar:(is_var_term r1) id2 metas -> bind_binding_as_term_env alp sigma id2 a1
   | r1, NVar id2 when is_bindinglist_meta id2 metas -> bind_singleton_bindinglist_as_term_env alp sigma id2 a1
 
   (* Matching recursive notations for terms *)
@@ -1657,7 +1681,7 @@ and match_extended_binders ?loc isprod u alp metas na1 na2 bk t sigma b1 b2 =
      match_in u alp metas sigma b1 b2
      | _ -> assert false)
   | Name p, GCases (LetPatternStyle,None,[(e,_)],(_::_ as eqns)), Name id
-       when is_gvar p e && is_onlybinding_pattern_like_meta false id metas && List.length (store (Detyping.factorize_eqns eqns)) = 1 ->
+       when is_gvar p e && is_onlybinding_pattern_like_meta ~strict:true ~isvar:false id metas && List.length (store (Detyping.factorize_eqns eqns)) = 1 ->
     (match get () with
      | [{CAst.v=(ids,disj_of_patl,b1)}] ->
      let disjpat = List.map (function [pat] -> pat | _ -> assert false) disj_of_patl in
@@ -1692,79 +1716,43 @@ and match_disjunctive_equations u alp metas sigma {CAst.v=(ids,disjpatl1,rhs1)} 
       (alp,sigma) disjpatl1 disjpatl2 in
   match_in u alp metas sigma rhs1 rhs2
 
-(* Turning substitution based on binding/term distinction into a
-   substitution based on entry production: indeed some binders may
-   have to be seen as terms from the parsing/printing point of view *)
-let group_by_type ids (terms,termlists,binders,binderlists) =
-  List.fold_right (fun (x,(scl,_,typ)) (terms',termlists',binders',binderlists') ->
-    match typ with
-    | NtnTypeConstr ->
-       (* term -> term *)
-       let vars,_alp',term = try Id.List.assoc x terms with Not_found -> raise No_match in
-       (((vars,term),scl)::terms',termlists',binders',binderlists')
-    | NtnTypeBinder (NtnBinderParsedAsConstr _) ->
-       (* binder -> term *)
-       (match Id.List.assoc x binders with
-        | vars,[pat] ->
-          let v = glob_constr_of_cases_pattern (Global.env()) pat in
-          (((vars,v),scl)::terms',termlists',binders',binderlists')
-        | _ -> raise No_match)
-    | NtnTypeBinder (NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _) ->
-       (* term list -> term list *)
-       (terms',termlists',(Id.List.assoc x binders,scl)::binders',binderlists')
-    | NtnTypeConstrList ->
-       (* term list -> term list *)
-       (terms',(Id.List.assoc x termlists,scl)::termlists',binders',binderlists')
-    | NtnTypeBinderList (NtnBinderParsedAsConstr _) ->
-       (* binder list -> term list *)
-       let vars,patl = try Id.List.assoc x binderlists with Not_found -> raise No_match in
-       let v = List.map (fun pat -> match DAst.get pat with
-           | GLocalPattern ((disjpat,_),_,_,_) ->
-             List.map (glob_constr_of_cases_pattern (Global.env())) disjpat
-           | GLocalAssum (Anonymous,_,bk,t) ->
-             let hole = DAst.make (GHole (GBinderType Anonymous)) in
-             [DAst.make (GCast (hole, Some DEFAULTcast, t))]
-           | GLocalAssum (Name id,_,bk,t) ->
-             [DAst.make (GCast (DAst.make (GVar id), Some DEFAULTcast, t))]
-           | GLocalDef _ -> raise No_match) patl in
-       (terms',((vars,List.flatten v),scl)::termlists',binders',binderlists')
-    | NtnTypeBinderList (NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _) ->
-      (* binder list -> binder list *)
-      let bl = try Id.List.assoc x binderlists with Not_found -> raise No_match in
-       (terms',termlists',binders',(bl,scl)::binderlists'))
-    ids ([],[],[],[])
+type 'a with_vars = Id.Set.t * (Name.t * Id.t) list * 'a
+
+type 'a glob_constr_notation_substitution =
+  ('a glob_constr_g with_vars, 'a cases_pattern_disjunction_g with_vars, 'a extended_glob_local_binder_g list with_vars) notation_arg_type
+    Id.Map.t
 
 let match_notation_constr ~print_parentheses ~print_univ c ~vars (metas,pat) =
-  let metatyps = List.map (fun (id,(_,_,typ)) -> (id,typ)) metas in
   let flags = { print_parentheses; print_universes = print_univ } in
-  let subst = match_ false flags {actualvars=vars;staticbinders=[];renaming=[]} metatyps ([],[],[],[]) c pat in
-  group_by_type metas subst
+  match_ false flags {actualvars=vars;staticbinders=[];renaming=[]} metas Id.Map.empty c pat
 
 (* Matching cases pattern *)
 
-let bind_env_cases_pattern (terms,x,termlists,y as sigma) var v =
+let bind_env_cases_pattern sigma var v =
   try
-    let vvar = Id.List.assoc var terms in
+    let vvar = Id.Map.find var sigma in
+    let vvar = get_pattern vvar in
     if cases_pattern_eq v vvar then sigma else raise No_match
   with Not_found ->
     (* TODO: handle the case of multiple occs in different scopes *)
-    (var,v)::terms,x,termlists,y
+    Id.Map.add var (Constrexpr.NtnTypeArg (NtnTypeArgPattern v)) sigma
 
 let match_cases_pattern_list match_fun metas sigma rest x y iter termin revert =
   let rec aux sigma acc rest =
     try
       let metas = add_ldots_var (add_meta_term y metas) in
-      let (terms,_,_,_ as sigma) = match_fun metas sigma rest iter in
-      let rest = Id.List.assoc ldots_var terms in
-      let t = Id.List.assoc y terms in
-      let sigma = remove_sigma y (remove_sigma ldots_var sigma) in
+      let sigma = match_fun metas sigma rest iter in
+      let rest = get_pattern (Id.Map.find ldots_var sigma) in
+      let t = get_pattern (Id.Map.find y sigma) in
+      let sigma = Id.Map.remove y (Id.Map.remove ldots_var sigma) in
       aux sigma (t::acc) rest
     with No_match when not (List.is_empty acc) ->
       acc, match_fun metas sigma rest termin in
-  let l,(terms,termlists,binders,binderlists as sigma) = aux sigma [] rest in
-  (terms,(x,if revert then l else List.rev l)::termlists,binders,binderlists)
+  let l,sigma = aux sigma [] rest in
+  let l = List.map (fun c -> NtnTypeArg (NtnTypeArgPattern c)) (if revert then l else List.rev l) in
+  Id.Map.add x (NtnTypeArgList l) sigma
 
-let rec match_cases_pattern metas (terms,termlists,(),() as sigma) a1 a2 =
+let rec match_cases_pattern metas sigma a1 a2 =
  match DAst.get a1, a2 with
   | r1, NVar id2 when Id.List.mem_assoc id2 metas -> (bind_env_cases_pattern sigma id2 a1),(false,0,[])
   | PatVar Anonymous, NHole _ -> sigma,(false,0,[])
@@ -1785,7 +1773,7 @@ let rec match_cases_pattern metas (terms,termlists,(),() as sigma) a1 a2 =
         (List.fold_left2 (match_cases_pattern_no_more_args metas) sigma l1' l2),(no_implicit,le2,more_args)
   | r1, NList (x,y,iter,termin,revert) ->
       (match_cases_pattern_list (match_cases_pattern_no_more_args)
-        metas (terms,termlists,(),()) a1 x y iter termin revert),(false,0,[])
+        metas sigma a1 x y iter termin revert),(false,0,[])
   | _ -> raise No_match
 
 and match_cases_pattern_no_more_args metas sigma a1 a2 =
@@ -1809,22 +1797,12 @@ let match_ind_pattern metas sigma ind pats a2 =
         (List.fold_left2 (match_cases_pattern_no_more_args metas) sigma l1' l2),(no_implicit,le2,more_args)
   |_ -> raise No_match
 
-let reorder_canonically_substitution terms termlists metas =
-  List.fold_right (fun (x,(scl,_,typ)) (terms',termlists',binders') ->
-    match typ with
-      | NtnTypeConstr | NtnTypeBinder (NtnBinderParsedAsConstr _) -> ((Id.List.assoc x terms, scl)::terms',termlists',binders')
-      | NtnTypeConstrList -> (terms',(Id.List.assoc x termlists,scl)::termlists',binders')
-      | NtnTypeBinder (NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _) ->
-         (terms',termlists',(Id.List.assoc x terms, scl)::binders')
-      | NtnTypeBinderList _ -> anomaly (str "Unexpected binder in pattern notation."))
-    metas ([],[],[])
+type 'a glob_cases_pattern_notation_substitution =
+  ('a glob_constr_g, 'a cases_pattern_g, unit) notation_arg_type
+    Id.Map.t
 
 let match_notation_constr_cases_pattern c (metas,pat) =
-  let metatyps = List.map (fun (id,(_,_,typ)) -> (id,typ)) metas in
-  let (terms,termlists,(),()),more_args = match_cases_pattern metatyps ([],[],(),()) c pat in
-  reorder_canonically_substitution terms termlists metas, more_args
+  (match_cases_pattern metas Id.Map.empty c pat)
 
 let match_notation_constr_ind_pattern ind args (metas,pat) =
-  let metatyps = List.map (fun (id,(_,_,typ)) -> (id,typ)) metas in
-  let (terms,termlists,(),()),more_args = match_ind_pattern metatyps ([],[],(),()) ind args pat in
-  reorder_canonically_substitution terms termlists metas, more_args
+  match_ind_pattern metas Id.Map.empty ind args pat

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -13,7 +13,6 @@ open CErrors
 open Util
 open Names
 open Nameops
-open Constr
 open Globnames
 open Glob_term
 open Glob_ops
@@ -996,31 +995,25 @@ let rec push_context_binders vars = function
     | GLocalDef (na,_,_,_) -> Termops.add_vname vars na in
     push_context_binders vars bl
 
-let is_term_meta id metas =
-  try match Id.List.assoc id metas with NtnTypeVar (_, NtnTypeVarConstr _) -> true | _ -> false
-  with Not_found -> false
+let is_term_meta = function
+  | NtnTypeVar (_, NtnTypeVarConstr _) -> true
+  | _ -> false
 
-let is_onlybinding_strict_meta id metas =
-  try match Id.List.assoc id metas with NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind AsStrictPattern)) -> true | _ -> false
-  with Not_found -> false
+let is_onlybinding_pattern_like_meta ~strict ~binder ~isvar = function
+  | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsConstr (AsAnyPattern | AsStrictPattern))) -> true
+  | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind AsStrictPattern)) -> strict
+  | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsBinder)) -> binder
+  | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind AsAnyPattern)) -> true
+  | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind (AsIdent | AsName))) -> isvar
+  | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsConstr (AsIdent | AsName))) -> isvar
+  | NtnTypeVar (_, (NtnTypeVarConstr _ | NtnTypeVarBinders _)) | NtnTypeVarList _ | NtnTypeVarTuple _ -> false
 
-let is_onlybinding_meta id metas =
-  try match Id.List.assoc id metas with NtnTypeVar (_, NtnTypeVarPattern _) -> true | _ -> false
-  with Not_found -> false
+let is_bindinglist_meta = function
+  | NtnTypeVar (_, NtnTypeVarBinders _) -> true
+  | _ -> false
 
-let is_onlybinding_pattern_like_meta ~strict ~isvar id metas =
-  try match Id.List.assoc id metas with
-    | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsConstr (AsAnyPattern | AsStrictPattern))) -> true
-    | NtnTypeVar (_, NtnTypeVarPattern ((NtnBinderParsedAsSomeBinderKind AsStrictPattern | NtnBinderParsedAsBinder))) -> strict
-    | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind AsAnyPattern)) -> true
-    | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind (AsIdent | AsName))) -> isvar
-    | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsConstr (AsIdent | AsName))) -> isvar
-    | NtnTypeVar (_, (NtnTypeVarConstr _ | NtnTypeVarBinders _)) | NtnTypeVarList _ | NtnTypeVarTuple _ -> false
-  with Not_found -> false
-
-let is_bindinglist_meta id metas =
-  try match Id.List.assoc id metas with NtnTypeVar (_, NtnTypeVarBinders _) -> true | _ -> false
-  with Not_found -> false
+let is_bindinglist_meta_var id metas =
+  try is_bindinglist_meta (Id.List.assoc id metas) with Not_found -> false
 
 exception No_match
 
@@ -1254,26 +1247,6 @@ let bind_termlist_env alp sigma var vl =
     add_termlist_env alp' sigma var vl
   with Not_found -> add_termlist_env alp sigma var vl
 
-let bind_ident_as_binding_env alp sigma var id =
-  try
-    (* If already bound to a term, unify the binder and the term *)
-    let vars', _alp', v' = get_term (Id.Map.find var sigma) in
-    match DAst.get v' with
-    | GVar id' | GRef (GlobRef.VarRef id',None) ->
-       let {actualvars;staticbinders;renaming} = alp in
-       let vars = Id.Set.add id' actualvars in
-       let renaming = if not (Id.equal id id') then (id,id')::renaming else renaming in
-       {actualvars = Id.Set.union vars' vars; staticbinders; renaming}, sigma
-    | t ->
-       (* The term is a non-variable pattern *)
-       raise No_match
-  with Not_found ->
-    let alp = {alp with actualvars = Id.Set.add id alp.actualvars} in
-    (* The matching against a term allowing to find the instance has not been found yet *)
-    (* If it will be a different name, we shall unfortunately fail *)
-    (* TODO: look at the consequences for alp *)
-    alp, add_env alp sigma var (DAst.make @@ GVar id)
-
 let bind_singleton_bindinglist_as_term_env alp sigma var c =
   try
     (* If already bound to a binder, unify the term and the binder *)
@@ -1365,39 +1338,62 @@ let match_opt f sigma t1 t2 = match (t1,t2) with
   | Some t1, Some t2 -> f sigma t1 t2
   | _ -> raise No_match
 
-let match_names metas (alp,sigma) na1 na2 = match (na1,na2) with
-  | (na1,Name id2) when is_onlybinding_strict_meta id2 metas (* strict pattern = not a variable *) ->
-      raise No_match
-  | (na1,Name id2) when is_onlybinding_meta id2 metas ->
-      bind_binding_env alp sigma id2 [DAst.make (PatVar na1)]
-  | (Name id1,Name id2) when is_term_meta id2 metas ->
-      (* We let the non-binding occurrence define the rhs and hence reason up to *)
-      (* alpha-conversion for the given occurrence of the name (see #4592)) *)
-      bind_ident_as_binding_env alp sigma id2 id1
-  | (Anonymous,Name id2) when is_term_meta id2 metas ->
-      (* We let the non-binding occurrence define the rhs *)
-      alp, sigma
-  | (na1,Name id2) ->
-      {alp with staticbinders = (na1,id2)::alp.staticbinders},sigma
+let is_meta_variable_name na metas =
+  match na with
+  | Name id -> (try Some (id, Id.List.assoc id metas) with Not_found -> None)
+  | Anonymous -> None
+
+let is_meta_variable_pat pat metas =
+  match pat with
+  | PatVar (Name id) -> (try Some (id, Id.List.assoc id metas) with Not_found -> None)
+  | _ -> None
+
+let is_meta_variable_term term metas =
+  match term with
+  | NVar id -> (try Some (id, Id.List.assoc id metas) with Not_found -> None)
+  | _ -> None
+
+let match_names_var (alp,sigma) na1 id2 typ =
+  if is_onlybinding_pattern_like_meta ~strict:false ~binder:true ~isvar:true typ then
+    bind_binding_env alp sigma id2 [DAst.make (PatVar na1)]
+  else
+    raise No_match
+
+let match_names_non_var (alp,sigma) na1 na2 =
+  match na1, na2 with
+  | (na1,Name id2) -> {alp with staticbinders = (na1,id2)::alp.staticbinders},sigma
   | (Anonymous,Anonymous) -> alp,sigma
   | _ -> raise No_match
+
+let match_names metas acc na1 na2 =
+  match is_meta_variable_name na2 metas with
+  | Some (id2, typ) -> match_names_var acc na1 id2 typ
+  | None -> match_names_non_var acc na1 na2
 
 let isPatVar = function PatVar _ -> true | _ -> false
 
 let rec match_cases_pattern_binders allow_catchall metas (alp,sigma as acc) pat1 pat2 =
-  match DAst.get pat1, DAst.get pat2 with
-  | pat, PatVar (Name id2) when is_onlybinding_pattern_like_meta ~strict:(not (isPatVar pat)) ~isvar:(isPatVar pat) id2 metas ->
+  let pat = DAst.get pat1 in
+  let pat2 = DAst.get pat2 in
+  match is_meta_variable_pat pat2 metas with
+  | Some (id2, typ) ->
+    if is_onlybinding_pattern_like_meta ~strict:(not (isPatVar pat)) ~binder:false ~isvar:(isPatVar pat) typ then
       bind_binding_env alp sigma id2 [pat1]
-  | PatVar id1, PatVar (Name id2) when is_bindinglist_meta id2 metas ->
-      let t1 = DAst.make @@ GHole(GBinderType id1) in
-      bind_bindinglist_env alp sigma id2 [DAst.make @@ GLocalAssum (id1,None,Explicit,t1)]
-  | _, PatVar (Name id2) when is_bindinglist_meta id2 metas ->
+    else if is_bindinglist_meta typ then
+      match pat with
+      | PatVar id1 ->
+        let t1 = DAst.make @@ GHole(GBinderType id1) in
+        bind_bindinglist_env alp sigma id2 [DAst.make @@ GLocalAssum (id1,None,Explicit,t1)]
+      | _ ->
       (* dummy data; should not be used anyway *)
       let id1 = Namegen.next_ident_away (Id.of_string "x") Id.Set.empty in
       let t1 = DAst.make @@ GHole(GBinderType (Name id1)) in
       let ids1 = [] in
       bind_bindinglist_env alp sigma id2 [DAst.make @@ GLocalPattern (([pat1],ids1),id1,Explicit,t1)]
-  | PatVar na1, PatVar na2 -> match_names metas acc na1 na2
+    else raise No_match
+  | None ->
+  match pat, pat2 with
+  | PatVar na1, PatVar na2 -> match_names_non_var acc na1 na2
   | _, PatVar Anonymous when allow_catchall -> acc
   | PatCstr (c1,patl1,na1), PatCstr (c2,patl2,na2)
       when Construct.CanOrd.equal c1 c2 && Int.equal (List.length patl1) (List.length patl2) ->
@@ -1476,7 +1472,7 @@ let match_termlist flags match_fun alp metas sigma rest x y iter termin revert =
       alp, acc, match_fun alp metas sigma rest termin in
   let alp,l,sigma = aux alp sigma [] rest in
   let l = if revert then l else List.rev l in
-  if is_bindinglist_meta x metas then
+  if is_bindinglist_meta_var x metas then
     (* This is a recursive pattern for both bindings and terms; it is *)
     (* registered for binders *)
     bind_bindinglist_as_termlist_env alp sigma x l
@@ -1509,12 +1505,16 @@ let is_var_term = function
 let rec match_ inner u alp metas sigma a1 a2 =
   let open CAst in
   let loc = a1.loc in
-  match DAst.get a1, a2 with
+  let r1 = DAst.get a1 in
   (* Matching notation variable *)
-  | r1, NVar id2 when is_term_meta id2 metas -> bind_term_env alp sigma id2 a1
-  | r1, NVar id2 when is_onlybinding_pattern_like_meta ~strict:true ~isvar:(is_var_term r1) id2 metas -> bind_binding_as_term_env alp sigma id2 a1
-  | r1, NVar id2 when is_bindinglist_meta id2 metas -> bind_singleton_bindinglist_as_term_env alp sigma id2 a1
-
+  match is_meta_variable_term a2 metas with
+  | Some (id2, typ) ->
+    if is_term_meta typ then bind_term_env alp sigma id2 a1 else
+    if is_onlybinding_pattern_like_meta ~strict:true ~binder:true ~isvar:(is_var_term r1) typ then bind_binding_as_term_env alp sigma id2 a1 else
+    if is_bindinglist_meta typ then bind_singleton_bindinglist_as_term_env alp sigma id2 a1 else
+      raise No_match
+  | None ->
+  match r1, a2 with
   (* Matching recursive notations for terms *)
   | r1, NList (x,y,iter,termin,revert) ->
       match_termlist u (match_hd u) alp metas sigma a1 x y iter termin revert
@@ -1638,7 +1638,7 @@ let rec match_ inner u alp metas sigma a1 a2 =
       | Some (NVar id2) -> bind_term_env alp sigma id2 t1
       | _ -> assert false in
       let (alp,sigma) =
-        if is_bindinglist_meta id metas then
+        if is_bindinglist_meta_var id metas then
           bind_bindinglist_env alp sigma id [DAst.make @@ GLocalAssum (Name id',None,Explicit,t1)]
         else
           match_names metas (alp,sigma) (Name id') na in
@@ -1669,36 +1669,40 @@ and match_binders u alp metas na1 na2 sigma b1 b2 =
   match_in u alp metas sigma b1 b2
 
 and match_extended_binders ?loc isprod u alp metas na1 na2 bk t sigma b1 b2 =
-  (* Match binders which can be substituted by a pattern *)
-  let store, get = set_temporary_memory () in
-  match na1, DAst.get b1, na2 with
-  (* Matching individual binders as part of a recursive pattern *)
-  | Name p, GCases (Constr.LetPatternStyle,None,[(e,_)],(_::_ as eqns)), Name id
-    when is_gvar p e && is_bindinglist_meta id metas
-         && List.length (store (Detyping.factorize_eqns ~flags:u.factorize_eqns eqns)) = 1 ->
-    (match get () with
-     | [{CAst.v=(ids,disj_of_patl,b1)}] ->
-     let disjpat = List.map (function [pat] -> pat | _ -> assert false) disj_of_patl in
-     let disjpat = if occur_glob_constr p b1 then List.map (set_pat_alias p) disjpat else disjpat in
-     let alp,sigma = bind_bindinglist_env alp sigma id [DAst.make ?loc @@ GLocalPattern ((disjpat,ids),p,bk,t)] in
-     match_in u alp metas sigma b1 b2
-     | _ -> assert false)
-  | Name p, GCases (LetPatternStyle,None,[(e,_)],(_::_ as eqns)), Name id
-       when is_gvar p e && is_onlybinding_pattern_like_meta ~strict:true ~isvar:false id metas && List.length (store (Detyping.factorize_eqns ~flags:u.factorize_eqns eqns)) = 1 ->
-    (match get () with
-     | [{CAst.v=(ids,disj_of_patl,b1)}] ->
-     let disjpat = List.map (function [pat] -> pat | _ -> assert false) disj_of_patl in
-     let disjpat = if occur_glob_constr p b1 then List.map (set_pat_alias p) disjpat else disjpat in
-     let alp,sigma = bind_binding_env alp sigma id disjpat in
-     match_in u alp metas sigma b1 b2
-     | _ -> assert false)
-  | _, _, Name id when is_bindinglist_meta id metas ->
-      if (isprod && na1 = Anonymous) then raise No_match (* prefer using "A -> B" for anonymous forall *);
-      let alp,sigma = bind_bindinglist_env alp sigma id [DAst.make ?loc @@ GLocalAssum (na1,None,bk,t)] in
-      match_in u alp metas sigma b1 b2
-  | _, _, _ ->
-     let (alp,sigma) = match_names metas (alp,sigma) na1 na2 in
-     match_in u alp metas sigma b1 b2
+  (* Match binders which can be substituted by a pattern: *)
+  (* that is, try to extract a pattern part in b2 that can be bound to na2 *)
+  match is_meta_variable_name na2 metas with
+  | Some (id2, typ) ->
+    (let store, get = set_temporary_memory () in
+    (* Matching individual binders as part of a recursive pattern *)
+    match na1, DAst.get b1 with
+    | Name p, GCases (Constr.LetPatternStyle,None,[(e,_)],(_::_ as eqns))
+      when is_gvar p e && (is_bindinglist_meta typ || is_onlybinding_pattern_like_meta ~strict:true ~binder:true ~isvar:false typ)
+           && List.length (store (Detyping.factorize_eqns ~flags:u.factorize_eqns eqns)) = 1 ->
+      (match get () with
+       | [{CAst.v=(ids,disj_of_patl,b1)}] ->
+         let disjpat = List.map (function [pat] -> pat | _ -> assert false) disj_of_patl in
+         let disjpat = if occur_glob_constr p b1 then List.map (set_pat_alias p) disjpat else disjpat in
+         let alp,sigma =
+           if is_bindinglist_meta typ then
+             bind_bindinglist_env alp sigma id2 [DAst.make ?loc @@ GLocalPattern ((disjpat,ids),p,bk,t)]
+           else
+             (* bk, t? *)
+             bind_binding_env alp sigma id2 disjpat in
+         match_in u alp metas sigma b1 b2
+       | _ -> assert false)
+    | _ ->
+      if is_bindinglist_meta typ then
+        begin
+          if (isprod && na1 = Anonymous) then raise No_match (* prefer using "A -> B" for anonymous forall *);
+          let alp,sigma = bind_bindinglist_env alp sigma id2 [DAst.make ?loc @@ GLocalAssum (na1,None,bk,t)] in
+          match_in u alp metas sigma b1 b2
+        end
+      else
+        let (alp,sigma) = match_names_var (alp,sigma) na1 id2 typ in
+        match_in u alp metas sigma b1 b2)
+  | None ->
+    match_binders u alp metas na1 na2 sigma b1 b2
 
 and match_equations u alp metas sigma {CAst.v=(ids,patl1,rhs1)} (patl2,rhs2) rest1 rest2 =
   (* patl1 and patl2 have the same length because they respectively

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -979,7 +979,7 @@ let rec push_context_binders vars = function
     push_context_binders vars bl
 
 let is_term_meta id metas =
-  try match Id.List.assoc id metas with NtnTypeConstr | NtnTypeConstrList -> true | _ -> false
+  try match Id.List.assoc id metas with NtnTypeConstr -> true | _ -> false
   with Not_found -> false
 
 let is_onlybinding_strict_meta id metas =

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -999,7 +999,7 @@ let is_term_meta = function
   | NtnTypeVar (_, NtnTypeVarConstr _) -> true
   | _ -> false
 
-let is_onlybinding_pattern_like_meta ~strict ~binder ~isvar = function
+let is_pattern_meta ~strict ~binder ~isvar = function
   | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsConstr (AsAnyPattern | AsStrictPattern))) -> true
   | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind AsStrictPattern)) -> strict
   | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsBinder)) -> binder
@@ -1008,12 +1008,12 @@ let is_onlybinding_pattern_like_meta ~strict ~binder ~isvar = function
   | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsConstr (AsIdent | AsName))) -> isvar
   | NtnTypeVar (_, (NtnTypeVarConstr _ | NtnTypeVarBinders _)) | NtnTypeVarList _ | NtnTypeVarTuple _ -> false
 
-let is_bindinglist_meta = function
+let is_binders_meta = function
   | NtnTypeVar (_, NtnTypeVarBinders _) -> true
   | _ -> false
 
-let is_bindinglist_meta_var id metas =
-  try is_bindinglist_meta (Id.List.assoc id metas) with Not_found -> false
+let is_binders_meta_var id metas =
+  try is_binders_meta (Id.List.assoc id metas) with Not_found -> false
 
 exception No_match
 
@@ -1024,7 +1024,7 @@ let alpha_rename renaming v =
 let static_binder_escape staticbinders v =
   List.exists (function (Name id,_) -> occur_glob_constr id v | (Anonymous,_) -> false) staticbinders
 
-let add_env {actualvars;staticbinders;renaming} sigma var v =
+let add_term_env {actualvars;staticbinders;renaming} sigma var v =
   (* Check that no capture of binding variables occur *)
   (* [staticbinders] is used when matching a pattern "fun x => ... x ... ?var ... x ..."
      with an actual term "fun z => ... z ..." when "x" is not bound in the
@@ -1059,11 +1059,11 @@ let add_termlist_env {actualvars;staticbinders;renaming} sigma var vl =
   let vl = List.map (fun c -> NtnTypeArg (NtnTypeArgConstr (actualvars,staticbinders,c))) vl in
   Id.Map.add var (NtnTypeArgList vl) sigma
 
-let add_binding_env {actualvars;staticbinders} sigma var v =
+let add_pattern_env {actualvars;staticbinders} sigma var v =
   (* TODO: handle the case of multiple occs in different scopes *)
   Id.Map.add var (NtnTypeArg (NtnTypeArgPattern (actualvars,staticbinders,v))) sigma
 
-let add_bindinglist_env {actualvars;staticbinders} sigma var bl =
+let add_binders_env {actualvars;staticbinders} sigma var bl =
   Id.Map.add var (NtnTypeArg (NtnTypeArgBinders (actualvars,staticbinders,bl))) sigma
 
 let rec map_cases_pattern_name_left f = DAst.map (function
@@ -1231,8 +1231,8 @@ let bind_term_env alp sigma var v =
     if v'' == v' then sigma else
       let sigma = Id.Map.remove var sigma in
       let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
-      add_env alp' sigma var v
-  with Not_found -> add_env alp sigma var v
+      add_term_env alp' sigma var v
+  with Not_found -> add_term_env alp sigma var v
 
 let bind_termlist_env alp sigma var vl =
   try
@@ -1247,7 +1247,7 @@ let bind_termlist_env alp sigma var vl =
     add_termlist_env alp' sigma var vl
   with Not_found -> add_termlist_env alp sigma var vl
 
-let bind_singleton_bindinglist_as_term_env alp sigma var c =
+let bind_singleton_binders_as_term_env alp sigma var c =
   try
     (* If already bound to a binder, unify the term and the binder *)
     let vars, _, patl' = get_binders (Id.Map.find var sigma) in
@@ -1256,12 +1256,12 @@ let bind_singleton_bindinglist_as_term_env alp sigma var c =
     else
       let sigma = Id.Map.remove var sigma in
       let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
-      add_bindinglist_env alp' sigma var patl''
+      add_binders_env alp' sigma var patl''
   with Not_found ->
     (* A term-as-binder occurs in the scope of a binder which is already bound *)
     anomaly (Pp.str "Unbound term as binder.")
 
-let bind_binding_as_term_env alp sigma var c =
+let bind_pattern_as_term_env alp sigma var c =
   let env = Global.env () in
   let pat = try cases_pattern_of_glob_constr env Anonymous c with Not_found -> raise No_match in
   try
@@ -1272,10 +1272,10 @@ let bind_binding_as_term_env alp sigma var c =
     else
       let sigma = Id.Map.remove var sigma  in
       let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
-      add_binding_env alp' sigma var disjpatl''
-  with Not_found -> add_binding_env alp sigma var [pat]
+      add_pattern_env alp' sigma var disjpatl''
+  with Not_found -> add_pattern_env alp sigma var [pat]
 
-let bind_binding_env alp sigma var disjpat =
+let bind_pattern_env alp sigma var disjpat =
   try
     (* If already bound to a binder possibly *)
     (* generating an alpha-renaming from unifying the new binder *)
@@ -1285,14 +1285,14 @@ let bind_binding_env alp sigma var disjpat =
     let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
     let alp, disjpat = List.fold_left2_map unify_pat_upto alp disjpat disjpat' in
     let sigma = Id.Map.remove var sigma in
-    alp, add_binding_env alp' sigma var disjpat
+    alp, add_pattern_env alp' sigma var disjpat
   with Not_found ->
     (* Note: all patterns of the disjunction are supposed to have the same
        variables, thus one is enough *)
     let alp = {alp with actualvars = push_pattern_binders alp.actualvars (List.hd disjpat)} in
-    alp, add_binding_env alp sigma var disjpat
+    alp, add_pattern_env alp sigma var disjpat
 
-let bind_bindinglist_env alp sigma var bl =
+let bind_binders_env alp sigma var bl =
   let bl = List.rev bl in
   try
     (* If already bound to a list of binders possibly *)
@@ -1304,19 +1304,19 @@ let bind_bindinglist_env alp sigma var bl =
     let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
     let alp, bl = unify_binders_upto alp bl bl' in
     let sigma = Id.Map.remove var sigma in
-    alp, add_bindinglist_env alp' sigma var bl
+    alp, add_binders_env alp' sigma var bl
   with Not_found ->
     let alp = {alp with actualvars = push_context_binders alp.actualvars bl} in
-    alp, add_bindinglist_env alp sigma var bl
+    alp, add_binders_env alp sigma var bl
 
-let bind_bindinglist_as_termlist_env alp sigma var cl =
+let bind_binders_as_termlist_env alp sigma var cl =
   try
     (* If already bound to a list of binders, unify the terms and binders *)
     let vars, _, bl' = get_binders (Id.Map.find var sigma) in
     let bl = unify_terms_binders alp.renaming cl bl' in
     let alp = {alp with actualvars = Id.Set.union vars alp.actualvars} in
     let sigma = Id.Map.remove var sigma in
-    add_bindinglist_env alp sigma var bl
+    add_binders_env alp sigma var bl
   with Not_found ->
     anomaly (str "There should be a binder list bindings this list of terms.")
 
@@ -1354,8 +1354,8 @@ let is_meta_variable_term term metas =
   | _ -> None
 
 let match_names_var (alp,sigma) na1 id2 typ =
-  if is_onlybinding_pattern_like_meta ~strict:false ~binder:true ~isvar:true typ then
-    bind_binding_env alp sigma id2 [DAst.make (PatVar na1)]
+  if is_pattern_meta ~strict:false ~binder:true ~isvar:true typ then
+    bind_pattern_env alp sigma id2 [DAst.make (PatVar na1)]
   else
     raise No_match
 
@@ -1377,19 +1377,19 @@ let rec match_cases_pattern_binders allow_catchall metas (alp,sigma as acc) pat1
   let pat2 = DAst.get pat2 in
   match is_meta_variable_pat pat2 metas with
   | Some (id2, typ) ->
-    if is_onlybinding_pattern_like_meta ~strict:(not (isPatVar pat)) ~binder:false ~isvar:(isPatVar pat) typ then
-      bind_binding_env alp sigma id2 [pat1]
-    else if is_bindinglist_meta typ then
+    if is_pattern_meta ~strict:(not (isPatVar pat)) ~binder:false ~isvar:(isPatVar pat) typ then
+      bind_pattern_env alp sigma id2 [pat1]
+    else if is_binders_meta typ then
       match pat with
       | PatVar id1 ->
         let t1 = DAst.make @@ GHole(GBinderType id1) in
-        bind_bindinglist_env alp sigma id2 [DAst.make @@ GLocalAssum (id1,None,Explicit,t1)]
+        bind_binders_env alp sigma id2 [DAst.make @@ GLocalAssum (id1,None,Explicit,t1)]
       | _ ->
       (* dummy data; should not be used anyway *)
       let id1 = Namegen.next_ident_away (Id.of_string "x") Id.Set.empty in
       let t1 = DAst.make @@ GHole(GBinderType (Name id1)) in
       let ids1 = [] in
-      bind_bindinglist_env alp sigma id2 [DAst.make @@ GLocalPattern (([pat1],ids1),id1,Explicit,t1)]
+      bind_binders_env alp sigma id2 [DAst.make @@ GLocalPattern (([pat1],ids1),id1,Explicit,t1)]
     else raise No_match
   | None ->
   match pat, pat2 with
@@ -1405,7 +1405,7 @@ let dummy_subscopes = ((constr_some_level,([],[])),Id.Set.empty)
 
 let add_ldots_var metas = (ldots_var,NtnTypeVar (dummy_subscopes, NtnTypeVarConstr (* Dummy: *)  NtnConstrForConstrAndPatternForPattern))::metas
 
-let add_meta_bindinglist x metas = (x,NtnTypeVar ((*arbitrary:*) dummy_subscopes, NtnTypeVarBinders NtnBinderParsedAsBinder))::metas
+let add_meta_binders x metas = (x,NtnTypeVar ((*arbitrary:*) dummy_subscopes, NtnTypeVarBinders NtnBinderParsedAsBinder))::metas
 
 (* This tells if letins in the middle of binders should be included in
    the sequence of binders *)
@@ -1420,7 +1420,7 @@ exception OnlyTrailingLetIns
 let match_binderlist match_iter_fun match_termin_fun alp metas sigma rest x y iter termin revert =
   let rec aux trailing_letins alp sigma bl rest =
     try
-      let metas = add_ldots_var (add_meta_bindinglist y metas) in
+      let metas = add_ldots_var (add_meta_binders y metas) in
       let sigma = match_iter_fun alp metas sigma rest iter in
       let _,newstaticbinders,rest = get_term (Id.Map.find ldots_var sigma) in
       let _, _, b = get_binders (Id.Map.find y sigma) in
@@ -1445,7 +1445,7 @@ let match_binderlist match_iter_fun match_termin_fun alp metas sigma rest x y it
        if not (List.is_empty bl) then alp, bl, rest, sigma else raise No_match in
   let alp,bl,rest,sigma = aux false alp sigma [] rest in
   let bl = if revert then List.rev bl else bl in
-  let alp,sigma = bind_bindinglist_env alp sigma x bl in
+  let alp,sigma = bind_binders_env alp sigma x bl in
   match_termin_fun alp metas sigma rest termin
 
 let add_meta_term x metas = (x,NtnTypeVar (dummy_subscopes, NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern))::metas
@@ -1472,10 +1472,10 @@ let match_termlist flags match_fun alp metas sigma rest x y iter termin revert =
       alp, acc, match_fun alp metas sigma rest termin in
   let alp,l,sigma = aux alp sigma [] rest in
   let l = if revert then l else List.rev l in
-  if is_bindinglist_meta_var x metas then
+  if is_binders_meta_var x metas then
     (* This is a recursive pattern for both bindings and terms; it is *)
     (* registered for binders *)
-    bind_bindinglist_as_termlist_env alp sigma x l
+    bind_binders_as_termlist_env alp sigma x l
   else
     bind_termlist_env alp sigma x l
 
@@ -1510,8 +1510,8 @@ let rec match_ inner u alp metas sigma a1 a2 =
   match is_meta_variable_term a2 metas with
   | Some (id2, typ) ->
     if is_term_meta typ then bind_term_env alp sigma id2 a1 else
-    if is_onlybinding_pattern_like_meta ~strict:true ~binder:true ~isvar:(is_var_term r1) typ then bind_binding_as_term_env alp sigma id2 a1 else
-    if is_bindinglist_meta typ then bind_singleton_bindinglist_as_term_env alp sigma id2 a1 else
+    if is_pattern_meta ~strict:true ~binder:true ~isvar:(is_var_term r1) typ then bind_pattern_as_term_env alp sigma id2 a1 else
+    if is_binders_meta typ then bind_singleton_binders_as_term_env alp sigma id2 a1 else
       raise No_match
   | None ->
   match r1, a2 with
@@ -1638,8 +1638,8 @@ let rec match_ inner u alp metas sigma a1 a2 =
       | Some (NVar id2) -> bind_term_env alp sigma id2 t1
       | _ -> assert false in
       let (alp,sigma) =
-        if is_bindinglist_meta_var id metas then
-          bind_bindinglist_env alp sigma id [DAst.make @@ GLocalAssum (Name id',None,Explicit,t1)]
+        if is_binders_meta_var id metas then
+          bind_binders_env alp sigma id [DAst.make @@ GLocalAssum (Name id',None,Explicit,t1)]
         else
           match_names metas (alp,sigma) (Name id') na in
       match_in u alp metas sigma (mkGApp a1 [DAst.make @@ GVar id']) b2
@@ -1677,25 +1677,25 @@ and match_extended_binders ?loc isprod u alp metas na1 na2 bk t sigma b1 b2 =
     (* Matching individual binders as part of a recursive pattern *)
     match na1, DAst.get b1 with
     | Name p, GCases (Constr.LetPatternStyle,None,[(e,_)],(_::_ as eqns))
-      when is_gvar p e && (is_bindinglist_meta typ || is_onlybinding_pattern_like_meta ~strict:true ~binder:true ~isvar:false typ)
+      when is_gvar p e && (is_binders_meta typ || is_pattern_meta ~strict:true ~binder:true ~isvar:false typ)
            && List.length (store (Detyping.factorize_eqns ~flags:u.factorize_eqns eqns)) = 1 ->
       (match get () with
        | [{CAst.v=(ids,disj_of_patl,b1)}] ->
          let disjpat = List.map (function [pat] -> pat | _ -> assert false) disj_of_patl in
          let disjpat = if occur_glob_constr p b1 then List.map (set_pat_alias p) disjpat else disjpat in
          let alp,sigma =
-           if is_bindinglist_meta typ then
-             bind_bindinglist_env alp sigma id2 [DAst.make ?loc @@ GLocalPattern ((disjpat,ids),p,bk,t)]
+           if is_binders_meta typ then
+             bind_binders_env alp sigma id2 [DAst.make ?loc @@ GLocalPattern ((disjpat,ids),p,bk,t)]
            else
              (* bk, t? *)
-             bind_binding_env alp sigma id2 disjpat in
+             bind_pattern_env alp sigma id2 disjpat in
          match_in u alp metas sigma b1 b2
        | _ -> assert false)
     | _ ->
-      if is_bindinglist_meta typ then
+      if is_binders_meta typ then
         begin
           if (isprod && na1 = Anonymous) then raise No_match (* prefer using "A -> B" for anonymous forall *);
-          let alp,sigma = bind_bindinglist_env alp sigma id2 [DAst.make ?loc @@ GLocalAssum (na1,None,bk,t)] in
+          let alp,sigma = bind_binders_env alp sigma id2 [DAst.make ?loc @@ GLocalAssum (na1,None,bk,t)] in
           match_in u alp metas sigma b1 b2
         end
       else

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -19,6 +19,7 @@ open Glob_term
 open Glob_ops
 open Mod_subst
 open Notation_term
+open Constrexpr
 
 (** Constr default entry *)
 
@@ -718,12 +719,25 @@ let notation_constr_and_vars_of_glob_constr recvars a =
   (* Side effect *)
   t, !found, !forgetful
 
+let rec make_iterated_pairs : type s. (s -> Id.t list) -> s notation_raw_type -> Id.t list =
+  fun f -> function
+  | NtnRawTypeVar x -> f x
+  | NtnRawTypeVarList typ -> make_iterated_pairs (fun (x,y) -> f x @ f y) typ
+  | NtnRawTypeVarTuple typs -> List.map_append (make_iterated_pairs f) typs
+
+let rec pairs_of_notation = function
+  | NtnRawTypeVar _ -> []
+  | NtnRawTypeVarList typ -> make_iterated_pairs (fun (x,y) -> [x;y]) typ
+  | NtnRawTypeVarTuple l -> List.map_append pairs_of_notation l
+
 let check_variables_and_reversibility nenv
   { vars = found; recursive_term_vars = foundrec; recursive_binders_vars = foundrecbinding } =
   let injective = ref [] in
-  let recvars = nenv.ninterp_rec_vars in
-  let fold _ y accu = Id.Set.add y accu in
-  let useless_vars = Id.Map.fold fold recvars Id.Set.empty in
+  let recvars = List.map pairs_of_notation nenv.ninterp_raw_types in
+  (* We have iterated tuples (pairs, pairs of pairs, etc.) where the first name is the reference *)
+  let recvars = List.filter (fun l -> not (List.is_empty l)) recvars in
+  let fold l accu = List.fold_right Id.Set.add (List.tl l) accu in
+  let useless_vars = List.fold_right fold recvars Id.Set.empty in
   let filter y _ = not (Id.Set.mem y useless_vars) in
   let vars = Id.Map.filter filter nenv.ninterp_var_type in
   let check_recvar x =
@@ -750,6 +764,8 @@ let check_variables_and_reversibility nenv
       user_err  (strbrk "in the right-hand side, " ++ Id.print x ++
         str " and " ++ Id.print y ++ strbrk " should appear in " ++ str s ++
         str " position as part of a recursive pattern.") in
+  (* TEMPORARY : no iteration *)
+  let recvars = Id.Map.of_list (List.map (fun l -> (List.hd l, List.hd (List.tl l))) recvars) in
   let check_type x typ =
     match typ with
     | NtnInternTypeAny _ ->
@@ -769,7 +785,9 @@ let[@warning "+9"] is_forgetful { forget_ltac; forget_volatile_cast } =
   forget_ltac || forget_volatile_cast
 
 let notation_constr_of_glob_constr nenv a =
-  let recvars = Id.Map.bindings nenv.ninterp_rec_vars in
+  let recvars = List.map pairs_of_notation nenv.ninterp_raw_types in
+  (* TEMPORARY : no iteration *)
+  let recvars = List.map (fun l -> (List.hd l, List.hd (List.tl l))) (List.filter (fun l -> not (List.is_empty l)) recvars) in
   let a, found, forgetful = notation_constr_and_vars_of_glob_constr recvars a in
   let injective = check_variables_and_reversibility nenv found in
   let status = if is_forgetful forgetful then Forgetful forgetful
@@ -788,7 +806,7 @@ let notation_constr_of_constr ~flags avoid t =
   let t = Detyping.detype Detyping.Now ~flags ~avoid env evd t in
   let nenv = {
     ninterp_var_type = Id.Map.empty;
-    ninterp_rec_vars = Id.Map.empty;
+    ninterp_raw_types = [];
   } in
   notation_constr_of_glob_constr nenv t
 
@@ -979,33 +997,29 @@ let rec push_context_binders vars = function
     push_context_binders vars bl
 
 let is_term_meta id metas =
-  try match Id.List.assoc id metas with NtnTypeConstr -> true | _ -> false
+  try match Id.List.assoc id metas with NtnTypeVar (_, NtnTypeVarConstr _) -> true | _ -> false
   with Not_found -> false
 
 let is_onlybinding_strict_meta id metas =
-  try match Id.List.assoc id metas with NtnTypeBinder (NtnBinderParsedAsSomeBinderKind AsStrictPattern) -> true | _ -> false
+  try match Id.List.assoc id metas with NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind AsStrictPattern)) -> true | _ -> false
   with Not_found -> false
 
 let is_onlybinding_meta id metas =
-  try match Id.List.assoc id metas with NtnTypeBinder _ -> true | _ -> false
+  try match Id.List.assoc id metas with NtnTypeVar (_, NtnTypeVarPattern _) -> true | _ -> false
   with Not_found -> false
 
-let is_onlybindinglist_meta id metas =
-  try match Id.List.assoc id metas with NtnTypeBinderList _ -> true | _ -> false
-  with Not_found -> false
-
-let is_onlybinding_pattern_like_meta isvar id metas =
+let is_onlybinding_pattern_like_meta ~strict ~isvar id metas =
   try match Id.List.assoc id metas with
-    | NtnTypeBinder (NtnBinderParsedAsConstr (AsAnyPattern | AsStrictPattern)) -> true
-    | NtnTypeBinder (NtnBinderParsedAsSomeBinderKind AsStrictPattern | NtnBinderParsedAsBinder) -> not isvar
-    | NtnTypeBinder (NtnBinderParsedAsSomeBinderKind AsAnyPattern) -> true
-    | NtnTypeBinder (NtnBinderParsedAsSomeBinderKind (AsIdent | AsName)) -> false
-    | NtnTypeBinder (NtnBinderParsedAsConstr (AsIdent | AsName)) -> false
-    | NtnTypeBinderList _ | NtnTypeConstr | NtnTypeConstrList -> false
+    | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsConstr (AsAnyPattern | AsStrictPattern))) -> true
+    | NtnTypeVar (_, NtnTypeVarPattern ((NtnBinderParsedAsSomeBinderKind AsStrictPattern | NtnBinderParsedAsBinder))) -> strict
+    | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind AsAnyPattern)) -> true
+    | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind (AsIdent | AsName))) -> isvar
+    | NtnTypeVar (_, NtnTypeVarPattern (NtnBinderParsedAsConstr (AsIdent | AsName))) -> isvar
+    | NtnTypeVar (_, (NtnTypeVarConstr _ | NtnTypeVarBinders _)) | NtnTypeVarList _ | NtnTypeVarTuple _ -> false
   with Not_found -> false
 
 let is_bindinglist_meta id metas =
-  try match Id.List.assoc id metas with NtnTypeBinderList _ -> true | _ -> false
+  try match Id.List.assoc id metas with NtnTypeVar (_, NtnTypeVarBinders _) -> true | _ -> false
   with Not_found -> false
 
 exception No_match
@@ -1017,7 +1031,7 @@ let alpha_rename renaming v =
 let static_binder_escape staticbinders v =
   List.exists (function (Name id,_) -> occur_glob_constr id v | (Anonymous,_) -> false) staticbinders
 
-let add_env {actualvars;staticbinders;renaming} (terms,termlists,binders,binderlists) var v =
+let add_env {actualvars;staticbinders;renaming} sigma var v =
   (* Check that no capture of binding variables occur *)
   (* [staticbinders] is used when matching a pattern "fun x => ... x ... ?var ... x ..."
      with an actual term "fun z => ... z ..." when "x" is not bound in the
@@ -1044,19 +1058,20 @@ let add_env {actualvars;staticbinders;renaming} (terms,termlists,binders,binderl
      refinement *)
   let v = alpha_rename renaming v in
   (* TODO: handle the case of multiple occs in different scopes *)
-  ((var,(actualvars,staticbinders,v))::terms,termlists,binders,binderlists)
+  Id.Map.add var (Constrexpr.NtnTypeArg (NtnTypeArgConstr (actualvars,staticbinders,v))) sigma
 
-let add_termlist_env {actualvars;staticbinders;renaming} (terms,termlists,binders,binderlists) var vl =
+let add_termlist_env {actualvars;staticbinders;renaming} sigma var vl =
   if List.exists (static_binder_escape staticbinders) vl then raise No_match;
   let vl = List.map (alpha_rename renaming) vl in
-  (terms,(var,(actualvars,vl))::termlists,binders,binderlists)
+  let vl = List.map (fun c -> NtnTypeArg (NtnTypeArgConstr (actualvars,staticbinders,c))) vl in
+  Id.Map.add var (NtnTypeArgList vl) sigma
 
-let add_binding_env {actualvars} (terms,termlists,binders,binderlists) var v =
+let add_binding_env {actualvars;staticbinders} sigma var v =
   (* TODO: handle the case of multiple occs in different scopes *)
-  (terms,termlists,(var,(actualvars,v))::binders,binderlists)
+  Id.Map.add var (NtnTypeArg (NtnTypeArgPattern (actualvars,staticbinders,v))) sigma
 
-let add_bindinglist_env {actualvars} (terms,termlists,binders,binderlists) var bl =
-  (terms,termlists,binders,(var,(actualvars,bl))::binderlists)
+let add_bindinglist_env {actualvars;staticbinders} sigma var bl =
+  Id.Map.add var (NtnTypeArg (NtnTypeArgBinders (actualvars,staticbinders,bl))) sigma
 
 let rec map_cases_pattern_name_left f = DAst.map (function
   | PatVar na -> PatVar (f na)
@@ -1197,33 +1212,52 @@ let rec unify_terms_binders renaming cl bl' =
      end
   | _ -> raise No_match
 
-let bind_term_env alp (terms,termlists,binders,binderlists as sigma) var v =
+let get_term = function
+  | Constrexpr.NtnTypeArg (NtnTypeArgConstr c) -> c
+  | _ -> raise Not_found
+
+let get_list f = function
+  | Constrexpr.NtnTypeArgList l -> List.map f l
+  | _ -> raise Not_found
+
+let get_pattern = function
+  | Constrexpr.NtnTypeArg (NtnTypeArgPattern b) -> b
+  | _ -> raise Not_found
+
+let get_binders = function
+  | Constrexpr.NtnTypeArg (NtnTypeArgBinders bl) -> bl
+  | _ -> raise Not_found
+
+let bind_term_env alp sigma var v =
   try
     (* If already bound to a term, unify with the new term *)
-    let vars,_alp',v' = Id.List.assoc var terms in
+    let vars, _ntnbinders', v' = get_term (Id.Map.find var sigma) in
     (* Note: at Notation definition time, it should have been checked that v and v' are
        in the same static context, i.e. alp.staticbinders = _alp'.staticbinders *)
     let v'' = unify_term alp.renaming v v' in
     if v'' == v' then sigma else
-      let sigma = (Id.List.remove_assoc var terms,termlists,binders,binderlists) in
+      let sigma = Id.Map.remove var sigma in
       let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
       add_env alp' sigma var v
   with Not_found -> add_env alp sigma var v
 
-let bind_termlist_env alp (terms,termlists,binders,binderlists as sigma) var vl =
+let bind_termlist_env alp sigma var vl =
   try
     (* If already bound to a list of term, unify with the new terms *)
-    let vars,vl' = Id.List.assoc var termlists in
+    let vl' = get_list get_term (Id.Map.find var sigma) in
+    let vars, varsl = List.sep_first (List.map pi1 vl') in
+    assert (List.for_all (Id.Set.equal vars) varsl);
+    let vl' = List.map pi3 vl' in
     let vl = unify_terms alp.renaming vl vl' in
-    let sigma = (terms,Id.List.remove_assoc var termlists,binders,binderlists) in
+    let sigma = Id.Map.remove var sigma in
     let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
     add_termlist_env alp' sigma var vl
   with Not_found -> add_termlist_env alp sigma var vl
 
-let bind_term_as_binding_env alp (terms,termlists,binders,binderlists as sigma) var id =
+let bind_ident_as_binding_env alp sigma var id =
   try
     (* If already bound to a term, unify the binder and the term *)
-    let vars',_alp',v' = Id.List.assoc var terms in
+    let vars', _alp', v' = get_term (Id.Map.find var sigma) in
     match DAst.get v' with
     | GVar id' | GRef (GlobRef.VarRef id',None) ->
        let {actualvars;staticbinders;renaming} = alp in
@@ -1240,44 +1274,44 @@ let bind_term_as_binding_env alp (terms,termlists,binders,binderlists as sigma) 
     (* TODO: look at the consequences for alp *)
     alp, add_env alp sigma var (DAst.make @@ GVar id)
 
-let bind_singleton_bindinglist_as_term_env alp (terms,termlists,binders,binderlists as sigma) var c =
+let bind_singleton_bindinglist_as_term_env alp sigma var c =
   try
     (* If already bound to a binder, unify the term and the binder *)
-    let vars,patl' = Id.List.assoc var binderlists in
+    let vars, _, patl' = get_binders (Id.Map.find var sigma) in
     let patl'' = unify_terms_binders alp.renaming [c] patl' in
     if patl' == patl'' then sigma
     else
-      let sigma = (terms,termlists,binders,Id.List.remove_assoc var binderlists) in
+      let sigma = Id.Map.remove var sigma in
       let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
       add_bindinglist_env alp' sigma var patl''
   with Not_found ->
     (* A term-as-binder occurs in the scope of a binder which is already bound *)
     anomaly (Pp.str "Unbound term as binder.")
 
-let bind_binding_as_term_env alp (terms,termlists,binders,binderlists as sigma) var c =
+let bind_binding_as_term_env alp sigma var c =
   let env = Global.env () in
   let pat = try cases_pattern_of_glob_constr env Anonymous c with Not_found -> raise No_match in
   try
     (* If already bound to a binder, unify the term and the binder *)
-    let vars,patl' = Id.List.assoc var binders in
-    let patl'' = List.map2 (unify_pat alp.renaming) [pat] patl' in
-    if patl' == patl'' then sigma
+    let vars, _, disjpatl' = get_pattern (Id.Map.find var sigma) in
+    let disjpatl'' = List.map2 (unify_pat alp.renaming) [pat] disjpatl' in
+    if disjpatl' == disjpatl'' then sigma
     else
-      let sigma = (terms,termlists,Id.List.remove_assoc var binders,binderlists) in
+      let sigma = Id.Map.remove var sigma  in
       let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
-      add_binding_env alp' sigma var patl''
+      add_binding_env alp' sigma var disjpatl''
   with Not_found -> add_binding_env alp sigma var [pat]
 
-let bind_binding_env alp (terms,termlists,binders,binderlists as sigma) var disjpat =
+let bind_binding_env alp sigma var disjpat =
   try
     (* If already bound to a binder possibly *)
     (* generating an alpha-renaming from unifying the new binder *)
-    let vars,disjpat' = Id.List.assoc var binders in
+    let vars, _, disjpat' = get_pattern (Id.Map.find var sigma) in
     (* if, maybe, there is eventually casts in patterns, the common types have *)
     (* to exclude the spine of variable from the two locations they occur *)
     let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
     let alp, disjpat = List.fold_left2_map unify_pat_upto alp disjpat disjpat' in
-    let sigma = (terms,termlists,Id.List.remove_assoc var binders,binderlists) in
+    let sigma = Id.Map.remove var sigma in
     alp, add_binding_env alp' sigma var disjpat
   with Not_found ->
     (* Note: all patterns of the disjunction are supposed to have the same
@@ -1285,30 +1319,30 @@ let bind_binding_env alp (terms,termlists,binders,binderlists as sigma) var disj
     let alp = {alp with actualvars = push_pattern_binders alp.actualvars (List.hd disjpat)} in
     alp, add_binding_env alp sigma var disjpat
 
-let bind_bindinglist_env alp (terms,termlists,binders,binderlists as sigma) var bl =
+let bind_bindinglist_env alp sigma var bl =
   let bl = List.rev bl in
   try
     (* If already bound to a list of binders possibly *)
     (* generating an alpha-renaming from unifying the new binders *)
-    let vars, bl' = Id.List.assoc var binderlists in
+    let vars, _, bl' = get_binders (Id.Map.find var sigma) in
     (* The shared subterm can be under two different spines of *)
     (* variables (themselves bound in the notation), so we take the *)
     (* union of both locations *)
     let alp' = {alp with actualvars = Id.Set.union vars alp.actualvars} in
     let alp, bl = unify_binders_upto alp bl bl' in
-    let sigma = (terms,termlists,binders,Id.List.remove_assoc var binderlists) in
+    let sigma = Id.Map.remove var sigma in
     alp, add_bindinglist_env alp' sigma var bl
   with Not_found ->
     let alp = {alp with actualvars = push_context_binders alp.actualvars bl} in
     alp, add_bindinglist_env alp sigma var bl
 
-let bind_bindinglist_as_termlist_env alp (terms,termlists,binders,binderlists) var cl =
+let bind_bindinglist_as_termlist_env alp sigma var cl =
   try
     (* If already bound to a list of binders, unify the terms and binders *)
-    let vars,bl' = Id.List.assoc var binderlists in
+    let vars, _, bl' = get_binders (Id.Map.find var sigma) in
     let bl = unify_terms_binders alp.renaming cl bl' in
     let alp = {alp with actualvars = Id.Set.union vars alp.actualvars} in
-    let sigma = (terms,termlists,binders,Id.List.remove_assoc var binderlists) in
+    let sigma = Id.Map.remove var sigma in
     add_bindinglist_env alp sigma var bl
   with Not_found ->
     anomaly (str "There should be a binder list bindings this list of terms.")
@@ -1332,14 +1366,14 @@ let match_opt f sigma t1 t2 = match (t1,t2) with
   | _ -> raise No_match
 
 let match_names metas (alp,sigma) na1 na2 = match (na1,na2) with
-  | (na1,Name id2) when is_onlybinding_strict_meta id2 metas ->
+  | (na1,Name id2) when is_onlybinding_strict_meta id2 metas (* strict pattern = not a variable *) ->
       raise No_match
   | (na1,Name id2) when is_onlybinding_meta id2 metas ->
       bind_binding_env alp sigma id2 [DAst.make (PatVar na1)]
   | (Name id1,Name id2) when is_term_meta id2 metas ->
       (* We let the non-binding occurrence define the rhs and hence reason up to *)
       (* alpha-conversion for the given occurrence of the name (see #4592)) *)
-      bind_term_as_binding_env alp sigma id2 id1
+      bind_ident_as_binding_env alp sigma id2 id1
   | (Anonymous,Name id2) when is_term_meta id2 metas ->
       (* We let the non-binding occurrence define the rhs *)
       alp, sigma
@@ -1348,16 +1382,16 @@ let match_names metas (alp,sigma) na1 na2 = match (na1,na2) with
   | (Anonymous,Anonymous) -> alp,sigma
   | _ -> raise No_match
 
+let isPatVar = function PatVar _ -> true | _ -> false
+
 let rec match_cases_pattern_binders allow_catchall metas (alp,sigma as acc) pat1 pat2 =
   match DAst.get pat1, DAst.get pat2 with
-  | PatVar _, PatVar (Name id2) when is_onlybinding_pattern_like_meta true id2 metas ->
+  | pat, PatVar (Name id2) when is_onlybinding_pattern_like_meta ~strict:(not (isPatVar pat)) ~isvar:(isPatVar pat) id2 metas ->
       bind_binding_env alp sigma id2 [pat1]
-  | PatVar id1, PatVar (Name id2) when is_onlybindinglist_meta id2 metas ->
+  | PatVar id1, PatVar (Name id2) when is_bindinglist_meta id2 metas ->
       let t1 = DAst.make @@ GHole(GBinderType id1) in
       bind_bindinglist_env alp sigma id2 [DAst.make @@ GLocalAssum (id1,None,Explicit,t1)]
-  | _, PatVar (Name id2) when is_onlybinding_pattern_like_meta false id2 metas ->
-      bind_binding_env alp sigma id2 [pat1]
-  | _, PatVar (Name id2) when is_onlybindinglist_meta id2 metas ->
+  | _, PatVar (Name id2) when is_bindinglist_meta id2 metas ->
       (* dummy data; should not be used anyway *)
       let id1 = Namegen.next_ident_away (Id.of_string "x") Id.Set.empty in
       let t1 = DAst.make @@ GHole(GBinderType (Name id1)) in
@@ -1371,15 +1405,11 @@ let rec match_cases_pattern_binders allow_catchall metas (alp,sigma as acc) pat1
         (match_names metas acc na1 na2) patl1 patl2
   | _ -> raise No_match
 
-let remove_sigma x (terms,termlists,binders,binderlists) =
-  (Id.List.remove_assoc x terms,termlists,binders,binderlists)
+let dummy_subscopes = ((constr_some_level,([],[])),Id.Set.empty)
 
-let remove_bindinglist_sigma x (terms,termlists,binders,binderlists) =
-  (terms,termlists,binders,Id.List.remove_assoc x binderlists)
+let add_ldots_var metas = (ldots_var,NtnTypeVar (dummy_subscopes, NtnTypeVarConstr (* Dummy: *)  NtnConstrForConstrAndPatternForPattern))::metas
 
-let add_ldots_var metas = (ldots_var,NtnTypeConstr)::metas
-
-let add_meta_bindinglist x metas = (x,NtnTypeBinderList (*arbitrary:*) NtnBinderParsedAsBinder)::metas
+let add_meta_bindinglist x metas = (x,NtnTypeVar ((*arbitrary:*) dummy_subscopes, NtnTypeVarBinders NtnBinderParsedAsBinder))::metas
 
 (* This tells if letins in the middle of binders should be included in
    the sequence of binders *)
@@ -1395,14 +1425,11 @@ let match_binderlist match_iter_fun match_termin_fun alp metas sigma rest x y it
   let rec aux trailing_letins alp sigma bl rest =
     try
       let metas = add_ldots_var (add_meta_bindinglist y metas) in
-      let (terms,_,_,binderlists as sigma) = match_iter_fun alp metas sigma rest iter in
-      let _,newstaticbinders,rest = Id.List.assoc ldots_var terms in
-      let b =
-        match Id.List.assoc y binderlists with _,[b] -> b | _ ->assert false
-      in
-      let sigma = remove_bindinglist_sigma y (remove_sigma ldots_var sigma) in
-      (* In case y is bound not only to a binder but also to a term *)
-      let sigma = remove_sigma y sigma in
+      let sigma = match_iter_fun alp metas sigma rest iter in
+      let _,newstaticbinders,rest = get_term (Id.Map.find ldots_var sigma) in
+      let _, _, b = get_binders (Id.Map.find y sigma) in
+      let b = match b with [b] -> b | _ -> assert false in
+      let sigma = Id.Map.remove y (Id.Map.remove ldots_var sigma) in
       let alp' = {alp with staticbinders = newstaticbinders} in
       aux false alp' sigma (b::bl) rest
     with No_match ->
@@ -1425,7 +1452,7 @@ let match_binderlist match_iter_fun match_termin_fun alp metas sigma rest x y it
   let alp,sigma = bind_bindinglist_env alp sigma x bl in
   match_termin_fun alp metas sigma rest termin
 
-let add_meta_term x metas = (x,NtnTypeConstr)::metas
+let add_meta_term x metas = (x,NtnTypeVar (dummy_subscopes, NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern))::metas
 
 type match_flags = {
   print_parentheses : bool;
@@ -1436,10 +1463,10 @@ let match_termlist flags match_fun alp metas sigma rest x y iter termin revert =
   let rec aux alp sigma acc rest =
     try
       let metas = add_ldots_var (add_meta_term y metas) in
-      let (terms,_,_,_ as sigma) = match_fun alp metas sigma rest iter in
-      let _,newstaticbinders,rest = Id.List.assoc ldots_var terms in
-      let vars,_,t = Id.List.assoc y terms in
-      let sigma = remove_sigma y (remove_sigma ldots_var sigma) in
+      let sigma = match_fun alp metas sigma rest iter in
+      let _,newstaticbinders,rest = get_term (Id.Map.find ldots_var sigma) in
+      let vars,_,t = get_term (Id.Map.find y sigma) in
+      let sigma = Id.Map.remove y (Id.Map.remove ldots_var sigma) in
       if flags.print_parentheses && not (List.is_empty acc) then raise No_match;
       (* The union is overkill at the current time because each term matches *)
       (* at worst the same binder metavariable of the same pattern *)
@@ -1447,7 +1474,7 @@ let match_termlist flags match_fun alp metas sigma rest x y iter termin revert =
       aux alp' sigma (t::acc) rest
     with No_match when not (List.is_empty acc) ->
       alp, acc, match_fun alp metas sigma rest termin in
-  let alp,l,(terms,termlists,binders,binderlists as sigma) = aux alp sigma [] rest in
+  let alp,l,sigma = aux alp sigma [] rest in
   let l = if revert then l else List.rev l in
   if is_bindinglist_meta x metas then
     (* This is a recursive pattern for both bindings and terms; it is *)
@@ -1485,10 +1512,7 @@ let rec match_ inner u alp metas sigma a1 a2 =
   match DAst.get a1, a2 with
   (* Matching notation variable *)
   | r1, NVar id2 when is_term_meta id2 metas -> bind_term_env alp sigma id2 a1
-  | r1, NVar id2 when is_var_term r1 && is_onlybinding_pattern_like_meta true id2 metas -> bind_binding_as_term_env alp sigma id2 a1
-  | r1, NVar id2 when is_onlybinding_pattern_like_meta false id2 metas -> bind_binding_as_term_env alp sigma id2 a1
-  | r1, NVar id2 when is_var_term r1 && is_onlybinding_strict_meta id2 metas -> raise No_match
-  | r1, NVar id2 when is_var_term r1 && is_onlybinding_meta id2 metas -> bind_binding_as_term_env alp sigma id2 a1
+  | r1, NVar id2 when is_onlybinding_pattern_like_meta ~strict:true ~isvar:(is_var_term r1) id2 metas -> bind_binding_as_term_env alp sigma id2 a1
   | r1, NVar id2 when is_bindinglist_meta id2 metas -> bind_singleton_bindinglist_as_term_env alp sigma id2 a1
 
   (* Matching recursive notations for terms *)
@@ -1660,8 +1684,7 @@ and match_extended_binders ?loc isprod u alp metas na1 na2 bk t sigma b1 b2 =
      match_in u alp metas sigma b1 b2
      | _ -> assert false)
   | Name p, GCases (LetPatternStyle,None,[(e,_)],(_::_ as eqns)), Name id
-    when is_gvar p e && is_onlybinding_pattern_like_meta false id metas
-         && List.length (store (Detyping.factorize_eqns ~flags:u.factorize_eqns eqns)) = 1 ->
+       when is_gvar p e && is_onlybinding_pattern_like_meta ~strict:true ~isvar:false id metas && List.length (store (Detyping.factorize_eqns ~flags:u.factorize_eqns eqns)) = 1 ->
     (match get () with
      | [{CAst.v=(ids,disj_of_patl,b1)}] ->
      let disjpat = List.map (function [pat] -> pat | _ -> assert false) disj_of_patl in
@@ -1696,79 +1719,43 @@ and match_disjunctive_equations u alp metas sigma {CAst.v=(ids,disjpatl1,rhs1)} 
       (alp,sigma) disjpatl1 disjpatl2 in
   match_in u alp metas sigma rhs1 rhs2
 
-(* Turning substitution based on binding/term distinction into a
-   substitution based on entry production: indeed some binders may
-   have to be seen as terms from the parsing/printing point of view *)
-let group_by_type ids (terms,termlists,binders,binderlists) =
-  List.fold_right (fun (x,(scl,_,typ)) (terms',termlists',binders',binderlists') ->
-    match typ with
-    | NtnTypeConstr ->
-       (* term -> term *)
-       let vars,_alp',term = try Id.List.assoc x terms with Not_found -> raise No_match in
-       (((vars,term),scl)::terms',termlists',binders',binderlists')
-    | NtnTypeBinder (NtnBinderParsedAsConstr _) ->
-       (* binder -> term *)
-       (match Id.List.assoc x binders with
-        | vars,[pat] ->
-          let v = glob_constr_of_cases_pattern (Global.env()) pat in
-          (((vars,v),scl)::terms',termlists',binders',binderlists')
-        | _ -> raise No_match)
-    | NtnTypeBinder (NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _) ->
-       (* term list -> term list *)
-       (terms',termlists',(Id.List.assoc x binders,scl)::binders',binderlists')
-    | NtnTypeConstrList ->
-       (* term list -> term list *)
-       (terms',(Id.List.assoc x termlists,scl)::termlists',binders',binderlists')
-    | NtnTypeBinderList (NtnBinderParsedAsConstr _) ->
-       (* binder list -> term list *)
-       let vars,patl = try Id.List.assoc x binderlists with Not_found -> raise No_match in
-       let v = List.map (fun pat -> match DAst.get pat with
-           | GLocalPattern ((disjpat,_),_,_,_) ->
-             List.map (glob_constr_of_cases_pattern (Global.env())) disjpat
-           | GLocalAssum (Anonymous,_,bk,t) ->
-             let hole = DAst.make (GHole (GBinderType Anonymous)) in
-             [DAst.make (GCast (hole, Some DEFAULTcast, t))]
-           | GLocalAssum (Name id,_,bk,t) ->
-             [DAst.make (GCast (DAst.make (GVar id), Some DEFAULTcast, t))]
-           | GLocalDef _ -> raise No_match) patl in
-       (terms',((vars,List.flatten v),scl)::termlists',binders',binderlists')
-    | NtnTypeBinderList (NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _) ->
-      (* binder list -> binder list *)
-      let bl = try Id.List.assoc x binderlists with Not_found -> raise No_match in
-       (terms',termlists',binders',(bl,scl)::binderlists'))
-    ids ([],[],[],[])
+type 'a with_vars = Id.Set.t * (Name.t * Id.t) list * 'a
+
+type 'a glob_constr_notation_substitution =
+  ('a glob_constr_g with_vars, 'a cases_pattern_disjunction_g with_vars, 'a extended_glob_local_binder_g list with_vars) notation_arg_type
+    Id.Map.t
 
 let match_notation_constr ~print_parentheses ~factorize_eqns c ~vars (metas,pat) =
-  let metatyps = List.map (fun (id,(_,_,typ)) -> (id,typ)) metas in
   let flags = { print_parentheses; factorize_eqns } in
-  let subst = match_ false flags {actualvars=vars;staticbinders=[];renaming=[]} metatyps ([],[],[],[]) c pat in
-  group_by_type metas subst
+  match_ false flags {actualvars=vars;staticbinders=[];renaming=[]} metas Id.Map.empty c pat
 
 (* Matching cases pattern *)
 
-let bind_env_cases_pattern (terms,x,termlists,y as sigma) var v =
+let bind_env_cases_pattern sigma var v =
   try
-    let vvar = Id.List.assoc var terms in
+    let vvar = Id.Map.find var sigma in
+    let vvar = get_pattern vvar in
     if cases_pattern_eq v vvar then sigma else raise No_match
   with Not_found ->
     (* TODO: handle the case of multiple occs in different scopes *)
-    (var,v)::terms,x,termlists,y
+    Id.Map.add var (Constrexpr.NtnTypeArg (NtnTypeArgPattern v)) sigma
 
 let match_cases_pattern_list match_fun metas sigma rest x y iter termin revert =
   let rec aux sigma acc rest =
     try
       let metas = add_ldots_var (add_meta_term y metas) in
-      let (terms,_,_,_ as sigma) = match_fun metas sigma rest iter in
-      let rest = Id.List.assoc ldots_var terms in
-      let t = Id.List.assoc y terms in
-      let sigma = remove_sigma y (remove_sigma ldots_var sigma) in
+      let sigma = match_fun metas sigma rest iter in
+      let rest = get_pattern (Id.Map.find ldots_var sigma) in
+      let t = get_pattern (Id.Map.find y sigma) in
+      let sigma = Id.Map.remove y (Id.Map.remove ldots_var sigma) in
       aux sigma (t::acc) rest
     with No_match when not (List.is_empty acc) ->
       acc, match_fun metas sigma rest termin in
-  let l,(terms,termlists,binders,binderlists as sigma) = aux sigma [] rest in
-  (terms,(x,if revert then l else List.rev l)::termlists,binders,binderlists)
+  let l,sigma = aux sigma [] rest in
+  let l = List.map (fun c -> NtnTypeArg (NtnTypeArgPattern c)) (if revert then l else List.rev l) in
+  Id.Map.add x (NtnTypeArgList l) sigma
 
-let rec match_cases_pattern metas (terms,termlists,(),() as sigma) a1 a2 =
+let rec match_cases_pattern metas sigma a1 a2 =
  match DAst.get a1, a2 with
   | r1, NVar id2 when Id.List.mem_assoc id2 metas -> (bind_env_cases_pattern sigma id2 a1),(false,0,[])
   | PatVar Anonymous, NHole _ -> sigma,(false,0,[])
@@ -1789,7 +1776,7 @@ let rec match_cases_pattern metas (terms,termlists,(),() as sigma) a1 a2 =
         (List.fold_left2 (match_cases_pattern_no_more_args metas) sigma l1' l2),(no_implicit,le2,more_args)
   | r1, NList (x,y,iter,termin,revert) ->
       (match_cases_pattern_list (match_cases_pattern_no_more_args)
-        metas (terms,termlists,(),()) a1 x y iter termin revert),(false,0,[])
+        metas sigma a1 x y iter termin revert),(false,0,[])
   | _ -> raise No_match
 
 and match_cases_pattern_no_more_args metas sigma a1 a2 =
@@ -1813,22 +1800,12 @@ let match_ind_pattern metas sigma ind pats a2 =
         (List.fold_left2 (match_cases_pattern_no_more_args metas) sigma l1' l2),(no_implicit,le2,more_args)
   |_ -> raise No_match
 
-let reorder_canonically_substitution terms termlists metas =
-  List.fold_right (fun (x,(scl,_,typ)) (terms',termlists',binders') ->
-    match typ with
-      | NtnTypeConstr | NtnTypeBinder (NtnBinderParsedAsConstr _) -> ((Id.List.assoc x terms, scl)::terms',termlists',binders')
-      | NtnTypeConstrList -> (terms',(Id.List.assoc x termlists,scl)::termlists',binders')
-      | NtnTypeBinder (NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _) ->
-         (terms',termlists',(Id.List.assoc x terms, scl)::binders')
-      | NtnTypeBinderList _ -> anomaly (str "Unexpected binder in pattern notation."))
-    metas ([],[],[])
+type 'a glob_cases_pattern_notation_substitution =
+  ('a glob_constr_g, 'a cases_pattern_g, unit) notation_arg_type
+    Id.Map.t
 
 let match_notation_constr_cases_pattern c (metas,pat) =
-  let metatyps = List.map (fun (id,(_,_,typ)) -> (id,typ)) metas in
-  let (terms,termlists,(),()),more_args = match_cases_pattern metatyps ([],[],(),()) c pat in
-  reorder_canonically_substitution terms termlists metas, more_args
+  (match_cases_pattern metas Id.Map.empty c pat)
 
 let match_notation_constr_ind_pattern ind args (metas,pat) =
-  let metatyps = List.map (fun (id,(_,_,typ)) -> (id,typ)) metas in
-  let (terms,termlists,(),()),more_args = match_ind_pattern metatyps ([],[],(),()) ind args pat in
-  reorder_canonically_substitution terms termlists metas, more_args
+  match_ind_pattern metas Id.Map.empty ind args pat

--- a/interp/notation_ops.mli
+++ b/interp/notation_ops.mli
@@ -11,6 +11,7 @@
 open Names
 open Notation_term
 open Glob_term
+open Constrexpr
 
 (** Constr default entries *)
 
@@ -76,6 +77,8 @@ val glob_constr_of_notation_constr : ?loc:Loc.t -> notation_constr -> glob_const
 val pr_notation_info :
   (Glob_term.glob_constr -> Pp.t) -> Constrexpr.notation_key -> Notation_term.notation_constr -> Pp.t
 
+val dummy_subscopes : extended_subscopes * notation_var_binders
+
 (** {5 Matching a notation pattern against a [glob_constr]} *)
 
 (** [match_notation_constr] matches a [glob_constr] against a notation
@@ -83,22 +86,28 @@ val pr_notation_info :
 
 exception No_match
 
+type 'a with_vars = Id.Set.t * (Name.t * Id.t) list * 'a
+
+(** Instances of notation variables, with their type as interpreted in
+    a term; also, when a variable is used both as term and binder, it
+    is represented as a a pattern *)
+type 'a glob_constr_notation_substitution =
+  ('a glob_constr_g with_vars, 'a cases_pattern_disjunction_g with_vars, 'a extended_glob_local_binder_g list with_vars) notation_arg_type
+    Id.Map.t
+
 val match_notation_constr : print_parentheses:bool -> print_univ:bool -> 'a glob_constr_g -> vars:Id.Set.t -> interpretation ->
-      ((Id.Set.t * 'a glob_constr_g) * extended_subscopes) list *
-      ((Id.Set.t * 'a glob_constr_g list) * extended_subscopes) list *
-      ((Id.Set.t * 'a cases_pattern_disjunction_g) * extended_subscopes) list *
-      ((Id.Set.t * 'a extended_glob_local_binder_g list) * extended_subscopes) list
+  'a glob_constr_notation_substitution
+
+(** Instances of notation variables, with their type as interpreted in
+    a pattern *)
+type 'a glob_cases_pattern_notation_substitution =
+  ('a glob_constr_g, 'a cases_pattern_g, unit) notation_arg_type
+    Id.Map.t
 
 val match_notation_constr_cases_pattern :
   'a cases_pattern_g -> interpretation ->
-  (('a cases_pattern_g * extended_subscopes) list *
-   ('a cases_pattern_g list * extended_subscopes) list *
-   ('a cases_pattern_g * extended_subscopes) list) *
-    (bool * int * 'a cases_pattern_g list)
+  'a glob_cases_pattern_notation_substitution * (bool * int * 'a cases_pattern_g list)
 
 val match_notation_constr_ind_pattern :
   inductive -> 'a cases_pattern_g list -> interpretation ->
-  (('a cases_pattern_g * extended_subscopes) list *
-   ('a cases_pattern_g list * extended_subscopes) list *
-   ('a cases_pattern_g * extended_subscopes) list) *
-    (bool * int * 'a cases_pattern_g list)
+  'a glob_cases_pattern_notation_substitution * (bool * int * 'a cases_pattern_g list)

--- a/interp/notation_ops.mli
+++ b/interp/notation_ops.mli
@@ -11,6 +11,7 @@
 open Names
 open Notation_term
 open Glob_term
+open Constrexpr
 
 (** Constr default entries *)
 
@@ -76,6 +77,8 @@ val glob_constr_of_notation_constr : ?loc:Loc.t -> notation_constr -> glob_const
 val pr_notation_info :
   (Glob_term.glob_constr -> Pp.t) -> Constrexpr.notation_key -> Notation_term.notation_constr -> Pp.t
 
+val dummy_subscopes : extended_subscopes * notation_var_binders
+
 (** {5 Matching a notation pattern against a [glob_constr]} *)
 
 (** [match_notation_constr] matches a [glob_constr] against a notation
@@ -83,24 +86,30 @@ val pr_notation_info :
 
 exception No_match
 
+type 'a with_vars = Id.Set.t * (Name.t * Id.t) list * 'a
+
+(** Instances of notation variables, with their type as interpreted in
+    a term; also, when a variable is used both as term and binder, it
+    is represented as a a pattern *)
+type 'a glob_constr_notation_substitution =
+  ('a glob_constr_g with_vars, 'a cases_pattern_disjunction_g with_vars, 'a extended_glob_local_binder_g list with_vars) notation_arg_type
+    Id.Map.t
+
 val match_notation_constr : print_parentheses:bool ->
   factorize_eqns:PrintingFlags.Extern.FactorizeEqns.t ->
   'a glob_constr_g -> vars:Id.Set.t -> interpretation ->
-      ((Id.Set.t * 'a glob_constr_g) * extended_subscopes) list *
-      ((Id.Set.t * 'a glob_constr_g list) * extended_subscopes) list *
-      ((Id.Set.t * 'a cases_pattern_disjunction_g) * extended_subscopes) list *
-      ((Id.Set.t * 'a extended_glob_local_binder_g list) * extended_subscopes) list
+  'a glob_constr_notation_substitution
+
+(** Instances of notation variables, with their type as interpreted in
+    a pattern *)
+type 'a glob_cases_pattern_notation_substitution =
+  ('a glob_constr_g, 'a cases_pattern_g, unit) notation_arg_type
+    Id.Map.t
 
 val match_notation_constr_cases_pattern :
   'a cases_pattern_g -> interpretation ->
-  (('a cases_pattern_g * extended_subscopes) list *
-   ('a cases_pattern_g list * extended_subscopes) list *
-   ('a cases_pattern_g * extended_subscopes) list) *
-    (bool * int * 'a cases_pattern_g list)
+  'a glob_cases_pattern_notation_substitution * (bool * int * 'a cases_pattern_g list)
 
 val match_notation_constr_ind_pattern :
   inductive -> 'a cases_pattern_g list -> interpretation ->
-  (('a cases_pattern_g * extended_subscopes) list *
-   ('a cases_pattern_g list * extended_subscopes) list *
-   ('a cases_pattern_g * extended_subscopes) list) *
-    (bool * int * 'a cases_pattern_g list)
+  'a glob_cases_pattern_notation_substitution * (bool * int * 'a cases_pattern_g list)

--- a/interp/notation_ops.mli
+++ b/interp/notation_ops.mli
@@ -86,6 +86,13 @@ val dummy_subscopes : extended_subscopes * notation_var_binders
 
 exception No_match
 
+(** When term matching a rule is found, with_vars informs about the
+    set of actual binder names of this term and the pairs (x,y) of
+    (notation-unbound) binder name [x] of the pattern and
+    corresponding binder name [y] in the term; e.g. when matching the
+    term "fun '((y,z) as c) b => t" against the pattern "fun x a => u"
+    (when x is not bound in the notation) the actual binder names include
+    [c,y,z,b] and the matching pairs are [(x,c);(b,a)] *)
 type 'a with_vars = Id.Set.t * (Name.t * Id.t) list * 'a
 
 (** Instances of notation variables, with their type as interpreted in
@@ -105,6 +112,18 @@ val match_notation_constr : print_parentheses:bool ->
 type 'a glob_cases_pattern_notation_substitution =
   ('a glob_constr_g, 'a cases_pattern_g, unit) notation_arg_type
     Id.Map.t
+
+(** In a result [subst,(b,n,more_args)] of [match_notation_constr_cases_pattern]
+    or [match_notation_constr_ind_pattern], [b] tells when the notation
+    is a notation for a pattern of the form [@f] in which case implicit
+    arguments are deactivated by convention. Otherwise, [n] tells how many
+    arguments are involved in the notation and [more_args] are the
+    extra arguments in case the pattern is a partially apply
+    constructor. For instance, if the pattern is [C ?x ?y] with
+    notation, say, "{x,y}" and the term is [C t1 t2 t3 t4], then [n]
+    is [2] and [more_args] is [t3;t4] (the information is needed so
+    that, later on, if e.g. [C] has its 3rd argument implicit, the
+    term should be written "{x,y} t4" *)
 
 val match_notation_constr_cases_pattern :
   'a cases_pattern_g -> interpretation ->

--- a/interp/notation_term.mli
+++ b/interp/notation_term.mli
@@ -118,6 +118,11 @@ type notation_var_internalization_type =
 
 (** This characterizes to what a notation is interpreted to *)
 type interpretation = (Id.t * notation_var_type) list * notation_constr
+  (* (var_types, n) is a pair with a notation n and the type of its
+     non terminals, var_types is a list giving a name and a type to
+     each non terminal. Type invariant: the length of var_types is the
+     number of non terminals appearing in n, as given by the function
+     TODO *)
 
 type forgetfulness = { forget_ltac : bool; forget_volatile_cast : bool }
 

--- a/interp/notation_term.mli
+++ b/interp/notation_term.mli
@@ -118,6 +118,11 @@ type notation_var_internalization_type =
 (** This characterizes to what a notation is interpreted to *)
 type 'a interpretation_gen = (Id.t * 'a) list * notation_constr
 type interpretation = notation_var_type interpretation_gen
+  (* (var_types, n) is a pair with a notation n and the type of its
+     non terminals, var_types is a list giving a name and a type to
+     each non terminal. Type invariant: the length of var_types is the
+     number of non terminals appearing in n, as given by the function
+     TODO *)
 
 type forgetfulness = { forget_ltac : bool; forget_volatile_cast : bool }
 

--- a/interp/notation_term.mli
+++ b/interp/notation_term.mli
@@ -93,7 +93,9 @@ type notation_binder_source =
   | NtnBinderParsedAsBinder
 
 type notation_var_constr_kind =
-  | NtnAlwaysConstr (* In anticipation of supporting PatCast in pattern *)
+  | NtnAlwaysConstr (* In anticipation of supporting PatCast in
+      pattern, which is a case where a constr in a pattern should be
+      kept as a constr and not interpreted by default as a pattern *)
   | NtnConstrForConstrAndPatternForPattern
 
 (** Type of variables in notation interpretations, remembering how it is parsed;
@@ -136,6 +138,9 @@ type notation_interp_var_types = notation_var_internalization_type Names.Id.Map.
 type 'a notation_raw_type =
   | NtnRawTypeVar of 'a
   | NtnRawTypeVarList of ('a * 'a) notation_raw_type (* A .. A *)
+      (* represented as a pattern pat(x) ... pat(y) in the declaration
+         of the notation and we keep the names of the two ends (note
+         that this may multiply in case of nested recursive patterns) *)
   | NtnRawTypeVarTuple of 'a notation_raw_type list (* A1 * ... * An *)
 
 type notation_interp_env = {

--- a/interp/notation_term.mli
+++ b/interp/notation_term.mli
@@ -64,6 +64,13 @@ type subscopes = tmp_scope_name list * scope_name list
 
 type extended_subscopes = Constrexpr.notation_entry_relative_level * subscopes
 
+(** The set of other notation variables that are bound to a binder or
+    binder list and that bind the given notation variable, for
+    instance, in ["{ x | P }" := (sigT (fun x => P)], "x" is under an
+    empty set of binders and "P" is under the binders bound to "x",
+    that is, its notation_var_binders set is "x" *)
+type notation_var_binders = Id.Set.t
+
 (** Type of the meta-variables of an notation_constr: in a recursive pattern x..y,
     x carries the sequence of objects bound to the list x..y  *)
 
@@ -85,11 +92,21 @@ type notation_binder_source =
   (* Parsed as open or closed binder: This accepts ident, _, quoted pattern, etc. *)
   | NtnBinderParsedAsBinder
 
-type notation_var_instance_type =
-  | NtnTypeConstr
-  | NtnTypeConstrList
-  | NtnTypeBinder of notation_binder_source
-  | NtnTypeBinderList of notation_binder_source
+type notation_var_constr_kind =
+  | NtnAlwaysConstr (* In anticipation of supporting PatCast in pattern *)
+  | NtnConstrForConstrAndPatternForPattern
+
+(** Type of variables in notation interpretations, remembering how it is parsed;
+    Note: when a notation variable appears both as term and as binder, its type is Pattern *)
+type notation_var_kind =
+  | NtnTypeVarConstr of notation_var_constr_kind
+  | NtnTypeVarPattern of notation_binder_source
+  | NtnTypeVarBinders of notation_binder_source
+
+type notation_var_type =
+  | NtnTypeVar of (extended_subscopes * notation_var_binders) * notation_var_kind
+  | NtnTypeVarList of notation_var_type (* list A *)
+  | NtnTypeVarTuple of notation_var_type list (* A1 * ... * An *)
 
 (** Type of variables when interpreting a constr_expr as a notation_constr:
     in a recursive pattern x..y, both x and y carry the individual type
@@ -98,16 +115,9 @@ type notation_var_internalization_type =
   | NtnInternTypeAny of scope_name option
   | NtnInternTypeOnlyBinder
 
-(** The set of other notation variables that are bound to a binder or
-    binder list and that bind the given notation variable, for
-    instance, in ["{ x | P }" := (sigT (fun x => P)], "x" is under an
-    empty set of binders and "P" is under the binders bound to "x",
-    that is, its notation_var_binders set is "x" *)
-type notation_var_binders = Id.Set.t
-
 (** This characterizes to what a notation is interpreted to *)
 type 'a interpretation_gen = (Id.t * 'a) list * notation_constr
-type interpretation = (extended_subscopes * notation_var_binders * notation_var_instance_type) interpretation_gen
+type interpretation = notation_var_type interpretation_gen
 
 type forgetfulness = { forget_ltac : bool; forget_volatile_cast : bool }
 
@@ -116,7 +126,14 @@ type reversibility_status =
   | Forgetful of forgetfulness
   | NonInjective of Id.t list
 
+type notation_interp_var_types = notation_var_internalization_type Names.Id.Map.t
+
+type 'a notation_raw_type =
+  | NtnRawTypeVar of 'a
+  | NtnRawTypeVarList of ('a * 'a) notation_raw_type (* A .. A *)
+  | NtnRawTypeVarTuple of 'a notation_raw_type list (* A1 * ... * An *)
+
 type notation_interp_env = {
-  ninterp_var_type : notation_var_internalization_type Id.Map.t;
-  ninterp_rec_vars : Id.t Id.Map.t;
+  ninterp_var_type : notation_interp_var_types;
+  ninterp_raw_types : Id.t notation_raw_type list;
 }

--- a/interp/notationextern.ml
+++ b/interp/notationextern.ml
@@ -46,8 +46,9 @@ let notation_entry_relative_level_eq
     { notation_subentry = e2; notation_relative_level = n2; notation_position = s2 } =
   notation_entry_eq e1 e2 && entry_relative_level_eq n1 n2 && s1 = s2
 
-let notation_eq (from1,ntn1) (from2,ntn2) =
-  notation_entry_eq from1 from2 && String.equal ntn1 ntn2
+let notation_eq ntn1 ntn2 =
+  notation_entry_eq ntn1.ntn_entry ntn2.ntn_entry
+  && String.equal ntn1.ntn_key ntn2.ntn_key
 
 let notation_binder_kind_eq k1 k2 = match k1, k2 with
 | AsIdent, AsIdent -> true
@@ -108,10 +109,8 @@ type 'a interp_rule_gen =
 
 type interp_rule = KerName.t interp_rule_gen
 
-let specific_notation_eq (sc1, (e1, s1)) (sc2, (e2, s2)) =
-  notation_with_optional_scope_eq sc1 sc2 &&
-  notation_entry_eq e1 e2 &&
-  String.equal s1 s2
+let specific_notation_eq (sc1, ntn1) (sc2, ntn2) =
+  notation_with_optional_scope_eq sc1 sc2 && notation_eq ntn1 ntn2
 
 let interp_rule_eq r1 r2 = match r1, r2 with
 | NotationRule n1, NotationRule n2 -> specific_notation_eq n1 n2

--- a/interp/notationextern.ml
+++ b/interp/notationextern.ml
@@ -70,8 +70,6 @@ let specific_notation_compare (scope1,ntn1) (scope2,ntn2) =
   if c <> 0 then c
   else notation_compare ntn1 ntn2
 
-let pair_eq f g (x1, y1) (x2, y2) = f x1 x2 && g y1 y2
-
 let notation_binder_kind_eq k1 k2 = match k1, k2 with
 | AsIdent, AsIdent -> true
 | AsName, AsName -> true
@@ -85,22 +83,37 @@ let notation_binder_source_eq s1 s2 = match s1, s2 with
 | NtnBinderParsedAsConstr bk1, NtnBinderParsedAsConstr bk2 -> notation_binder_kind_eq bk1 bk2
 | (NtnBinderParsedAsSomeBinderKind _ | NtnBinderParsedAsBinder | NtnBinderParsedAsConstr _), _ -> false
 
-let ntpe_eq t1 t2 = match t1, t2 with
-| NtnTypeConstr, NtnTypeConstr -> true
-| NtnTypeBinder s1, NtnTypeBinder s2 -> notation_binder_source_eq s1 s2
-| NtnTypeConstrList, NtnTypeConstrList -> true
-| NtnTypeBinderList s1, NtnTypeBinderList s2 -> notation_binder_source_eq s1 s2
-| (NtnTypeConstr | NtnTypeBinder _ | NtnTypeConstrList | NtnTypeBinderList _), _ -> false
+let subscopes_eq (tmpscl1,scl1) (tmpscl2,scl2) =
+  List.equal String.equal tmpscl1 tmpscl2 && List.equal String.equal scl1 scl2
 
-let var_attributes_eq (_, ((entry1, sc1), binders1, tp1)) (_, ((entry2, sc2), binders2, tp2)) =
+let notation_var_constr_kind s1 s2 = match s1, s2 with
+| NtnAlwaysConstr, NtnAlwaysConstr -> true
+| NtnConstrForConstrAndPatternForPattern, NtnConstrForConstrAndPatternForPattern -> true
+| (NtnAlwaysConstr | NtnConstrForConstrAndPatternForPattern), _ -> false
+
+let ntpe_eq t1 t2 = match t1, t2 with
+| NtnTypeVarConstr s1, NtnTypeVarConstr s2 -> notation_var_constr_kind s1 s2
+| NtnTypeVarPattern s1, NtnTypeVarPattern s2 -> notation_binder_source_eq s1 s2
+| NtnTypeVarBinders s1, NtnTypeVarBinders s2 -> notation_binder_source_eq s1 s2
+| (NtnTypeVarConstr _ | NtnTypeVarPattern _ | NtnTypeVarBinders _), _ -> false
+
+let var_attributes_eq ((entry1, sc1), binders1) ((entry2, sc2), binders2) =
   notation_entry_relative_level_eq entry1 entry2 &&
-  pair_eq (List.equal String.equal) (List.equal String.equal) sc1 sc2 &&
-  Id.Set.equal binders1 binders2 &&
-  ntpe_eq tp1 tp2
+  subscopes_eq sc1 sc2 &&
+  Id.Set.equal binders1 binders2
+
+let rec notation_var_kind_eq t1 t2 = match t1, t2 with
+| NtnTypeVar (attr1,t1), NtnTypeVar (attr2,t2) -> var_attributes_eq attr1 attr2 && ntpe_eq t1 t2
+| NtnTypeVarList t1, NtnTypeVarList t2 -> notation_var_kind_eq t1 t2
+| NtnTypeVarTuple l1, NtnTypeVarTuple l2 -> List.equal notation_var_kind_eq l1 l2
+| (NtnTypeVar _ | NtnTypeVarList _ | NtnTypeVarTuple _), _ -> false
+
+let vars_notation_type_eq (id1,t1) (id2,t2) =
+(*  Id.equal id1 id2 && *) notation_var_kind_eq t1 t2
 
 let interpretation_eq (vars1, t1 as x1) (vars2, t2 as x2) =
   x1 == x2 ||
-  List.equal var_attributes_eq vars1 vars2 &&
+  List.equal vars_notation_type_eq vars1 vars2 &&
   Notation_ops.eq_notation_constr (List.map fst vars1, List.map fst vars2) t1 t2
 
 type level = notation_entry_level * entry_relative_level list

--- a/interp/notationextern.ml
+++ b/interp/notationextern.ml
@@ -58,12 +58,13 @@ let notation_entry_relative_level_eq
     { notation_subentry = e2; notation_relative_level = n2; notation_position = s2 } =
   notation_entry_eq e1 e2 && entry_relative_level_eq n1 n2 && s1 = s2
 
-let notation_eq (from1,ntn1) (from2,ntn2) =
-  notation_entry_eq from1 from2 && String.equal ntn1 ntn2
+let notation_eq ntn1 ntn2 =
+  notation_entry_eq ntn1.ntn_entry ntn2.ntn_entry
+  && String.equal ntn1.ntn_key ntn2.ntn_key
 
-let notation_compare (from1,ntn1) (from2,ntn2) =
-  let c = notation_entry_compare from1 from2 in
-  if c <> 0 then c else String.compare ntn1 ntn2
+let notation_compare ntn1 ntn2 =
+  let c = notation_entry_compare ntn1.ntn_entry ntn2.ntn_entry in
+  if c <> 0 then c else String.compare ntn1.ntn_key ntn2.ntn_key
 
 let specific_notation_compare (scope1,ntn1) (scope2,ntn2) =
   let c = notation_with_optional_scope_compare scope1 scope2 in
@@ -127,10 +128,8 @@ type interp_rule =
   | NotationRule of Constrexpr.specific_notation
   | AbbrevRule of Globnames.abbreviation
 
-let specific_notation_eq (sc1, (e1, s1)) (sc2, (e2, s2)) =
-  notation_with_optional_scope_eq sc1 sc2 &&
-  notation_entry_eq e1 e2 &&
-  String.equal s1 s2
+let specific_notation_eq (sc1, ntn1) (sc2, ntn2) =
+  notation_with_optional_scope_eq sc1 sc2 && notation_eq ntn1 ntn2
 
 let interp_rule_eq r1 r2 = match r1, r2 with
 | NotationRule n1, NotationRule n2 -> specific_notation_eq n1 n2

--- a/interp/reserve.ml
+++ b/interp/reserve.ml
@@ -120,8 +120,7 @@ let revert_reserved_type env evd t =
         then I've introduced a bug... *)
     let filter _ pat =
       try
-        let _ : _ * _ * _ * _ =
-          match_notation_constr ~print_parentheses:true ~factorize_eqns t ~vars:Id.Set.empty ([], pat)
+        let _ = match_notation_constr ~print_parentheses:true ~factorize_eqns t ~vars:Id.Set.empty ([], pat)
         in
         true
       with No_match -> false

--- a/parsing/extend.ml
+++ b/parsing/extend.ml
@@ -69,6 +69,7 @@ let constr_entry_key_visible_eq = constr_entry_key_eq_gen
     (fun _ _ -> true)
     (fun _ _ -> true)
 
+
 (** Entries level (left-hand side of grammar rules) *)
 
 type constr_entry_key =
@@ -78,6 +79,11 @@ type constr_entry_key =
 
 type simple_constr_prod_entry_key =
     production_level constr_entry_key_gen
+
+let simple_constr_entry_key_eq =
+  constr_entry_key_eq_gen
+    (Option.equal Notationextern.notation_binder_kind_eq)
+    production_level_eq
 
 (** Entries used in productions (in right-hand-side of grammar rules), to parse non-terminals *)
 

--- a/parsing/extend.ml
+++ b/parsing/extend.ml
@@ -14,6 +14,19 @@ type production_position =
   | BorderProd of Constrexpr.side * Gramlib.Gramext.g_assoc option
   | InternalProd
 
+let side_eq s1 s2 =
+  Constrexpr.(match s1, s2 with
+  | Left, Left -> true
+  | Right, Right -> true
+  | (Left | Right), _ -> false)
+
+let production_position_eq pos1 pos2 =
+  match pos1, pos2 with
+  | BorderProd (s1,a1), BorderProd (s2,a2) ->
+    side_eq s1 s2 && Option.equal Gramlib.Gramext.g_assoc_eq a1 a2
+  | InternalProd, InternalProd -> true
+  | (BorderProd _ | InternalProd), _ -> false
+
 type production_level =
   | NextLevel
   | NumLevel of int
@@ -37,20 +50,24 @@ type ('custom,'a) constr_entry_key_gen =
   | ETConstr of 'custom Constrexpr.notation_entry_gen * Notation_term.notation_binder_kind option * 'a
   | ETPattern of bool * int option (* true = strict pattern, i.e. not a single variable *)
 
-let constr_entry_key_eq_gen binder_kind_eq v1 v2 = match v1, v2 with
+let constr_entry_key_eq_gen binder_kind_eq level_eq v1 v2 = match v1, v2 with
   | ETIdent, ETIdent -> true
   | ETName, ETName -> true
   | ETGlobal, ETGlobal -> true
   | ETBigint, ETBigint -> true
   | ETBinder b1, ETBinder b2 -> b1 == b2
-  | ETConstr (s1,bko1,_lev1), ETConstr (s2,bko2,_lev2) ->
-    Notationextern.notation_entry_eq s1 s2 && binder_kind_eq bko1 bko2
+  | ETConstr (s1,bko1,a1), ETConstr (s2,bko2,a2) ->
+    Notationextern.notation_entry_eq s1 s2 && binder_kind_eq bko1 bko2 && level_eq a1 a2
   | ETPattern (b1,n1), ETPattern (b2,n2) -> b1 = b2 && Option.equal Int.equal n1 n2
   | (ETIdent | ETName | ETGlobal | ETBigint | ETBinder _ | ETConstr _ | ETPattern _), _ -> false
 
-let constr_entry_key_eq = constr_entry_key_eq_gen (Option.equal Notationextern.notation_binder_kind_eq)
+let constr_entry_key_eq = constr_entry_key_eq_gen
+    (Option.equal Notationextern.notation_binder_kind_eq)
+    (Util.eq_pair production_level_eq production_position_eq)
 
-let constr_entry_key_eq_ignore_binder_kind = constr_entry_key_eq_gen (fun _ _ -> true)
+let constr_entry_key_visible_eq = constr_entry_key_eq_gen
+    (fun _ _ -> true)
+    (fun _ _ -> true)
 
 (** Entries level (left-hand side of grammar rules) *)
 

--- a/parsing/extend.ml
+++ b/parsing/extend.ml
@@ -79,6 +79,11 @@ type constr_entry_key =
 type 'custom simple_constr_prod_entry_key =
     ('custom, production_level) constr_entry_key_gen
 
+let simple_constr_entry_key_eq =
+  constr_entry_key_eq_gen
+    (Option.equal Notationextern.notation_binder_kind_eq)
+    production_level_eq
+
 (** Entries used in productions (in right-hand-side of grammar rules), to parse non-terminals *)
 
 type binder_target = ForBinder | ForTerm

--- a/parsing/extend.mli
+++ b/parsing/extend.mli
@@ -46,6 +46,8 @@ val constr_entry_key_visible_eq : constr_entry_key -> constr_entry_key -> bool
 type simple_constr_prod_entry_key =
     production_level constr_entry_key_gen
 
+val simple_constr_entry_key_eq : simple_constr_prod_entry_key -> simple_constr_prod_entry_key -> bool
+
 (** Entries used in productions (in right-hand-side of grammar rules), to parse non-terminals *)
 
 type binder_target = ForBinder | ForTerm

--- a/parsing/extend.mli
+++ b/parsing/extend.mli
@@ -39,7 +39,7 @@ type constr_entry_key =
 
 val constr_entry_key_eq : constr_entry_key -> constr_entry_key -> bool
 
-val constr_entry_key_eq_ignore_binder_kind : constr_entry_key -> constr_entry_key -> bool
+val constr_entry_key_visible_eq : constr_entry_key -> constr_entry_key -> bool
 
 (** Entries used in productions, vernac side (e.g. "x bigint" or "x ident") *)
 

--- a/parsing/extend.mli
+++ b/parsing/extend.mli
@@ -41,7 +41,7 @@ type constr_entry_key =
 
 val constr_entry_key_eq : constr_entry_key -> constr_entry_key -> bool
 
-val constr_entry_key_eq_ignore_binder_kind : constr_entry_key -> constr_entry_key -> bool
+val constr_entry_key_visible_eq : constr_entry_key -> constr_entry_key -> bool
 
 (** Entries used in productions, vernac side (e.g. "x bigint" or "x ident") *)
 

--- a/parsing/extend.mli
+++ b/parsing/extend.mli
@@ -48,6 +48,8 @@ val constr_entry_key_visible_eq : constr_entry_key -> constr_entry_key -> bool
 type 'custom simple_constr_prod_entry_key =
     ('custom, production_level) constr_entry_key_gen
 
+val simple_constr_entry_key_eq : CustomName.t simple_constr_prod_entry_key -> CustomName.t simple_constr_prod_entry_key -> bool
+
 (** Entries used in productions (in right-hand-side of grammar rules), to parse non-terminals *)
 
 type binder_target = ForBinder | ForTerm

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -220,7 +220,7 @@ GRAMMAR EXTEND Gram
              collapse -(3) into the number -3. *)
           (match c.CAst.v with
             | CPrim (Number (NumTok.SPlus,n)) ->
-                CAst.make ~loc @@ CNotation(None,(InConstrEntry,"( _ )"),[NtnTypeArg (NtnTypeArgConstr c)])
+                CAst.make ~loc @@ CNotation(None,(mk_ntn_in_constr "( _ )"),[NtnTypeArg (NtnTypeArgConstr c)])
             | _ -> c) }
       | "{|"; c = record_declaration; bar_cbrace -> { c }
       | "`{"; c = term LEVEL "200"; "}" ->
@@ -415,7 +415,7 @@ GRAMMAR EXTEND Gram
              collapse -(3) into the number -3. *)
           match p.CAst.v with
           | CPatPrim (Number (NumTok.SPlus,n)) ->
-              CAst.make ~loc @@ CPatNotation(None,(InConstrEntry,"( _ )"),[NtnTypeArg (NtnTypeArgPattern (p,Explicit))],[])
+              CAst.make ~loc @@ CPatNotation(None,(mk_ntn_in_constr "( _ )"),[NtnTypeArg (NtnTypeArgPattern (p,Explicit))],[])
           | _ -> p }
       | "("; p = pattern LEVEL "200"; "|" ; pl = LIST1 pattern LEVEL "200" SEP "|"; ")" ->
         { CAst.make ~loc @@ CPatOr (p::pl) }

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -220,7 +220,7 @@ GRAMMAR EXTEND Gram
              collapse -(3) into the number -3. *)
           (match c.CAst.v with
             | CPrim (Number (NumTok.SPlus,n)) ->
-                CAst.make ~loc @@ CNotation(None,(InConstrEntry,"( _ )"),([c],[],[],[]))
+                CAst.make ~loc @@ CNotation(None,(InConstrEntry,"( _ )"),[NtnTypeArg (NtnTypeArgConstr c)])
             | _ -> c) }
       | "{|"; c = record_declaration; bar_cbrace -> { c }
       | "`{"; c = term LEVEL "200"; "}" ->
@@ -415,7 +415,7 @@ GRAMMAR EXTEND Gram
              collapse -(3) into the number -3. *)
           match p.CAst.v with
           | CPatPrim (Number (NumTok.SPlus,n)) ->
-              CAst.make ~loc @@ CPatNotation(None,(InConstrEntry,"( _ )"),([p],[],[]),[])
+              CAst.make ~loc @@ CPatNotation(None,(InConstrEntry,"( _ )"),[NtnTypeArg (NtnTypeArgPattern (p,Explicit))],[])
           | _ -> p }
       | "("; p = pattern LEVEL "200"; "|" ; pl = LIST1 pattern LEVEL "200" SEP "|"; ")" ->
         { CAst.make ~loc @@ CPatOr (p::pl) }

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -278,7 +278,7 @@ GRAMMAR EXTEND Gram
              collapse -(3) into the number -3. *)
           (match c.CAst.v with
             | CPrim (Number (NumTok.SPlus,n)) ->
-                CAst.make ~loc @@ CNotation(None,(InConstrEntry,"( _ )"),[NtnTypeArg (NtnTypeArgConstr c)])
+                CAst.make ~loc @@ CNotation(None,(mk_ntn_in_constr "( _ )"),[NtnTypeArg (NtnTypeArgConstr c)])
             | _ -> c) }
       | "{|"; c = record_declaration; bar_cbrace -> { c }
       | "`{"; c = term LEVEL "200"; "}" ->
@@ -441,7 +441,7 @@ GRAMMAR EXTEND Gram
              collapse -(3) into the number -3. *)
           match p.CAst.v with
           | CPatPrim (Number (NumTok.SPlus,n)) ->
-              CAst.make ~loc @@ CPatNotation(None,(InConstrEntry,"( _ )"),[NtnTypeArg (NtnTypeArgPattern (p,Explicit))],[])
+              CAst.make ~loc @@ CPatNotation(None,(mk_ntn_in_constr "( _ )"),[NtnTypeArg (NtnTypeArgPattern (p,Explicit))],[])
           | _ -> p }
       | "("; p = pattern LEVEL "200"; "|" ; pl = LIST1 pattern LEVEL "200" SEP "|"; ")" ->
         { CAst.make ~loc @@ CPatOr (p::pl) }

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -278,7 +278,7 @@ GRAMMAR EXTEND Gram
              collapse -(3) into the number -3. *)
           (match c.CAst.v with
             | CPrim (Number (NumTok.SPlus,n)) ->
-                CAst.make ~loc @@ CNotation(None,(InConstrEntry,"( _ )"),([c],[],[],[]))
+                CAst.make ~loc @@ CNotation(None,(InConstrEntry,"( _ )"),[NtnTypeArg (NtnTypeArgConstr c)])
             | _ -> c) }
       | "{|"; c = record_declaration; bar_cbrace -> { c }
       | "`{"; c = term LEVEL "200"; "}" ->
@@ -441,7 +441,7 @@ GRAMMAR EXTEND Gram
              collapse -(3) into the number -3. *)
           match p.CAst.v with
           | CPatPrim (Number (NumTok.SPlus,n)) ->
-              CAst.make ~loc @@ CPatNotation(None,(InConstrEntry,"( _ )"),([p],[],[]),[])
+              CAst.make ~loc @@ CPatNotation(None,(InConstrEntry,"( _ )"),[NtnTypeArg (NtnTypeArgPattern (p,Explicit))],[])
           | _ -> p }
       | "("; p = pattern LEVEL "200"; "|" ; pl = LIST1 pattern LEVEL "200" SEP "|"; ")" ->
         { CAst.make ~loc @@ CPatOr (p::pl) }

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -285,7 +285,7 @@ GRAMMAR EXTEND Gram
              collapse -(3) into the number -3. *)
           (match c.CAst.v with
             | CPrim (Number (NumTok.SPlus,n)) ->
-                CAst.make ~loc @@ CNotation(None,(InConstrEntry,"( _ )"),[NtnTypeArg (NtnTypeArgConstr c)])
+                CAst.make ~loc @@ CNotation(None,(mk_ntn_in_constr "( _ )"),[NtnTypeArg (NtnTypeArgConstr c)])
             | _ -> c) }
       | "{|"; c = full_record_declaration; bar_cbrace -> { c }
       | "`{"; c = term LEVEL "200"; "}" ->
@@ -452,7 +452,7 @@ GRAMMAR EXTEND Gram
              collapse -(3) into the number -3. *)
           match p.CAst.v with
           | CPatPrim (Number (NumTok.SPlus,n)) ->
-              CAst.make ~loc @@ CPatNotation(None,(InConstrEntry,"( _ )"),[NtnTypeArg (NtnTypeArgPattern (p,Explicit))],[])
+              CAst.make ~loc @@ CPatNotation(None,(mk_ntn_in_constr "( _ )"),[NtnTypeArg (NtnTypeArgPattern (p,Explicit))],[])
           | _ -> p }
       | "("; p = pattern LEVEL "200"; "|" ; pl = LIST1 pattern LEVEL "200" SEP "|"; ")" ->
         { CAst.make ~loc @@ CPatOr (p::pl) }

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -285,7 +285,7 @@ GRAMMAR EXTEND Gram
              collapse -(3) into the number -3. *)
           (match c.CAst.v with
             | CPrim (Number (NumTok.SPlus,n)) ->
-                CAst.make ~loc @@ CNotation(None,(InConstrEntry,"( _ )"),([c],[],[],[]))
+                CAst.make ~loc @@ CNotation(None,(InConstrEntry,"( _ )"),[NtnTypeArg (NtnTypeArgConstr c)])
             | _ -> c) }
       | "{|"; c = full_record_declaration; bar_cbrace -> { c }
       | "`{"; c = term LEVEL "200"; "}" ->
@@ -452,7 +452,7 @@ GRAMMAR EXTEND Gram
              collapse -(3) into the number -3. *)
           match p.CAst.v with
           | CPatPrim (Number (NumTok.SPlus,n)) ->
-              CAst.make ~loc @@ CPatNotation(None,(InConstrEntry,"( _ )"),([p],[],[]),[])
+              CAst.make ~loc @@ CPatNotation(None,(InConstrEntry,"( _ )"),[NtnTypeArg (NtnTypeArgPattern (p,Explicit))],[])
           | _ -> p }
       | "("; p = pattern LEVEL "200"; "|" ; pl = LIST1 pattern LEVEL "200" SEP "|"; ")" ->
         { CAst.make ~loc @@ CPatOr (p::pl) }

--- a/parsing/notgram_ops.ml
+++ b/parsing/notgram_ops.ml
@@ -56,6 +56,8 @@ let declare_prefixes ntn =
 
 let notation_non_terminals_map = Summary.ref ~stage:Summary.Stage.Synterp ~name:"notation_non_terminals_map" NotationMap.empty
 
+type entry_types = Extend.constr_entry_key list
+
 let declare_notation_non_terminals ntn entries =
   try
     let _ = NotationMap.find ntn !notation_grammar_map in

--- a/parsing/notgram_ops.ml
+++ b/parsing/notgram_ops.ml
@@ -61,6 +61,8 @@ let declare_prefixes ntn =
 
 let notation_non_terminals_map = Summary.ref ~stage:Summary.Stage.Synterp ~name:"notation_non_terminals_map" NotationMap.empty
 
+type entry_types = Extend.constr_entry_key list
+
 let declare_notation_non_terminals ntn entries =
   try
     let _ = NotationMap.find ntn !notation_grammar_map in

--- a/parsing/notgram_ops.mli
+++ b/parsing/notgram_ops.mli
@@ -14,12 +14,14 @@ open Notation_gram
 
 (** {6 Declare the parsing rules and entries of a (possibly uninterpreted) notation } *)
 
+type entry_types = Extend.constr_entry_key list
+
 val declare_notation_grammar : notation -> notation_grammar -> unit
 val grammar_of_notation : notation -> notation_grammar
   (** raise [Not_found] if not declared *)
 
-val declare_notation_non_terminals : notation -> Extend.constr_entry_key list -> unit
-val non_terminals_of_notation : notation -> Extend.constr_entry_key list
+val declare_notation_non_terminals : notation -> entry_types -> unit
+val non_terminals_of_notation : notation -> entry_types
 
 (** [longest_common_prefix ntn] looks among notations [ntn'] already
     registered with [declare_notation_non_terminals ntn'] for the one

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -949,7 +949,7 @@ let glob_cpattern gs p =
   | {kind=k; pattern=(v, Some t); _} as orig ->
      if k = Cpattern then glob_ssrterm gs {kind=InParens; pattern=(v, Some t); interpretation=None} else
      match t.CAst.v with
-     | CNotation(_,(InConstrEntry,"( _ in _ )"), ([t1; t2], [], [], [])) ->
+     | CNotation(_,(InConstrEntry,"( _ in _ )"), [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2)]) ->
        (try match glob t1, glob t2 with
           | (r1, None), (r2, None) -> encode k "In" [r1;r2]
           | (r1, Some _), (r2, Some _) when isCVar t1 ->
@@ -957,11 +957,11 @@ let glob_cpattern gs p =
           | (r1, Some _), (r2, Some _) -> encode k "In" [r1; r2]
           | _ -> CErrors.anomaly (str"where are we?.")
         with e when CErrors.noncritical e && isCVar t1 -> encode k "In" [bind_in t1 t2])
-     | CNotation(_,(InConstrEntry,"( _ in _ in _ )"), ([t1; t2; t3], [], [], [])) ->
+     | CNotation(_,(InConstrEntry,"( _ in _ in _ )"), [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2); NtnTypeArg (NtnTypeArgConstr t3)]) ->
          check_var t2; encode k "In" [fst (glob t1); bind_in t2 t3]
-     | CNotation(_,(InConstrEntry,"( _ as _ )"), ([t1; t2], [], [], [])) ->
+     | CNotation(_,(InConstrEntry,"( _ as _ )"), [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2)]) ->
          encode k "As" [fst (glob t1); fst (glob t2)]
-     | CNotation(_,(InConstrEntry,"( _ as _ in _ )"), ([t1; t2; t3], [], [], [])) ->
+     | CNotation(_,(InConstrEntry,"( _ as _ in _ )"), [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2); NtnTypeArg (NtnTypeArgConstr t3)]) ->
          check_var t2; encode k "As" [fst (glob t1); bind_in t2 t3]
      | _ -> glob_ssrterm gs orig
 ;;

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -949,7 +949,7 @@ let glob_cpattern gs p =
   | {kind=k; pattern=(v, Some t); _} as orig ->
      if k = Cpattern then glob_ssrterm gs {kind=InParens; pattern=(v, Some t); interpretation=None} else
      match t.CAst.v with
-     | CNotation(_,(InConstrEntry,"( _ in _ )"), [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2)]) ->
+     | CNotation(_,{ntn_entry = InConstrEntry; ntn_key = "( _ in _ )"}, [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2)]) ->
        (try match glob t1, glob t2 with
           | (r1, None), (r2, None) -> encode k "In" [r1;r2]
           | (r1, Some _), (r2, Some _) when isCVar t1 ->
@@ -957,11 +957,11 @@ let glob_cpattern gs p =
           | (r1, Some _), (r2, Some _) -> encode k "In" [r1; r2]
           | _ -> CErrors.anomaly (str"where are we?.")
         with e when CErrors.noncritical e && isCVar t1 -> encode k "In" [bind_in t1 t2])
-     | CNotation(_,(InConstrEntry,"( _ in _ in _ )"), [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2); NtnTypeArg (NtnTypeArgConstr t3)]) ->
+     | CNotation(_,{ntn_entry = InConstrEntry; ntn_key = "( _ in _ in _ )"}, [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2); NtnTypeArg (NtnTypeArgConstr t3)]) ->
          check_var t2; encode k "In" [fst (glob t1); bind_in t2 t3]
-     | CNotation(_,(InConstrEntry,"( _ as _ )"), [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2)]) ->
+     | CNotation(_,{ntn_entry = InConstrEntry; ntn_key = "( _ as _ )"}, [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2)]) ->
          encode k "As" [fst (glob t1); fst (glob t2)]
-     | CNotation(_,(InConstrEntry,"( _ as _ in _ )"), [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2); NtnTypeArg (NtnTypeArgConstr t3)]) ->
+     | CNotation(_,{ntn_entry = InConstrEntry; ntn_key = "( _ as _ in _ )"}, [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2); NtnTypeArg (NtnTypeArgConstr t3)]) ->
          check_var t2; encode k "As" [fst (glob t1); bind_in t2 t3]
      | _ -> glob_ssrterm gs orig
 ;;

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -1113,7 +1113,7 @@ let glob_cpattern gs p =
   | {kind=k; pattern=(v, Some t); _} as orig ->
      if k = Cpattern then glob_ssrterm gs {kind=InParens; pattern=(v, Some t); interpretation=None} else
      match t.CAst.v with
-     | CNotation(_,(InConstrEntry,"( _ in _ )"), ([t1; t2], [], [], [])) ->
+     | CNotation(_,(InConstrEntry,"( _ in _ )"), [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2)]) ->
        (try match glob t1, glob t2 with
           | (r1, None), (r2, None) -> encode k "In" [r1;r2]
           | (r1, Some _), (r2, Some _) when isCVar t1 ->
@@ -1121,11 +1121,11 @@ let glob_cpattern gs p =
           | (r1, Some _), (r2, Some _) -> encode k "In" [r1; r2]
           | _ -> CErrors.anomaly (str"where are we?.")
         with e when CErrors.noncritical e && isCVar t1 -> encode k "In" [bind_in t1 t2])
-     | CNotation(_,(InConstrEntry,"( _ in _ in _ )"), ([t1; t2; t3], [], [], [])) ->
+     | CNotation(_,(InConstrEntry,"( _ in _ in _ )"), [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2); NtnTypeArg (NtnTypeArgConstr t3)]) ->
          check_var t2; encode k "In" [fst (glob t1); bind_in t2 t3]
-     | CNotation(_,(InConstrEntry,"( _ as _ )"), ([t1; t2], [], [], [])) ->
+     | CNotation(_,(InConstrEntry,"( _ as _ )"), [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2)]) ->
          encode k "As" [fst (glob t1); fst (glob t2)]
-     | CNotation(_,(InConstrEntry,"( _ as _ in _ )"), ([t1; t2; t3], [], [], [])) ->
+     | CNotation(_,(InConstrEntry,"( _ as _ in _ )"), [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2); NtnTypeArg (NtnTypeArgConstr t3)]) ->
          check_var t2; encode k "As" [fst (glob t1); bind_in t2 t3]
      | _ -> glob_ssrterm gs orig
 

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -1113,7 +1113,7 @@ let glob_cpattern gs p =
   | {kind=k; pattern=(v, Some t); _} as orig ->
      if k = Cpattern then glob_ssrterm gs {kind=InParens; pattern=(v, Some t); interpretation=None} else
      match t.CAst.v with
-     | CNotation(_,(InConstrEntry,"( _ in _ )"), [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2)]) ->
+     | CNotation(_,{ntn_entry = InConstrEntry; ntn_key = "( _ in _ )"}, [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2)]) ->
        (try match glob t1, glob t2 with
           | (r1, None), (r2, None) -> encode k "In" [r1;r2]
           | (r1, Some _), (r2, Some _) when isCVar t1 ->
@@ -1121,11 +1121,11 @@ let glob_cpattern gs p =
           | (r1, Some _), (r2, Some _) -> encode k "In" [r1; r2]
           | _ -> CErrors.anomaly (str"where are we?.")
         with e when CErrors.noncritical e && isCVar t1 -> encode k "In" [bind_in t1 t2])
-     | CNotation(_,(InConstrEntry,"( _ in _ in _ )"), [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2); NtnTypeArg (NtnTypeArgConstr t3)]) ->
+     | CNotation(_,{ntn_entry = InConstrEntry; ntn_key = "( _ in _ in _ )"}, [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2); NtnTypeArg (NtnTypeArgConstr t3)]) ->
          check_var t2; encode k "In" [fst (glob t1); bind_in t2 t3]
-     | CNotation(_,(InConstrEntry,"( _ as _ )"), [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2)]) ->
+     | CNotation(_,{ntn_entry = InConstrEntry; ntn_key = "( _ as _ )"}, [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2)]) ->
          encode k "As" [fst (glob t1); fst (glob t2)]
-     | CNotation(_,(InConstrEntry,"( _ as _ in _ )"), [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2); NtnTypeArg (NtnTypeArgConstr t3)]) ->
+     | CNotation(_,{ntn_entry = InConstrEntry; ntn_key = "( _ as _ in _ )"}, [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2); NtnTypeArg (NtnTypeArgConstr t3)]) ->
          check_var t2; encode k "As" [fst (glob t1); bind_in t2 t3]
      | _ -> glob_ssrterm gs orig
 

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -391,7 +391,7 @@ and pr_patt sep pr lev_after inh p =
         let pp p = hov 0 (pr_patt mt pr lev_after lpattop p) in
         surround (hov 0 (prlist_with_sep pr_spcbar pp pl))) lpator
 
-  | CPatNotation (_,(_,"( _ )"),[NtnTypeArg (NtnTypeArgPattern (p,_bk))],[]) ->
+  | CPatNotation (_,{ntn_key = "( _ )"},[NtnTypeArg (NtnTypeArgPattern (p,_bk))],[]) ->
     return (fun lev_after -> pr_patt (fun()->str"(") pr no_after lpattop p ++ str")") latom
 
   | CPatNotation (which,s,l,args) ->
@@ -790,7 +790,7 @@ let pr pr sep lev_after inherited a =
         hv 0 (pr mt no_after (LevelLt lcast) a ++ spc () ++
               (pr_cast k) ++ ws 1 ++ pr mt lev_after (LevelLe lprod) b))
       lcast
-  | CNotation (_,(_,"( _ )"),[NtnTypeArg (NtnTypeArgConstr t)]) ->
+  | CNotation (_,{ntn_key = "( _ )"},[NtnTypeArg (NtnTypeArgConstr t)]) ->
     return (fun lev_after -> pr (fun()->str"(") no_after ltop t ++ str")") latom
   | CNotation (which,s,env) ->
     let l_not = (find_notation_printing_rule which s).notation_printing_level in

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -98,10 +98,14 @@ let adjust_level side lev_after l_not prec =
   | Some Left -> Some l_not, prec
   | None -> no_after,prec (* should we care about the separator being possibly empty? *)
 
-let print_hunks l_not lev_after pr pr_patt pr_binders (terms, termlists, binders, binderlists) unps =
-  let env = ref terms and envlist = ref termlists and bl = ref binders and bll = ref binderlists in
+let print_hunks l_not lev_after pr pr_patt pr_binders subst unps =
+  let env = ref subst in
   let pop r = let a = List.hd !r in r := List.tl !r; a in
   let return unp pp1 pp2 = (tag_unparsing unp pp1) ++ pp2 in
+  let pr_constr lev_after prec = function
+    | NtnTypeArgConstr c -> pr lev_after prec c
+    | NtnTypeArgPattern (c,bk) -> pr_patt prec NotQuotedPattern bk c
+    | _ -> assert false in
   (* Warning:
      The following function enforces a very precise order of
      evaluation of sub-components.
@@ -110,31 +114,39 @@ let print_hunks l_not lev_after pr pr_patt pr_binders (terms, termlists, binders
     | [] ->
       mt ()
     | UnpMetaVar {notation_relative_level = prec; notation_position = side} as unp :: l ->
-      let c = pop env in
-      let pp2 = aux l in
       let lev_after, prec = adjust_level side lev_after l_not prec in
-      let pp1 = pr lev_after prec c in
+      let pp1 = match pop env with
+        | NtnTypeArg c -> pr_constr lev_after prec c
+        | _ -> assert false in
+      let pp2 = aux l in
       return unp pp1 pp2
     | UnpBinderMetaVar (subentry,style) as unp :: l ->
-      let c,bk = pop bl in
+      let c,bk = match pop env with
+        | NtnTypeArg (NtnTypeArgPattern (c,bk)) -> c,bk
+        | _ -> assert false in
       let pp2 = aux l in
       let pp1 = pr_patt subentry.notation_relative_level style bk c in
       return unp pp1 pp2
     | UnpListMetaVar ({notation_relative_level = prec; notation_position = side}, sl) as unp :: l ->
       let lev_after', prec' = adjust_level side lev_after l_not prec in
+      let cl = match pop env with
+        | NtnTypeArgList l -> List.map (function NtnTypeArg c -> c | _ -> assert false) l
+        | _ -> assert false in
       let pp1 =
-        match pop envlist with
+        match cl with
         | [] -> assert false
-        | [c] -> pr lev_after' prec' c
+        | [c] -> pr_constr lev_after' prec' c
         | c1::cl ->
           let cn, cl = List.sep_last cl in
-          pr lev_after' prec c1 ++
-          prlist (fun c -> aux sl ++ pr (if List.is_empty sl then Some l_not else no_after) prec c) cl ++
-          aux sl ++ pr lev_after prec' cn in
+          pr_constr lev_after' prec c1 ++
+          prlist (fun c -> aux sl ++ pr_constr (if List.is_empty sl then Some l_not else no_after) prec c) cl ++
+          aux sl ++ pr_constr lev_after prec' cn in
       let pp2 = aux l in
       return unp pp1 pp2
     | UnpBinderListMetaVar (isopen, withquote, sl) as unp :: l ->
-      let cl = pop bll in
+      let cl = match pop env with
+        | NtnTypeArg (NtnTypeArgBinders cl) -> cl
+        | _ -> assert false in
       let pp2 = aux l in
       let pp1 = pr_binders (fun () -> aux sl) isopen withquote cl in
       return unp pp1 pp2
@@ -379,15 +391,15 @@ and pr_patt sep pr lev_after inh p =
         let pp p = hov 0 (pr_patt mt pr lev_after lpattop p) in
         surround (hov 0 (prlist_with_sep pr_spcbar pp pl))) lpator
 
-  | CPatNotation (_,(_,"( _ )"),([p],[],[]),[]) ->
+  | CPatNotation (_,(_,"( _ )"),[NtnTypeArg (NtnTypeArgPattern (p,_bk))],[]) ->
     return (fun lev_after -> pr_patt (fun()->str"(") pr no_after lpattop p ++ str")") latom
 
-  | CPatNotation (which,s,(l,ll,bl),args) ->
+  | CPatNotation (which,s,l,args) ->
     let l_not = (find_notation_printing_rule which s).notation_printing_level in
     let no_inner_surrounding = List.is_empty args || Notation.prec_less l_not (LevelLt lapp) in
     return (fun lev_after ->
         let lev_after' = if no_inner_surrounding then lev_after else no_after in
-        let strm_not = pr_notation lev_after (pr_patt mt pr) (pr_patt_binder pr) (fun _ _ _ _ -> mt()) which s (l,ll,bl,[]) in
+        let strm_not = pr_notation lev_after pr (pr_patt_binder pr) (fun _ _ _ _ -> assert false) which s l in
         (if List.is_empty args then strm_not else
          if overlap_right_left which s lev_after then surround strm_not else
          if Notation.prec_less l_not (LevelLt lapp) then strm_not else
@@ -402,7 +414,7 @@ and pr_patt sep pr lev_after inh p =
     return (fun lev_after -> pr_delimiters depth k (pr_patt mt pr (Some 1) lsimplepatt p)) 1
 
   | CPatCast (p,t) ->
-    return (fun lev_after -> pr_patt mt pr (Some 1) lpatcast p ++ spc () ++ str ":" ++ ws 1 ++ pr t) 1
+    return (fun lev_after -> pr_patt mt pr (Some 1) lpatcast p ++ spc () ++ str ":" ++ ws 1 ++ pr lev_after (LevelLe lprod) t) 1
 
 and pr_patt_binder pr prec style bk c =
   match bk with
@@ -420,7 +432,7 @@ let pr_eqn pr {loc;v=(pl,rhs)} =
     (pr_with_comments ?loc
        (str "| " ++
         hov 0 (prlist_with_sep pr_spcbar
-                 (fun p -> hov 0 (prlist_with_sep sep_v (pr_patt (pr no_after ltop) no_after ltop) p)) pl
+                 (fun p -> hov 0 (prlist_with_sep sep_v (pr_patt pr no_after ltop) p)) pl
                ++ str " =>") ++
         pr_sep_com spc (pr no_after ltop) rhs))
 
@@ -473,11 +485,11 @@ let pr_binder many pr (nal,r,k,t) =
 
 let pr_binder_among_many withquote pr_c = function
   | CLocalAssum (nal,r,k,t) ->
-    pr_binder true pr_c (nal,r,k,t)
+    pr_binder true (pr_c no_after ltop) (nal,r,k,t)
   | CLocalDef (na,r,c,topt) ->
     surround (pr_lname na ++ pr_relevance_info r ++
-              pr_opt_no_spc (fun t -> str " :" ++ ws 1 ++ pr_c t) topt ++
-              str" :=" ++ spc() ++ pr_c c)
+              pr_opt_no_spc (fun t -> str " :" ++ ws 1 ++ pr_c no_after ltop t) topt ++
+              str" :=" ++ spc() ++ pr_c no_after ltop c)
   | CLocalPattern p ->
     str (if withquote then "'" else "") ++ pr_patt pr_c no_after lsimplepatt p
 
@@ -488,7 +500,7 @@ let pr_delimited_binders kw sep withquote pr_c bl =
   let n = begin_of_binders bl in
   match bl with
   | [CLocalAssum (nal,r,k,t)] ->
-    kw n ++ pr_binder false pr_c (nal,r,k,t)
+    kw n ++ pr_binder false (pr_c no_after ltop) (nal,r,k,t)
   | (CLocalAssum _ | CLocalPattern _ | CLocalDef _) :: _ as bdl ->
     kw n ++ pr_undelimited_binders sep withquote pr_c bdl
   | [] -> anomaly (Pp.str "The ast is malformed, found lambda/prod without proper binders.")
@@ -501,7 +513,7 @@ let pr_recursive_decl pr pr_dangling lev_after kw dangling_with_for id bl annot 
   let pr_body =
     if dangling_with_for then pr_dangling else pr in
   hov 0 (str kw ++ brk(1,2) ++ pr_id id ++ (if bl = [] then mt () else brk(1,2)) ++
-         hov 0 (pr_undelimited_binders spc true (pr no_after ltop) bl ++ annot) ++
+         hov 0 (pr_undelimited_binders spc true pr bl ++ annot) ++
          pr_opt_type_spc pr t ++ str " :=") ++
   pr_sep_com (fun () -> brk(1,2)) (pr_body lev_after ltop) c
 
@@ -551,7 +563,7 @@ let pr_as_in pr na indnalopt =
    | Some t -> spc () ++ keyword "in" ++ spc () ++ pr_patt pr no_after lsimplepatt t)
 
 let pr_case_item pr (tm,as_clause, in_clause) =
-  hov 0 (pr no_after (LevelLe lcast) tm ++ pr_as_in (pr no_after ltop) as_clause in_clause)
+  hov 0 (pr no_after (LevelLe lcast) tm ++ pr_as_in pr as_clause in_clause)
 
 let pr_case_type pr po =
   match po with
@@ -668,14 +680,14 @@ let pr pr sep lev_after inherited a =
     return (fun lev_after ->
         hov 0 (
           hov 2 (pr_delimited_binders pr_forall spc true
-                   (pr mt no_after ltop) bl) ++
+                   (pr mt) bl) ++
           str "," ++ pr spc lev_after ltop a))
       lprod
   | CLambdaN (bl,a) ->
     return (fun lev_after ->
         hov 0 (
           hov 2 (pr_delimited_binders pr_fun spc true
-                   (pr mt no_after ltop) bl) ++
+                   (pr mt) bl) ++
           pr_fun_sep ++ pr spc lev_after ltop a))
       llambda
   | CLetIn ({v=Name x}, ({ v = CFix({v=x'},[_])}
@@ -718,8 +730,8 @@ let pr pr sep lev_after inherited a =
     return (fun lev_after ->
         hv 0 (
           keyword "let" ++ spc () ++ str"'" ++
-          hov 0 (pr_patt (pr mt no_after ltop) no_after ltop p ++
-                 pr_as_in (pr mt no_after ltop) as_clause in_clause ++
+          hov 0 (pr_patt (pr mt) no_after ltop p ++
+                 pr_as_in (pr mt) as_clause in_clause ++
                  str " :=" ++ pr spc no_after ltop c ++
                  pr_case_type (pr_dangling_with_for mt pr) rtntypopt ++
                  spc () ++ keyword "in" ++ pr spc lev_after ltop b)))
@@ -778,12 +790,12 @@ let pr pr sep lev_after inherited a =
         hv 0 (pr mt no_after (LevelLt lcast) a ++ spc () ++
               (pr_cast k) ++ ws 1 ++ pr mt lev_after (LevelLe lprod) b))
       lcast
-  | CNotation (_,(_,"( _ )"),([t],[],[],[])) ->
+  | CNotation (_,(_,"( _ )"),[NtnTypeArg (NtnTypeArgConstr t)]) ->
     return (fun lev_after -> pr (fun()->str"(") no_after ltop t ++ str")") latom
   | CNotation (which,s,env) ->
     let l_not = (find_notation_printing_rule which s).notation_printing_level in
     let l_not = if overlap_right_left which s lev_after then max_int else l_not in
-    return (fun lev_after -> pr_notation lev_after (pr mt) (pr_patt_binder (pr mt no_after ltop)) (pr_binders_gen (pr mt no_after ltop)) which s env) l_not
+    return (fun lev_after -> pr_notation lev_after (pr mt) (pr_patt_binder (pr mt)) (pr_binders_gen (pr mt)) which s env) l_not
   | CGeneralization (bk,c) ->
     return (fun lev_after -> pr_generalization bk (pr mt no_after ltop c)) latom
   | CPrim p ->
@@ -848,6 +860,6 @@ let pr_lconstr_expr c  = !term_pr.pr_lconstr_expr  c
 let pr_constr_pattern_expr c  = !term_pr.pr_constr_pattern_expr  c
 let pr_lconstr_pattern_expr c = !term_pr.pr_lconstr_pattern_expr c
 
-let pr_cases_pattern_expr = pr_patt (pr no_after ltop) no_after ltop
+let pr_cases_pattern_expr = pr_patt pr no_after ltop
 
-let pr_binders env sigma = pr_undelimited_binders spc true (pr_expr env sigma no_after ltop)
+let pr_binders env sigma = pr_undelimited_binders spc true (pr_expr env sigma)

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -403,7 +403,7 @@ and pr_patt ~flags sep pr lev_after inh p =
         let pp p = hov 0 (pr_patt ~flags mt pr lev_after lpattop p) in
         surround (hov 0 (prlist_with_sep pr_spcbar pp pl))) lpator
 
-  | CPatNotation (_,(_,"( _ )"),[NtnTypeArg (NtnTypeArgPattern (p,_bk))],[]) ->
+  | CPatNotation (_,{ntn_key = "( _ )"},[NtnTypeArg (NtnTypeArgPattern (p,_bk))],[]) ->
     return (fun lev_after -> pr_patt ~flags (fun()->str"(") pr no_after lpattop p ++ str")") latom
 
   | CPatNotation (which,s,l,args) ->
@@ -811,7 +811,7 @@ let pr ~flags pr sep lev_after inherited a =
         hv 0 (pr mt no_after (LevelLt lcast) a ++ spc () ++
               (pr_cast k) ++ ws 1 ++ pr mt lev_after (LevelLe lprod) b))
       lcast
-  | CNotation (_,(_,"( _ )"),[NtnTypeArg (NtnTypeArgConstr t)]) ->
+  | CNotation (_,{ntn_key = "( _ )"},[NtnTypeArg (NtnTypeArgConstr t)]) ->
     return (fun lev_after -> pr (fun()->str"(") no_after ltop t ++ str")") latom
   | CNotation (which,s,env) ->
     let l_not = (find_notation_printing_rule which s).notation_printing_level in

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -111,10 +111,14 @@ let adjust_level ~flags side lev_after l_not prec =
   | Some Left -> Some l_not, prec
   | None -> no_after,prec (* should we care about the separator being possibly empty? *)
 
-let print_hunks ~flags l_not lev_after pr pr_patt pr_binders (terms, termlists, binders, binderlists) unps =
-  let env = ref terms and envlist = ref termlists and bl = ref binders and bll = ref binderlists in
+let print_hunks ~flags l_not lev_after pr pr_patt pr_binders subst unps =
+  let env = ref subst in
   let pop r = let a = List.hd !r in r := List.tl !r; a in
   let return unp pp1 pp2 = (tag_unparsing unp pp1) ++ pp2 in
+  let pr_constr lev_after prec = function
+    | NtnTypeArgConstr c -> pr lev_after prec c
+    | NtnTypeArgPattern (c,bk) -> pr_patt prec NotQuotedPattern bk c
+    | _ -> assert false in
   (* Warning:
      The following function enforces a very precise order of
      evaluation of sub-components.
@@ -123,31 +127,39 @@ let print_hunks ~flags l_not lev_after pr pr_patt pr_binders (terms, termlists, 
     | [] ->
       mt ()
     | UnpMetaVar {notation_relative_level = prec; notation_position = side} as unp :: l ->
-      let c = pop env in
-      let pp2 = aux l in
       let lev_after, prec = adjust_level ~flags side lev_after l_not prec in
-      let pp1 = pr lev_after prec c in
+      let pp1 = match pop env with
+        | NtnTypeArg c -> pr_constr lev_after prec c
+        | _ -> assert false in
+      let pp2 = aux l in
       return unp pp1 pp2
     | UnpBinderMetaVar (subentry,style) as unp :: l ->
-      let c,bk = pop bl in
+      let c,bk = match pop env with
+        | NtnTypeArg (NtnTypeArgPattern (c,bk)) -> c,bk
+        | _ -> assert false in
       let pp2 = aux l in
       let pp1 = pr_patt subentry.notation_relative_level style bk c in
       return unp pp1 pp2
     | UnpListMetaVar ({notation_relative_level = prec; notation_position = side}, sl) as unp :: l ->
       let lev_after', prec' = adjust_level ~flags side lev_after l_not prec in
+      let cl = match pop env with
+        | NtnTypeArgList l -> List.map (function NtnTypeArg c -> c | _ -> assert false) l
+        | _ -> assert false in
       let pp1 =
-        match pop envlist with
+        match cl with
         | [] -> assert false
-        | [c] -> pr lev_after' prec' c
+        | [c] -> pr_constr lev_after' prec' c
         | c1::cl ->
           let cn, cl = List.sep_last cl in
-          pr lev_after' prec c1 ++
-          prlist (fun c -> aux sl ++ pr (if List.is_empty sl then Some l_not else no_after) prec c) cl ++
-          aux sl ++ pr lev_after prec' cn in
+          pr_constr lev_after' prec c1 ++
+          prlist (fun c -> aux sl ++ pr_constr (if List.is_empty sl then Some l_not else no_after) prec c) cl ++
+          aux sl ++ pr_constr lev_after prec' cn in
       let pp2 = aux l in
       return unp pp1 pp2
     | UnpBinderListMetaVar (isopen, withquote, sl) as unp :: l ->
-      let cl = pop bll in
+      let cl = match pop env with
+        | NtnTypeArg (NtnTypeArgBinders cl) -> cl
+        | _ -> assert false in
       let pp2 = aux l in
       let pp1 = pr_binders (fun () -> aux sl) isopen withquote cl in
       return unp pp1 pp2
@@ -391,15 +403,15 @@ and pr_patt ~flags sep pr lev_after inh p =
         let pp p = hov 0 (pr_patt ~flags mt pr lev_after lpattop p) in
         surround (hov 0 (prlist_with_sep pr_spcbar pp pl))) lpator
 
-  | CPatNotation (_,(_,"( _ )"),([p],[],[]),[]) ->
+  | CPatNotation (_,(_,"( _ )"),[NtnTypeArg (NtnTypeArgPattern (p,_bk))],[]) ->
     return (fun lev_after -> pr_patt ~flags (fun()->str"(") pr no_after lpattop p ++ str")") latom
 
-  | CPatNotation (which,s,(l,ll,bl),args) ->
+  | CPatNotation (which,s,l,args) ->
     let l_not = (find_notation_printing_rule which s).notation_printing_level in
     let no_inner_surrounding = List.is_empty args || Notation.prec_less l_not (LevelLt lapp) in
     return (fun lev_after ->
         let lev_after' = if no_inner_surrounding then lev_after else no_after in
-        let strm_not = pr_notation ~flags lev_after (pr_patt ~flags mt pr) (pr_patt_binder ~flags pr) (fun _ _ _ _ -> mt()) which s (l,ll,bl,[]) in
+        let strm_not = pr_notation ~flags lev_after pr (pr_patt_binder ~flags pr) (fun _ _ _ _ -> assert false) which s l in
         (if List.is_empty args then strm_not else
          if overlap_right_left which s lev_after then surround strm_not else
          if Notation.prec_less l_not (LevelLt lapp) then strm_not else
@@ -414,7 +426,7 @@ and pr_patt ~flags sep pr lev_after inh p =
     return (fun lev_after -> pr_delimiters depth k (pr_patt ~flags mt pr (Some 1) lsimplepatt p)) 1
 
   | CPatCast (p,t) ->
-    return (fun lev_after -> pr_patt ~flags mt pr (Some 1) lpatcast p ++ spc () ++ str ":" ++ ws 1 ++ pr t) 1
+    return (fun lev_after -> pr_patt ~flags mt pr (Some 1) lpatcast p ++ spc () ++ str ":" ++ ws 1 ++ pr lev_after (LevelLe lprod) t) 1
 
 and pr_patt_binder ~flags pr prec style bk c =
   match bk with
@@ -432,7 +444,7 @@ let pr_eqn ~flags pr {loc;v=(pl,rhs)} =
     (pr_with_comments ?loc
        (str "| " ++
         hov 0 (prlist_with_sep pr_spcbar
-                 (fun p -> hov 0 (prlist_with_sep sep_v (pr_patt ~flags (pr no_after ltop) no_after ltop) p)) pl
+                 (fun p -> hov 0 (prlist_with_sep sep_v (pr_patt ~flags pr no_after ltop) p)) pl
                ++ str " =>") ++
         pr_sep_com spc (pr no_after ltop) rhs))
 
@@ -485,11 +497,11 @@ let pr_binder many pr (nal,r,k,t) =
 
 let pr_binder_among_many ~flags withquote pr_c = function
   | CLocalAssum (nal,r,k,t) ->
-    pr_binder true pr_c (nal,r,k,t)
+    pr_binder true (pr_c no_after ltop) (nal,r,k,t)
   | CLocalDef (na,r,c,topt) ->
     surround (pr_lname na ++ pr_relevance_info r ++
-              pr_opt_no_spc (fun t -> str " :" ++ ws 1 ++ pr_c t) topt ++
-              str" :=" ++ spc() ++ pr_c c)
+              pr_opt_no_spc (fun t -> str " :" ++ ws 1 ++ pr_c no_after ltop t) topt ++
+              str" :=" ++ spc() ++ pr_c no_after ltop c)
   | CLocalPattern p ->
     str (if withquote then "'" else "") ++ pr_patt ~flags pr_c no_after lsimplepatt p
 
@@ -500,7 +512,7 @@ let pr_delimited_binders ~flags kw sep withquote pr_c bl =
   let n = begin_of_binders bl in
   match bl with
   | [CLocalAssum (nal,r,k,t)] ->
-    kw n ++ pr_binder false pr_c (nal,r,k,t)
+    kw n ++ pr_binder false (pr_c no_after ltop) (nal,r,k,t)
   | (CLocalAssum _ | CLocalPattern _ | CLocalDef _) :: _ as bdl ->
     kw n ++ pr_undelimited_binders ~flags sep withquote pr_c bdl
   | [] -> anomaly (Pp.str "The ast is malformed, found lambda/prod without proper binders.")
@@ -513,7 +525,7 @@ let pr_recursive_decl ~flags pr pr_dangling lev_after kw dangling_with_for id bl
   let pr_body =
     if dangling_with_for then pr_dangling else pr in
   hov 0 (str kw ++ brk(1,2) ++ pr_id id ++ (if bl = [] then mt () else brk(1,2)) ++
-         hov 0 (pr_undelimited_binders ~flags spc true (pr no_after ltop) bl ++ annot) ++
+         hov 0 (pr_undelimited_binders ~flags spc true pr bl ++ annot) ++
          pr_opt_type_spc pr t ++ str " :=") ++
   pr_sep_com (fun () -> brk(1,2)) (pr_body lev_after ltop) c
 
@@ -563,7 +575,7 @@ let pr_as_in ~flags pr na indnalopt =
    | Some t -> spc () ++ keyword "in" ++ spc () ++ pr_patt ~flags pr no_after ltop t)
 
 let pr_case_item ~flags pr (tm,as_clause, in_clause) =
-  hov 0 (pr no_after (LevelLe lcast) tm ++ pr_as_in ~flags (pr no_after ltop) as_clause in_clause)
+  hov 0 (pr no_after (LevelLe lcast) tm ++ pr_as_in ~flags pr as_clause in_clause)
 
 let pr_case_type pr po =
   match po with
@@ -677,14 +689,14 @@ let pr ~flags pr sep lev_after inherited a =
     return (fun lev_after ->
         hov 0 (
           hov 2 (pr_delimited_binders ~flags pr_forall spc true
-                   (pr mt no_after ltop) bl) ++
+                   (pr mt) bl) ++
           str "," ++ pr spc lev_after ltop a))
       lprod
   | CLambdaN (bl,a) ->
     return (fun lev_after ->
         hov 0 (
           hov 2 (pr_delimited_binders ~flags pr_fun spc true
-                   (pr mt no_after ltop) bl) ++
+                   (pr mt) bl) ++
           pr_fun_sep ++ pr spc lev_after ltop a))
       llambda
   | CLetIn ({v=Name x}, ({ v = CFix({v=x'},[_])}
@@ -727,8 +739,8 @@ let pr ~flags pr sep lev_after inherited a =
     return (fun lev_after ->
         hv 0 (
           keyword "let" ++ spc () ++ str"'" ++
-          hov 0 (pr_patt ~flags (pr mt no_after ltop) no_after ltop p ++
-                 pr_as_in ~flags (pr mt no_after ltop) as_clause in_clause ++
+          hov 0 (pr_patt ~flags (pr mt) no_after ltop p ++
+                 pr_as_in ~flags (pr mt) as_clause in_clause ++
                  str " :=" ++ pr spc no_after ltop c ++
                  pr_case_type (pr_dangling_with_for mt pr) rtntypopt ++
                  spc () ++ keyword "in" ++ pr spc lev_after ltop b)))
@@ -737,9 +749,9 @@ let pr ~flags pr sep lev_after inherited a =
     return (fun lev_after ->
         hv 0 (
           hov 1 (keyword "if" ++ spc () ++ pr mt no_after ltop c
-                 ++ pr_as_in ~flags (pr mt no_after ltop) as_clause in_clause
+                 ++ pr_as_in ~flags (pr mt) as_clause in_clause
                  ++ spc () ++ keyword "is" ++ spc ()
-                 ++ pr_patt ~flags (pr mt no_after ltop) no_after ltop p) ++
+                 ++ pr_patt ~flags (pr mt) no_after ltop p) ++
           spc () ++
           hov 0 (keyword "then"
                  ++ pr (fun () -> brk (1,1)) no_after ltop b1) ++ spc () ++
@@ -799,12 +811,12 @@ let pr ~flags pr sep lev_after inherited a =
         hv 0 (pr mt no_after (LevelLt lcast) a ++ spc () ++
               (pr_cast k) ++ ws 1 ++ pr mt lev_after (LevelLe lprod) b))
       lcast
-  | CNotation (_,(_,"( _ )"),([t],[],[],[])) ->
+  | CNotation (_,(_,"( _ )"),[NtnTypeArg (NtnTypeArgConstr t)]) ->
     return (fun lev_after -> pr (fun()->str"(") no_after ltop t ++ str")") latom
   | CNotation (which,s,env) ->
     let l_not = (find_notation_printing_rule which s).notation_printing_level in
     let l_not = if overlap_right_left which s lev_after then max_int else l_not in
-    return (fun lev_after -> pr_notation ~flags lev_after (pr mt) (pr_patt_binder ~flags (pr mt no_after ltop)) (pr_binders_gen ~flags (pr mt no_after ltop)) which s env) l_not
+    return (fun lev_after -> pr_notation ~flags lev_after (pr mt) (pr_patt_binder ~flags (pr mt)) (pr_binders_gen ~flags (pr mt)) which s env) l_not
   | CGeneralization (bk,c) ->
     return (fun lev_after -> pr_generalization bk (pr mt no_after ltop c)) latom
   | CPrim p ->
@@ -866,9 +878,9 @@ let pr_lconstr_expr ~flags env sigma c : Pp.t = !term_pr.pr_lconstr_expr ~flags 
 let pr_constr_pattern_expr ~flags env sigma c : Pp.t = !term_pr.pr_constr_pattern_expr ~flags env sigma c
 let pr_lconstr_pattern_expr ~flags env sigma c : Pp.t = !term_pr.pr_lconstr_pattern_expr ~flags env sigma c
 
-let pr_cases_pattern_expr ~flags c : Pp.t = pr_patt ~flags (pr ~flags no_after ltop) no_after ltop c
+let pr_cases_pattern_expr ~flags c : Pp.t = pr_patt ~flags (pr ~flags) no_after ltop c
 
-let pr_binders ~flags env sigma l : Pp.t = pr_undelimited_binders ~flags spc true (pr_expr ~flags env sigma no_after ltop) l
+let pr_binders ~flags env sigma l : Pp.t = pr_undelimited_binders ~flags spc true (pr_expr ~flags env sigma) l
 
 module CompactedDecl = struct
   type t =

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -111,10 +111,14 @@ let adjust_level ~flags side lev_after l_not prec =
   | Some Left -> Some l_not, prec
   | None -> no_after,prec (* should we care about the separator being possibly empty? *)
 
-let print_hunks ~flags l_not lev_after pr pr_patt pr_binders (terms, termlists, binders, binderlists) unps =
-  let env = ref terms and envlist = ref termlists and bl = ref binders and bll = ref binderlists in
+let print_hunks ~flags l_not lev_after pr pr_patt pr_binders subst unps =
+  let env = ref subst in
   let pop r = let a = List.hd !r in r := List.tl !r; a in
   let return unp pp1 pp2 = (tag_unparsing unp pp1) ++ pp2 in
+  let pr_constr lev_after prec = function
+    | NtnTypeArgConstr c -> pr lev_after prec c
+    | NtnTypeArgPattern (c,bk) -> pr_patt prec NotQuotedPattern bk c
+    | _ -> assert false in
   (* Warning:
      The following function enforces a very precise order of
      evaluation of sub-components.
@@ -123,31 +127,39 @@ let print_hunks ~flags l_not lev_after pr pr_patt pr_binders (terms, termlists, 
     | [] ->
       mt ()
     | UnpMetaVar {notation_relative_level = prec; notation_position = side} as unp :: l ->
-      let c = pop env in
-      let pp2 = aux l in
       let lev_after, prec = adjust_level ~flags side lev_after l_not prec in
-      let pp1 = pr lev_after prec c in
+      let pp1 = match pop env with
+        | NtnTypeArg c -> pr_constr lev_after prec c
+        | _ -> assert false in
+      let pp2 = aux l in
       return unp pp1 pp2
     | UnpBinderMetaVar (subentry,style) as unp :: l ->
-      let c,bk = pop bl in
+      let c,bk = match pop env with
+        | NtnTypeArg (NtnTypeArgPattern (c,bk)) -> c,bk
+        | _ -> assert false in
       let pp2 = aux l in
       let pp1 = pr_patt subentry.notation_relative_level style bk c in
       return unp pp1 pp2
     | UnpListMetaVar ({notation_relative_level = prec; notation_position = side}, sl) as unp :: l ->
       let lev_after', prec' = adjust_level ~flags side lev_after l_not prec in
+      let cl = match pop env with
+        | NtnTypeArgList l -> List.map (function NtnTypeArg c -> c | _ -> assert false) l
+        | _ -> assert false in
       let pp1 =
-        match pop envlist with
+        match cl with
         | [] -> assert false
-        | [c] -> pr lev_after' prec' c
+        | [c] -> pr_constr lev_after' prec' c
         | c1::cl ->
           let cn, cl = List.sep_last cl in
-          pr lev_after' prec c1 ++
-          prlist (fun c -> aux sl ++ pr (if List.is_empty sl then Some l_not else no_after) prec c) cl ++
-          aux sl ++ pr lev_after prec' cn in
+          pr_constr lev_after' prec c1 ++
+          prlist (fun c -> aux sl ++ pr_constr (if List.is_empty sl then Some l_not else no_after) prec c) cl ++
+          aux sl ++ pr_constr lev_after prec' cn in
       let pp2 = aux l in
       return unp pp1 pp2
     | UnpBinderListMetaVar (isopen, withquote, sl) as unp :: l ->
-      let cl = pop bll in
+      let cl = match pop env with
+        | NtnTypeArg (NtnTypeArgBinders cl) -> cl
+        | _ -> assert false in
       let pp2 = aux l in
       let pp1 = pr_binders (fun () -> aux sl) isopen withquote cl in
       return unp pp1 pp2
@@ -396,15 +408,15 @@ and pr_patt ~flags sep pr lev_after inh p =
         let pp p = hov 0 (pr_patt ~flags mt pr lev_after lpattop p) in
         surround (hov 0 (prlist_with_sep pr_spcbar pp pl))) lpator
 
-  | CPatNotation (_,(_,"( _ )"),([p],[],[]),[]) ->
+  | CPatNotation (_,(_,"( _ )"),[NtnTypeArg (NtnTypeArgPattern (p,_bk))],[]) ->
     return (fun lev_after -> pr_patt ~flags (fun()->str"(") pr no_after lpattop p ++ str")") latom
 
-  | CPatNotation (which,s,(l,ll,bl),args) ->
+  | CPatNotation (which,s,l,args) ->
     let l_not = (find_notation_printing_rule which s).notation_printing_level in
     let no_inner_surrounding = List.is_empty args || Notation.prec_less l_not (LevelLt lapp) in
     return (fun lev_after ->
         let lev_after' = if no_inner_surrounding then lev_after else no_after in
-        let strm_not = pr_notation ~flags lev_after (pr_patt ~flags mt pr) (pr_patt_binder ~flags pr) (fun _ _ _ _ -> mt()) which s (l,ll,bl,[]) in
+        let strm_not = pr_notation ~flags lev_after pr (pr_patt_binder ~flags pr) (fun _ _ _ _ -> assert false) which s l in
         (if List.is_empty args then strm_not else
          if overlap_right_left which s lev_after then surround strm_not else
          if Notation.prec_less l_not (LevelLt lapp) then strm_not else
@@ -419,7 +431,7 @@ and pr_patt ~flags sep pr lev_after inh p =
     return (fun lev_after -> pr_delimiters depth k (pr_patt ~flags mt pr (Some 1) lsimplepatt p)) 1
 
   | CPatCast (p,t) ->
-    return (fun lev_after -> pr_patt ~flags mt pr (Some 1) lpatcast p ++ spc () ++ str ":" ++ ws 1 ++ pr t) 1
+    return (fun lev_after -> pr_patt ~flags mt pr (Some 1) lpatcast p ++ spc () ++ str ":" ++ ws 1 ++ pr lev_after (LevelLe lprod) t) 1
 
 and pr_patt_binder ~flags pr prec style bk c =
   match bk with
@@ -437,7 +449,7 @@ let pr_eqn ~flags pr {loc;v=(pl,rhs)} =
     (pr_with_comments ?loc
        (str "| " ++
         hov 0 (prlist_with_sep pr_spcbar
-                 (fun p -> hov 0 (prlist_with_sep sep_v (pr_patt ~flags (pr no_after ltop) no_after ltop) p)) pl
+                 (fun p -> hov 0 (prlist_with_sep sep_v (pr_patt ~flags pr no_after ltop) p)) pl
                ++ str " =>") ++
         pr_sep_com spc (pr no_after ltop) rhs))
 
@@ -490,11 +502,11 @@ let pr_binder many pr (nal,r,k,t) =
 
 let pr_binder_among_many ~flags withquote pr_c = function
   | CLocalAssum (nal,r,k,t) ->
-    pr_binder true pr_c (nal,r,k,t)
+    pr_binder true (pr_c no_after ltop) (nal,r,k,t)
   | CLocalDef (na,r,c,topt) ->
     surround (pr_lname na ++ pr_relevance_info r ++
-              pr_opt_no_spc (fun t -> str " :" ++ ws 1 ++ pr_c t) topt ++
-              str" :=" ++ spc() ++ pr_c c)
+              pr_opt_no_spc (fun t -> str " :" ++ ws 1 ++ pr_c no_after ltop t) topt ++
+              str" :=" ++ spc() ++ pr_c no_after ltop c)
   | CLocalPattern p ->
     str (if withquote then "'" else "") ++ pr_patt ~flags pr_c no_after lsimplepatt p
 
@@ -505,7 +517,7 @@ let pr_delimited_binders ~flags kw sep withquote pr_c bl =
   let n = begin_of_binders bl in
   match bl with
   | [CLocalAssum (nal,r,k,t)] ->
-    kw n ++ pr_binder false pr_c (nal,r,k,t)
+    kw n ++ pr_binder false (pr_c no_after ltop) (nal,r,k,t)
   | (CLocalAssum _ | CLocalPattern _ | CLocalDef _) :: _ as bdl ->
     kw n ++ pr_undelimited_binders ~flags sep withquote pr_c bdl
   | [] -> anomaly (Pp.str "The ast is malformed, found lambda/prod without proper binders.")
@@ -518,7 +530,7 @@ let pr_recursive_decl ~flags pr pr_dangling lev_after kw dangling_with_for id bl
   let pr_body =
     if dangling_with_for then pr_dangling else pr in
   hov 0 (str kw ++ brk(1,2) ++ pr_id id ++ (if bl = [] then mt () else brk(1,2)) ++
-         hov 0 (pr_undelimited_binders ~flags spc true (pr no_after ltop) bl ++ annot) ++
+         hov 0 (pr_undelimited_binders ~flags spc true pr bl ++ annot) ++
          pr_opt_type_spc pr t ++ str " :=") ++
   pr_sep_com (fun () -> brk(1,2)) (pr_body lev_after ltop) c
 
@@ -568,7 +580,7 @@ let pr_as_in ~flags pr na indnalopt =
    | Some t -> spc () ++ keyword "in" ++ spc () ++ pr_patt ~flags pr no_after ltop t)
 
 let pr_case_item ~flags pr (tm,as_clause, in_clause) =
-  hov 0 (pr no_after (LevelLe lcast) tm ++ pr_as_in ~flags (pr no_after ltop) as_clause in_clause)
+  hov 0 (pr no_after (LevelLe lcast) tm ++ pr_as_in ~flags pr as_clause in_clause)
 
 let pr_case_type pr po =
   match po with
@@ -682,14 +694,14 @@ let pr ~flags pr sep lev_after inherited a =
     return (fun lev_after ->
         hov 0 (
           hov 2 (pr_delimited_binders ~flags pr_forall spc true
-                   (pr mt no_after ltop) bl) ++
+                   (pr mt) bl) ++
           str "," ++ pr spc lev_after ltop a))
       lprod
   | CLambdaN (bl,a) ->
     return (fun lev_after ->
         hov 0 (
           hov 2 (pr_delimited_binders ~flags pr_fun spc true
-                   (pr mt no_after ltop) bl) ++
+                   (pr mt) bl) ++
           pr_fun_sep ++ pr spc lev_after ltop a))
       llambda
   | CLetIn ({v=Name x}, ({ v = CFix({v=x'},[_])}
@@ -733,8 +745,8 @@ let pr ~flags pr sep lev_after inherited a =
     return (fun lev_after ->
         hv 0 (
           keyword "let" ++ spc () ++ str"'" ++
-          hov 0 (pr_patt ~flags (pr mt no_after ltop) no_after ltop p ++
-                 pr_as_in ~flags (pr mt no_after ltop) as_clause in_clause ++
+          hov 0 (pr_patt ~flags (pr mt) no_after ltop p ++
+                 pr_as_in ~flags (pr mt) as_clause in_clause ++
                  str " :=" ++ pr spc no_after ltop c ++
                  pr_case_type (pr_dangling_with_for mt pr) rtntypopt ++
                  spc () ++ keyword "in" ++ pr spc lev_after ltop b)))
@@ -743,9 +755,9 @@ let pr ~flags pr sep lev_after inherited a =
     return (fun lev_after ->
         hv 0 (
           hov 1 (keyword "if" ++ spc () ++ pr mt no_after ltop c
-                 ++ pr_as_in ~flags (pr mt no_after ltop) as_clause in_clause
+                 ++ pr_as_in ~flags (pr mt) as_clause in_clause
                  ++ spc () ++ keyword "is" ++ spc ()
-                 ++ pr_patt ~flags (pr mt no_after ltop) no_after ltop p) ++
+                 ++ pr_patt ~flags (pr mt) no_after ltop p) ++
           spc () ++
           hov 0 (keyword "then"
                  ++ pr (fun () -> brk (1,1)) no_after ltop b1) ++ spc () ++
@@ -805,12 +817,12 @@ let pr ~flags pr sep lev_after inherited a =
         hv 0 (pr mt no_after (LevelLt lcast) a ++ spc () ++
               (pr_cast k) ++ ws 1 ++ pr mt lev_after (LevelLe lprod) b))
       lcast
-  | CNotation (_,(_,"( _ )"),([t],[],[],[])) ->
+  | CNotation (_,(_,"( _ )"),[NtnTypeArg (NtnTypeArgConstr t)]) ->
     return (fun lev_after -> pr (fun()->str"(") no_after ltop t ++ str")") latom
   | CNotation (which,s,env) ->
     let l_not = (find_notation_printing_rule which s).notation_printing_level in
     let l_not = if overlap_right_left which s lev_after then max_int else l_not in
-    return (fun lev_after -> pr_notation ~flags lev_after (pr mt) (pr_patt_binder ~flags (pr mt no_after ltop)) (pr_binders_gen ~flags (pr mt no_after ltop)) which s env) l_not
+    return (fun lev_after -> pr_notation ~flags lev_after (pr mt) (pr_patt_binder ~flags (pr mt)) (pr_binders_gen ~flags (pr mt)) which s env) l_not
   | CGeneralization (bk,c) ->
     return (fun lev_after -> pr_generalization bk (pr mt no_after ltop c)) latom
   | CPrim p ->
@@ -872,9 +884,9 @@ let pr_lconstr_expr ~flags env sigma c : Pp.t = !term_pr.pr_lconstr_expr ~flags 
 let pr_constr_pattern_expr ~flags env sigma c : Pp.t = !term_pr.pr_constr_pattern_expr ~flags env sigma c
 let pr_lconstr_pattern_expr ~flags env sigma c : Pp.t = !term_pr.pr_lconstr_pattern_expr ~flags env sigma c
 
-let pr_cases_pattern_expr ~flags c : Pp.t = pr_patt ~flags (pr ~flags no_after ltop) no_after ltop c
+let pr_cases_pattern_expr ~flags c : Pp.t = pr_patt ~flags (pr ~flags) no_after ltop c
 
-let pr_binders ~flags env sigma l : Pp.t = pr_undelimited_binders ~flags spc true (pr_expr ~flags env sigma no_after ltop) l
+let pr_binders ~flags env sigma l : Pp.t = pr_undelimited_binders ~flags spc true (pr_expr ~flags env sigma) l
 
 module CompactedDecl = struct
   type t =

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -408,7 +408,7 @@ and pr_patt ~flags sep pr lev_after inh p =
         let pp p = hov 0 (pr_patt ~flags mt pr lev_after lpattop p) in
         surround (hov 0 (prlist_with_sep pr_spcbar pp pl))) lpator
 
-  | CPatNotation (_,(_,"( _ )"),[NtnTypeArg (NtnTypeArgPattern (p,_bk))],[]) ->
+  | CPatNotation (_,{ntn_key = "( _ )"},[NtnTypeArg (NtnTypeArgPattern (p,_bk))],[]) ->
     return (fun lev_after -> pr_patt ~flags (fun()->str"(") pr no_after lpattop p ++ str")") latom
 
   | CPatNotation (which,s,l,args) ->
@@ -817,7 +817,7 @@ let pr ~flags pr sep lev_after inherited a =
         hv 0 (pr mt no_after (LevelLt lcast) a ++ spc () ++
               (pr_cast k) ++ ws 1 ++ pr mt lev_after (LevelLe lprod) b))
       lcast
-  | CNotation (_,(_,"( _ )"),[NtnTypeArg (NtnTypeArgConstr t)]) ->
+  | CNotation (_,{ntn_key = "( _ )"},[NtnTypeArg (NtnTypeArgConstr t)]) ->
     return (fun lev_after -> pr (fun()->str"(") no_after ltop t ++ str")") latom
   | CNotation (which,s,env) ->
     let l_not = (find_notation_printing_rule which s).notation_printing_level in

--- a/vernac/egramrocq.ml
+++ b/vernac/egramrocq.ml
@@ -411,78 +411,82 @@ let cases_pattern_expr_of_name { CAst.loc; v = na } = CAst.make ?loc @@ match na
   | Anonymous -> CPatAtom None
   | Name id   -> CPatAtom (Some (qualid_of_ident ?loc id))
 
-type 'r env = {
-  constrs : 'r list;
-  constrlists : 'r list list;
-  binders : kinded_cases_pattern_expr list;
-  binderlists : local_binder_expr list list;
-}
+let push a subst = NtnTypeArg a :: subst
 
-let push_constr subst v = { subst with constrs = v :: subst.constrs }
+type env = (constr_expr, kinded_cases_pattern_expr, local_binder_expr list) notation_arg_type list
 
-let push_item : type s r. s target -> (s, r) entry -> s env -> r -> s env = fun forpat e subst v ->
+let push_item : type s r. s target -> (s, r) entry -> env -> r -> env = fun forpat e subst v ->
+let open Glob_term in
 match e with
-| TTConstr _ -> push_constr subst v
-| TTIdent -> { subst with binders = (cases_pattern_expr_of_id v, Glob_term.Explicit) :: subst.binders }
-| TTName -> { subst with binders = (cases_pattern_expr_of_name v, Glob_term.Explicit) :: subst.binders }
-| TTPattern _ -> { subst with binders = (v, Glob_term.Explicit) :: subst.binders }
-| TTBinder o -> { subst with binders = v :: subst.binders }
-| TTOpenBinderList -> { subst with binderlists = v :: subst.binderlists }
-| TTClosedBinderListPure _ -> { subst with binderlists = List.flatten v :: subst.binderlists }
-| TTClosedBinderListOther (TTIdent, _) -> { subst with binderlists = List.map (fun a -> CLocalPattern (cases_pattern_expr_of_id a)) v :: subst.binderlists }
-| TTClosedBinderListOther (TTName, _) -> { subst with binderlists = List.map (fun a -> CLocalPattern (cases_pattern_expr_of_name a)) v :: subst.binderlists }
-| TTClosedBinderListOther (TTPattern _, _) -> { subst with binderlists = List.map (fun a -> CLocalPattern a) v :: subst.binderlists }
+| TTConstr _ ->
+  begin match forpat with
+  | ForConstr -> push (NtnTypeArgConstr v) subst
+  | ForPattern -> push (NtnTypeArgPattern (v, Explicit)) subst
+  end
+| TTIdent -> push (NtnTypeArgPattern (cases_pattern_expr_of_id v, Glob_term.Explicit)) subst
+| TTName -> push (NtnTypeArgPattern (cases_pattern_expr_of_name v, Glob_term.Explicit)) subst
+| TTPattern _ -> push (NtnTypeArgPattern (v, Glob_term.Explicit)) subst
+| TTBinder o -> push (NtnTypeArgPattern v) subst
+| TTOpenBinderList -> push (NtnTypeArgBinders v) subst
+| TTClosedBinderListPure _ -> push (NtnTypeArgBinders (List.flatten v)) subst
+| TTClosedBinderListOther (TTIdent, _) -> push (NtnTypeArgBinders (List.map (fun a -> CLocalPattern (cases_pattern_expr_of_id a)) v)) subst
+| TTClosedBinderListOther (TTName, _) -> push (NtnTypeArgBinders (List.map (fun a -> CLocalPattern (cases_pattern_expr_of_name a)) v)) subst
+| TTClosedBinderListOther (TTPattern _, _) -> push (NtnTypeArgBinders (List.map (fun a -> CLocalPattern a) v)) subst
 | TTClosedBinderListOther _ -> user_err (Pp.str "Invalid binder list entry.")
 | TTBigint ->
   begin match forpat with
-  | ForConstr ->  push_constr subst (CAst.make @@ CPrim (Number (NumTok.Signed.of_int_string v)))
-  | ForPattern -> push_constr subst (CAst.make @@ CPatPrim (Number (NumTok.Signed.of_int_string v)))
+  | ForConstr -> push (NtnTypeArgConstr (CAst.make @@ CPrim (Number (NumTok.Signed.of_int_string v)))) subst
+  | ForPattern -> push (NtnTypeArgPattern (CAst.make @@ CPatPrim (Number (NumTok.Signed.of_int_string v)), Explicit)) subst
   end
 | TTGlobal ->
   begin match forpat with
-  | ForConstr  -> push_constr subst (CAst.make @@ CRef (v, None))
-  | ForPattern -> push_constr subst (CAst.make @@ CPatAtom (Some v))
+  | ForConstr  -> push (NtnTypeArgConstr (CAst.make @@ CRef (v, None))) subst
+  | ForPattern -> push (NtnTypeArgPattern (CAst.make @@ CPatAtom (Some v), Explicit)) subst
   end
-| TTConstrList _ -> { subst with constrlists = v :: subst.constrlists }
+| TTConstrList _ ->
+  begin match forpat with
+  | ForConstr -> NtnTypeArgList (List.map (fun x -> NtnTypeArg (NtnTypeArgConstr x)) v) :: subst
+  | ForPattern -> NtnTypeArgList (List.map (fun x -> NtnTypeArg (NtnTypeArgPattern (x, Explicit))) v) :: subst
+  end
 
 type (_, _) ty_symbol =
 | TyTerm : 'a Tok.p -> ('s, 'a) ty_symbol
-| TyNonTerm : 's target * ('s, 'a) entry * ('s, 'a) mayrec_symbol * bool -> ('s, 'a) ty_symbol
+| TyNonTerm : 's target * ('s, 'a) entry * ('s, 'a) mayrec_symbol * Id.t option -> ('s, 'a) ty_symbol
 
 type ('self, _, 'r) ty_rule =
 | TyStop : ('self, 'r, 'r) ty_rule
 | TyNext : ('self, 'a, 'r) ty_rule * ('self, 'b) ty_symbol -> ('self, 'b -> 'a, 'r) ty_rule
 | TyMark : int * bool * int * ('self, 'a, 'r) ty_rule -> ('self, 'a, 'r) ty_rule
 
-type 'r gen_eval = Loc.t -> 'r env -> 'r
+type 'r gen_eval = Loc.t -> env -> 'r
 
-let rec ty_eval : type s a. (s, a, Loc.t -> s) ty_rule -> s gen_eval -> s env -> a = function
+let rec ty_eval : type s a. (s, a, Loc.t -> s) ty_rule -> s gen_eval -> env -> a = function
 | TyStop ->
   fun f env loc -> f loc env
 | TyNext (rem, TyTerm _) ->
   fun f env _ -> ty_eval rem f env
-| TyNext (rem, TyNonTerm (_, _, _, false)) ->
+| TyNext (rem, TyNonTerm (_, _, _, None)) ->
   fun f env _ -> ty_eval rem f env
-| TyNext (rem, TyNonTerm (forpat, e, _, true)) ->
+| TyNext (rem, TyNonTerm (forpat, e, _, Some id)) ->
   fun f env v ->
     ty_eval rem f (push_item forpat e env v)
 | TyMark (n, b, p, rem) ->
   fun f env ->
-    let heads, constrs = List.chop n env.constrs in
-    let constrlists, constrs =
+    let heads, env = List.chop n env in
+    let env =
       if b then
          (* We rearrange constrs = c1..cn rem and constrlists = [d1..dr e1..ep] rem' into
             constrs = e1..ep rem and constrlists [c1..cn d1..dr] rem' *)
-         let constrlist = List.hd env.constrlists in
+         let constrlist = match List.hd env with NtnTypeArgList l -> l | _ -> anomaly (Pp.str "TyMark: List expected") in
          let constrlist, tail = List.chop (List.length constrlist - p) constrlist in
-         (heads @ constrlist) :: List.tl env.constrlists, tail @ constrs
+         NtnTypeArgList (heads @ constrlist) :: tail @ List.tl env
       else
          (* We rearrange constrs = c1..cn e1..ep rem into
             constrs = e1..ep rem and add a constr list [c1..cn] *)
         let constrlist, tail = List.chop (n - p) heads in
-        constrlist :: env.constrlists, tail @ constrs
+        NtnTypeArgList constrlist :: tail @ env
     in
-    ty_eval rem f { env with constrs; constrlists; }
+    ty_eval rem f env
 
 type ('s, 'a, 'r) mayrec_rule =
 | MayRecRNo : ('s, Gramlib.Grammar.norec, 'a, 'r) Rule.t -> ('s, 'a, 'r) mayrec_rule
@@ -516,8 +520,7 @@ let make_ty_rule assoc from forpat prods =
     let AnyTyRule r = make_ty_rule rem in
     let TTAny e = interp_entry forpat e in
     let s = symbol_of_entry assoc from e in
-    let bind = match var with None -> false | Some _ -> true in
-    AnyTyRule (TyNext (r, TyNonTerm (forpat, e, s, bind)))
+    AnyTyRule (TyNext (r, TyNonTerm (forpat, e, s, var)))
   | GramConstrListMark (n, b, p) :: rem ->
     let AnyTyRule r = make_ty_rule rem in
     AnyTyRule (TyMark (n, b, p, r))
@@ -564,10 +567,8 @@ let rec pure_sublevels' assoc from forpat level = function
 
 let make_act : type r. r target -> _ -> r gen_eval = function
 | ForConstr -> fun notation loc env ->
-  let env = (env.constrs, env.constrlists, env.binders, env.binderlists) in
   CAst.make ~loc @@ CNotation (None, notation, env)
 | ForPattern -> fun notation loc env ->
-  let env = (env.constrs, env.constrlists, env.binders) in
   CAst.make ~loc @@ CPatNotation (None, notation, env, [])
 
 let extend_constr state forpat ng =
@@ -581,8 +582,7 @@ let extend_constr state forpat ng =
     let needed_levels, state = register_empty_levels state isforpat pure_sublevels in
     let (pos,p4assoc,name), state = find_position state custom isforpat assoc level in
     let empty_rules = List.map (prepare_empty_levels forpat) needed_levels in
-    let empty = { constrs = []; constrlists = []; binders = []; binderlists = [] } in
-    let act = ty_eval r (make_act forpat ng.notgram_notation) empty in
+    let act = ty_eval r (make_act forpat ng.notgram_notation) [] in
     let rule =
       let r = match ty_erase r with
         | MayRecRNo symbs -> Procq.Production.make symbs act

--- a/vernac/egramrocq.ml
+++ b/vernac/egramrocq.ml
@@ -603,7 +603,7 @@ let extend_constr state forpat ng =
 let constr_levels = GramState.field "constr_levels"
 
 let is_disjunctive_pattern_rule ng =
-  String.is_sub "( _ | " (snd ng.notgram_notation) 0
+  String.is_sub "( _ | " ng.notgram_notation.ntn_key 0
 
 let warn_disj_pattern_notation =
   let open Pp in

--- a/vernac/egramrocq.ml
+++ b/vernac/egramrocq.ml
@@ -603,7 +603,7 @@ let extend_constr (type r) state (forpat:r target) ng =
 let constr_levels = GramState.field "constr_levels"
 
 let is_disjunctive_pattern_rule ng =
-  String.is_sub "( _ | " (snd ng.notgram_notation) 0
+  String.is_sub "( _ | " ng.notgram_notation.ntn_key 0
 
 let warn_disj_pattern_notation =
   let open Pp in

--- a/vernac/egramrocq.ml
+++ b/vernac/egramrocq.ml
@@ -412,39 +412,43 @@ let cases_pattern_expr_of_name { CAst.loc; v = na } = CAst.make ?loc @@ match na
   | Anonymous -> CPatAtom None
   | Name id   -> CPatAtom (Some (qualid_of_ident ?loc id))
 
-type 'r env = {
-  constrs : 'r list;
-  constrlists : 'r list list;
-  binders : kinded_cases_pattern_expr list;
-  binderlists : local_binder_expr list list;
-}
+let push a subst = NtnTypeArg a :: subst
 
-let push_constr subst v = { subst with constrs = v :: subst.constrs }
+type env = (constr_expr, kinded_cases_pattern_expr, local_binder_expr list) notation_arg_type list
 
-let push_item : type s r. s target -> (s, r) entry -> s env -> r -> s env = fun forpat e subst v ->
+let push_item : type s r. s target -> (s, r) entry -> env -> r -> env = fun forpat e subst v ->
+let open Glob_term in
 match e with
-| TTConstr _ -> push_constr subst v
-| TTIdent -> { subst with binders = (cases_pattern_expr_of_id v, Glob_term.Explicit) :: subst.binders }
-| TTName -> { subst with binders = (cases_pattern_expr_of_name v, Glob_term.Explicit) :: subst.binders }
-| TTPattern _ -> { subst with binders = (v, Glob_term.Explicit) :: subst.binders }
-| TTBinder o -> { subst with binders = v :: subst.binders }
-| TTOpenBinderList -> { subst with binderlists = v :: subst.binderlists }
-| TTClosedBinderListPure _ -> { subst with binderlists = List.flatten v :: subst.binderlists }
-| TTClosedBinderListOther (TTIdent, _) -> { subst with binderlists = List.map (fun a -> CLocalPattern (cases_pattern_expr_of_id a)) v :: subst.binderlists }
-| TTClosedBinderListOther (TTName, _) -> { subst with binderlists = List.map (fun a -> CLocalPattern (cases_pattern_expr_of_name a)) v :: subst.binderlists }
-| TTClosedBinderListOther (TTPattern _, _) -> { subst with binderlists = List.map (fun a -> CLocalPattern a) v :: subst.binderlists }
+| TTConstr _ ->
+  begin match forpat with
+  | ForConstr -> push (NtnTypeArgConstr v) subst
+  | ForPattern -> push (NtnTypeArgPattern (v, Explicit)) subst
+  end
+| TTIdent -> push (NtnTypeArgPattern (cases_pattern_expr_of_id v, Glob_term.Explicit)) subst
+| TTName -> push (NtnTypeArgPattern (cases_pattern_expr_of_name v, Glob_term.Explicit)) subst
+| TTPattern _ -> push (NtnTypeArgPattern (v, Glob_term.Explicit)) subst
+| TTBinder o -> push (NtnTypeArgPattern v) subst
+| TTOpenBinderList -> push (NtnTypeArgBinders v) subst
+| TTClosedBinderListPure _ -> push (NtnTypeArgBinders (List.flatten v)) subst
+| TTClosedBinderListOther (TTIdent, _) -> push (NtnTypeArgBinders (List.map (fun a -> CLocalPattern (cases_pattern_expr_of_id a)) v)) subst
+| TTClosedBinderListOther (TTName, _) -> push (NtnTypeArgBinders (List.map (fun a -> CLocalPattern (cases_pattern_expr_of_name a)) v)) subst
+| TTClosedBinderListOther (TTPattern _, _) -> push (NtnTypeArgBinders (List.map (fun a -> CLocalPattern a) v)) subst
 | TTClosedBinderListOther _ -> user_err (Pp.str "Invalid binder list entry.")
 | TTBigint ->
   begin match forpat with
-  | ForConstr ->  push_constr subst (CAst.make @@ CPrim (Number (NumTok.Signed.of_int_string v)))
-  | ForPattern -> push_constr subst (CAst.make @@ CPatPrim (Number (NumTok.Signed.of_int_string v)))
+  | ForConstr -> push (NtnTypeArgConstr (CAst.make @@ CPrim (Number (NumTok.Signed.of_int_string v)))) subst
+  | ForPattern -> push (NtnTypeArgPattern (CAst.make @@ CPatPrim (Number (NumTok.Signed.of_int_string v)), Explicit)) subst
   end
 | TTGlobal ->
   begin match forpat with
-  | ForConstr  -> push_constr subst (CAst.make @@ CRef (v, None))
-  | ForPattern -> push_constr subst (CAst.make @@ CPatAtom (Some v))
+  | ForConstr  -> push (NtnTypeArgConstr (CAst.make @@ CRef (v, None))) subst
+  | ForPattern -> push (NtnTypeArgPattern (CAst.make @@ CPatAtom (Some v), Explicit)) subst
   end
-| TTConstrList _ -> { subst with constrlists = v :: subst.constrlists }
+| TTConstrList _ ->
+  begin match forpat with
+  | ForConstr -> NtnTypeArgList (List.map (fun x -> NtnTypeArg (NtnTypeArgConstr x)) v) :: subst
+  | ForPattern -> NtnTypeArgList (List.map (fun x -> NtnTypeArg (NtnTypeArgPattern (x, Explicit))) v) :: subst
+  end
 
 type (_, _) ty_symbol =
 | TyTerm : 'a Tok.p -> ('s, 'a) ty_symbol
@@ -455,9 +459,9 @@ type ('self, _, 'r) ty_rule =
 | TyNext : ('self, 'a, 'r) ty_rule * ('self, 'b) ty_symbol -> ('self, 'b -> 'a, 'r) ty_rule
 | TyMark : int * bool * int * ('self, 'a, 'r) ty_rule -> ('self, 'a, 'r) ty_rule
 
-type 'r gen_eval = Loc.t -> 'r env -> 'r
+type 'r gen_eval = Loc.t -> env -> 'r
 
-let rec ty_eval : type s a. (s, a, Loc.t -> s) ty_rule -> s gen_eval -> s env -> a = function
+let rec ty_eval : type s a. (s, a, Loc.t -> s) ty_rule -> s gen_eval -> env -> a = function
 | TyStop ->
   fun f env loc -> f loc env
 | TyNext (rem, TyTerm _) ->
@@ -467,21 +471,21 @@ let rec ty_eval : type s a. (s, a, Loc.t -> s) ty_rule -> s gen_eval -> s env ->
     ty_eval rem f (push_item forpat e env v)
 | TyMark (n, b, p, rem) ->
   fun f env ->
-    let heads, constrs = List.chop n env.constrs in
-    let constrlists, constrs =
+    let heads, env = List.chop n env in
+    let env =
       if b then
          (* We rearrange constrs = c1..cn rem and constrlists = [d1..dr e1..ep] rem' into
             constrs = e1..ep rem and constrlists [c1..cn d1..dr] rem' *)
-         let constrlist = List.hd env.constrlists in
+         let constrlist = match List.hd env with NtnTypeArgList l -> l | _ -> anomaly (Pp.str "TyMark: List expected") in
          let constrlist, tail = List.chop (List.length constrlist - p) constrlist in
-         (heads @ constrlist) :: List.tl env.constrlists, tail @ constrs
+         NtnTypeArgList (heads @ constrlist) :: tail @ List.tl env
       else
          (* We rearrange constrs = c1..cn e1..ep rem into
             constrs = e1..ep rem and add a constr list [c1..cn] *)
         let constrlist, tail = List.chop (n - p) heads in
-        constrlist :: env.constrlists, tail @ constrs
+        NtnTypeArgList constrlist :: tail @ env
     in
-    ty_eval rem f { env with constrs; constrlists; }
+    ty_eval rem f env
 
 type ('s, 'a, 'r) mayrec_rule =
 | MayRecR : ('s, _, 'a, 'r) Rule.t -> ('s, 'a, 'r) mayrec_rule
@@ -556,10 +560,8 @@ let rec pure_sublevels' assoc from forpat level = function
 
 let make_act : type r. r target -> _ -> r gen_eval = function
 | ForConstr -> fun notation loc env ->
-  let env = (env.constrs, env.constrlists, env.binders, env.binderlists) in
   CAst.make ~loc @@ CNotation (None, notation, env)
 | ForPattern -> fun notation loc env ->
-  let env = (env.constrs, env.constrlists, env.binders) in
   CAst.make ~loc @@ CPatNotation (None, notation, env, [])
 
 let extend_constr (type r) state (forpat:r target) ng =
@@ -580,8 +582,7 @@ let extend_constr (type r) state (forpat:r target) ng =
     let needed_levels, state = register_empty_levels state isforpat pure_sublevels in
     let (pos,p4assoc,name), state = find_position state custom isforpat assoc (Some level) in
     let empty_rules = List.map (prepare_empty_levels forpat) needed_levels in
-    let empty = { constrs = []; constrlists = []; binders = []; binderlists = [] } in
-    let act = ty_eval r (make_act forpat ng.notgram_notation) empty in
+    let act = ty_eval r (make_act forpat ng.notgram_notation) [] in
     let rule =
       let r =
         let MayRecR symbs = ty_erase r in

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -924,7 +924,7 @@ let check_prefix_incompatible_level ntn prec nottyps =
        let pref_nottyps = Notgram_ops.non_terminals_of_notation pref in
        let pref_nottyps = CList.firstn k pref_nottyps in
        let nottyps = CList.firstn k nottyps in
-       if not (level_eq prec pref_prec && List.for_all2 Extend.constr_entry_key_eq_ignore_binder_kind nottyps pref_nottyps) then
+       if not (level_eq prec pref_prec && List.for_all2 Extend.constr_entry_key_visible_eq nottyps pref_nottyps) then
          warn_prefix_incompatible_level (pref, ntn, pref_prec, pref_nottyps, prec, nottyps);
      with Not_found | Failure _ -> ()
 
@@ -940,7 +940,7 @@ let cache_one_syntax_extension (ntn,synext) =
         with Not_found -> None
       in
       let oldtyps = Notgram_ops.non_terminals_of_notation ntn in
-      if not (level_eq prec oldprec && List.for_all2 Extend.constr_entry_key_eq synext.synext_nottyps oldtyps) &&
+      if not (level_eq prec oldprec && List.for_all2 Extend.constr_entry_key_visible_eq synext.synext_nottyps oldtyps) &&
          (oldparsing <> None || synext.synext_notgram = None) then
         error_incompatible_level ntn oldprec oldtyps prec synext.synext_nottyps;
       oldparsing

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -254,12 +254,21 @@ let quote_notation_token x =
   if (n > 0 && norm) || (n > 2 && x.[0] == '\'') then "'"^x^"'"
   else x
 
+let rec notation_variables : type s. (s -> Id.t list) -> s notation_raw_type -> Id.t list =
+  fun f -> function
+  | NtnRawTypeVar x -> f x
+  | NtnRawTypeVarList typ -> notation_variables (fun (x,y) -> f x @ f y) typ
+  | NtnRawTypeVarTuple typs -> List.map_append (notation_variables f) typs
+
+let all_notation_variables =
+  List.map_append (notation_variables (fun x -> [x]))
+
 let analyze_notation_tokens ~onlyprinting ~infix entry df =
   let df = if infix then quote_notation_token df else df in
-  let { recvars; mainvars; symbols } as res = decompose_raw_notation df in
+  let { maintypes; symbols } as res = decompose_raw_notation df in
     (* don't check for nonlinearity if printing only, see Bug 5526 *)
   (if not onlyprinting then
-    match List.duplicates Id.equal (mainvars @ List.map snd recvars) with
+    match List.duplicates Id.equal (all_notation_variables maintypes) with
     | id :: _ ->
         user_err
           (str "Variable " ++ Id.print id ++ str " occurs more than once.")
@@ -271,7 +280,8 @@ let adjust_symbols vars notation_symbols =
   let x = Namegen.next_ident_away (Id.of_string "x") vars in
   let y = Namegen.next_ident_away (Id.of_string "y") (Id.Set.add x vars) in
   let notation_symbols = {
-      recvars = notation_symbols.recvars; mainvars = x::notation_symbols.mainvars@[y];
+      mainvars = x :: notation_symbols.mainvars @ [y];
+      maintypes = NtnRawTypeVar x :: notation_symbols.maintypes @ [NtnRawTypeVar y];
       symbols = NonTerminal x :: notation_symbols.symbols @ [NonTerminal y];
     } in
   x, y, notation_symbols
@@ -847,7 +857,7 @@ let warn_incompatible_format =
 
 type syntax_extension = {
   synext_level : level;
-  synext_nottyps : constr_entry_key list;
+  synext_nottyps : Notgram_ops.entry_types;
   synext_notgram : notation_grammar option;
   synext_notprint : generic_notation_printing_rules option;
 }
@@ -940,9 +950,10 @@ let cache_one_syntax_extension (ntn,synext) =
         with Not_found -> None
       in
       let oldtyps = Notgram_ops.non_terminals_of_notation ntn in
-      if not (level_eq prec oldprec && List.for_all2 Extend.constr_entry_key_visible_eq synext.synext_nottyps oldtyps) &&
+      let nottyps = synext.synext_nottyps in
+      if not (level_eq prec oldprec && List.for_all2 Extend.constr_entry_key_visible_eq nottyps oldtyps) &&
          (oldparsing <> None || synext.synext_notgram = None) then
-        error_incompatible_level ntn oldprec oldtyps prec synext.synext_nottyps;
+        error_incompatible_level ntn oldprec oldtyps prec nottyps;
       oldparsing
     with Not_found ->
       check_prefix_incompatible_level ntn prec synext.synext_nottyps;
@@ -1066,8 +1077,8 @@ let interp_modifiers entry modl = let open NotationMods in
   in
   interp default modl
 
-let check_useless_entry_types recvars mainvars etyps =
-  let vars = let (l1,l2) = List.split recvars in l1@l2@mainvars in
+let check_useless_entry_types mainvars etyps =
+  let vars = all_notation_variables mainvars in
   match List.filter (fun (x,etyp) -> not (List.mem x vars)) etyps with
   | (x,_)::_ -> user_err
                   (Id.print x ++ str " is unbound in the notation.")
@@ -1174,56 +1185,75 @@ let set_entry_type from n etyps (x,typ) =
       ETConstr (from,None,(make_lev n from,typ))
   in (x,typ)
 
-let join_auxiliary_recursive_types recvars etyps =
-  List.fold_right (fun (x,y) typs ->
-    let xtyp = try Some (List.assoc x etyps) with Not_found -> None in
-    let ytyp = try Some (List.assoc y etyps) with Not_found -> None in
-    match xtyp,ytyp with
-    | None, None -> typs
-    | Some _, None -> typs
-    | None, Some ytyp -> (x,ytyp)::typs
-    | Some xtyp, Some ytyp when (=) xtyp ytyp -> typs (* FIXME *)
-    | Some xtyp, Some ytyp ->
-        user_err
-          (strbrk "In " ++ Id.print x ++ str " .. " ++ Id.print y ++
-           strbrk ", both ends have incompatible types."))
-    recvars etyps
-
 let internalization_type_of_entry_type = function
   | ETBinder _ | ETConstr (_,Some _,_) -> NtnInternTypeOnlyBinder
   | ETConstr (_,None,_) | ETBigint | ETGlobal
   | ETIdent | ETName | ETPattern _ -> NtnInternTypeAny None
 
-let make_internalization_vars recvars maintyps =
-  let maintyps = List.map (on_snd internalization_type_of_entry_type) maintyps in
-  let extratyps = List.map (fun (x,y) -> (y,List.assoc x maintyps)) recvars in
-  maintyps @ extratyps
+let default_interp_type = NtnInternTypeAny None
 
-let make_interpretation_type isrec isbinding default_if_binding typ =
-  match typ, isrec with
-  (* Parsed as constr, but interpreted as a specific kind of binder *)
-  | ETConstr (_,Some bk,_), true -> NtnTypeBinderList (NtnBinderParsedAsConstr bk)
-  | ETConstr (_,Some bk,_), false -> NtnTypeBinder (NtnBinderParsedAsConstr bk)
-  (* Parsed as constr list but interpreted as the default kind of binder *)
-  | ETConstr (_,None,_), true when isbinding -> NtnTypeBinderList (NtnBinderParsedAsConstr default_if_binding)
-  | ETConstr (_,None,_), false when isbinding -> NtnTypeBinder (NtnBinderParsedAsConstr default_if_binding)
+let join_variable_types etyps vars =
+  let typs = List.map (fun x -> (x, try Some (List.assoc x etyps) with Not_found -> None)) vars in
+  let check_and_remove x typ typs etyps =
+    List.fold_left (fun etyps (x',typ') ->
+        match typ' with
+        | None -> etyps
+        | Some typ' ->
+          if not (simple_constr_entry_key_eq typ typ') then
+            user_err
+              (strbrk "In " ++ Id.print x ++ str " .. " ++ Id.print x' ++
+               strbrk ", both ends have incompatible types.");
+          List.remove_assoc x' etyps)
+      etyps typs in
+  match typs with
+  | [] -> etyps
+  | (x, Some typ) :: typs -> (* First name is the key: it already has a type *)
+    check_and_remove x typ typs etyps
+  | (x, None) :: typs ->
+    let rec aux = function
+      | [] -> etyps
+      | (_, None) :: typs -> aux typs
+      | (x', Some typ) :: typs ->
+        (x,typ) :: check_and_remove x' typ typs (List.remove_assoc x' etyps)
+    in aux typs
+
+let join_types maintypes etyps =
+  let allvars = List.map (notation_variables (fun x -> [x])) maintypes in
+  List.fold_left join_variable_types etyps allvars
+
+let make_interp_atom_type_rec used_as_binder default_if_binding scl = function
+  (* Parsed as constr, but intended to denote a specific kind of binder, independently of the interpretation *)
+  | ETConstr (_,Some bk,_) -> NtnTypeVar (scl, NtnTypeVarBinders (NtnBinderParsedAsConstr bk))
+  (* Parsed as constr list but known to be used as binder (and maybe also as constr) in the interpretation *)
+  | ETConstr (_,None,_) when used_as_binder -> NtnTypeVar (scl, NtnTypeVarBinders (NtnBinderParsedAsConstr default_if_binding))
   (* Parsed as constr, interpreted as constr *)
-  | ETConstr (_,None,_), true -> NtnTypeConstrList
-  | ETConstr (_,None,_), false -> NtnTypeConstr
+  | ETConstr (_,None,_) -> NtnTypeVarList (NtnTypeVar (scl, NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern))
   (* Different way of parsing binders, maybe interpreted also as
      constr, but conventionally internally binders *)
-  | ETIdent, true -> NtnTypeBinderList (NtnBinderParsedAsSomeBinderKind AsIdent)
-  | ETIdent, false -> NtnTypeBinder (NtnBinderParsedAsSomeBinderKind AsIdent)
-  | ETName, true -> NtnTypeBinderList (NtnBinderParsedAsSomeBinderKind AsName)
-  | ETName, false -> NtnTypeBinder (NtnBinderParsedAsSomeBinderKind AsName)
+  | ETIdent -> NtnTypeVar (scl, NtnTypeVarBinders (NtnBinderParsedAsSomeBinderKind AsIdent))
+  | ETName -> NtnTypeVar (scl, NtnTypeVarBinders (NtnBinderParsedAsSomeBinderKind AsName))
   (* Parsed as ident/pattern, primarily interpreted as binder; maybe strict at printing *)
-  | ETPattern (ppstrict,_), true -> NtnTypeBinderList (NtnBinderParsedAsSomeBinderKind (if ppstrict then AsStrictPattern else AsAnyPattern))
-  | ETPattern (ppstrict,_), false -> NtnTypeBinder (NtnBinderParsedAsSomeBinderKind (if ppstrict then AsStrictPattern else AsAnyPattern))
-  | ETBinder _, true -> NtnTypeBinderList NtnBinderParsedAsBinder
-  | ETBinder _, false -> NtnTypeBinder NtnBinderParsedAsBinder
+  | ETPattern (ppstrict,_) -> NtnTypeVar (scl, NtnTypeVarBinders (NtnBinderParsedAsSomeBinderKind (if ppstrict then AsStrictPattern else AsAnyPattern)))
+  | ETBinder _ -> NtnTypeVar (scl, NtnTypeVarBinders NtnBinderParsedAsBinder)
   (* Others *)
-  | ETBigint, true | ETGlobal, true -> NtnTypeConstrList
-  | ETBigint, false | ETGlobal, false -> NtnTypeConstr
+  | ETBigint | ETGlobal -> NtnTypeVarList (NtnTypeVar (scl, NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern))
+
+let make_interp_atom_type used_as_binder default_if_binding scl = function
+  (* Parsed as constr, but intended to denote a specific kind of binder, independently of the interpretation *)
+  | ETConstr (_,Some bk,_) -> NtnTypeVar (scl, NtnTypeVarPattern (NtnBinderParsedAsConstr bk))
+  (* Parsed as constr list but known to be used as binder (and maybe also as constr) in the interpretation *)
+  | ETConstr (_,None,_) when used_as_binder -> NtnTypeVar (scl, NtnTypeVarPattern (NtnBinderParsedAsConstr default_if_binding))
+  (* Parsed as constr, interpreted as constr *)
+  | ETConstr (_,None,_) -> NtnTypeVar (scl, NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern)
+  (* Different way of parsing binders, maybe interpreted also as
+     constr, but conventionally internally binders *)
+  | ETIdent -> NtnTypeVar (scl, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind AsIdent))
+  | ETName -> NtnTypeVar (scl, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind AsName))
+  (* Parsed as ident/pattern, primarily interpreted as binder; maybe strict at printing *)
+  | ETPattern (ppstrict,_) -> NtnTypeVar (scl, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind (if ppstrict then AsStrictPattern else AsAnyPattern)))
+  | ETBinder _ -> NtnTypeVar (scl, NtnTypeVarPattern NtnBinderParsedAsBinder)
+  (* Others *)
+  | ETBigint | ETGlobal -> NtnTypeVar (scl, NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern)
 
 let entry_relative_level_of_constr_prod_entry from_level = function
   | ETConstr (entry,_,(_,y)) as x ->
@@ -1231,30 +1261,56 @@ let entry_relative_level_of_constr_prod_entry from_level = function
      { notation_subentry = entry; notation_relative_level = precedence_of_entry_type from_level x; notation_position = side }
   | _ -> constr_some_level
 
+let rec make_internalization_var : type s. (s -> Id.t list) -> _ -> _ -> s notation_raw_type -> _ =
+  fun f etyps typs typ -> match typ with
+  | NtnRawTypeVar x ->
+    (match f x with
+    | [] -> assert false
+    | mainname :: _ as allnames ->
+    let t = try internalization_type_of_entry_type (Id.List.assoc mainname etyps) with Not_found -> default_interp_type in
+    List.fold_left (fun typs x -> Id.Map.add x t typs) typs allnames)
+  | NtnRawTypeVarList typ -> make_internalization_var (fun (x,y) -> f x @ f y) etyps typs typ
+  | NtnRawTypeVarTuple typl -> List.fold_left (make_internalization_var f etyps) typs typl
+
+let make_internalization_vars maintyps etyps =
+  List.fold_left (make_internalization_var (fun x -> [x]) etyps) Id.Map.empty maintyps
+
 let make_interpretation_vars
   (* For binders, default is to parse only as an ident *) ?(default_if_binding=AsName)
-   recvars allvars (entry,_) typs =
-  let eq_subscope (sc1, l1) (sc2, l2) =
-    List.equal String.equal sc1 sc2 &&
-    List.equal String.equal l1 l2
+    maintypes (entry,_) i_varscopes sy_typs =
+  let rec aux = function
+    | NtnRawTypeVar x ->
+      let (used_as_binder, xscope, ntn_binding_ids) = Id.Map.find x i_varscopes in
+      let sy_typ = Id.List.assoc x sy_typs in
+      let entry = entry_relative_level_of_constr_prod_entry entry sy_typ in
+      make_interp_atom_type used_as_binder default_if_binding ((entry, xscope), ntn_binding_ids) sy_typ
+    | NtnRawTypeVarTuple typl -> NtnTypeVarTuple (List.map aux typl)
+    | NtnRawTypeVarList (NtnRawTypeVar (x,y)) ->
+      (* Maybe binders *)
+      let (used_as_binder_x, xscope, _ntn_binding_ids1) = Id.Map.find x i_varscopes in
+      let (used_as_binder_y, yscope, ntn_binding_ids2) = Id.Map.find y i_varscopes in
+      let () =
+        if used_as_binder_x <> used_as_binder_y then
+          user_err Pp.(str "The two ends " ++ Id.print x ++ str " and " ++ Id.print y ++
+                        strbrk " of a recursive notation are not both used consistently in binding position.") in
+      let () =
+        if not (eq_pair (List.equal String.equal) (List.equal String.equal) xscope yscope) then
+          user_err Pp.(str "The two ends " ++ Id.print x ++ str " and " ++ Id.print y ++
+                        strbrk " of a recursive notation are not both used consistently in the same scope.") in
+      let eq_subscope (sc1, l1) (sc2, l2) =
+        List.equal String.equal sc1 sc2 &&
+        List.equal String.equal l1 l2 in
+      if not (eq_subscope xscope yscope) then error_not_same_scope x y;
+      (* Note: binding_ids should currently be the same, and even with
+         eventually more complex notations, such as e.g.
+          Notation "!! x .. y , P .. Q" := (fun x => (P, .. (fun y => (Q, True)) ..)).
+         each occurrence of the recursive notation variables may have its own binders *)
+      let sy_typ = Id.List.assoc x sy_typs in
+      let entry = entry_relative_level_of_constr_prod_entry entry sy_typ in
+      make_interp_atom_type_rec used_as_binder_y default_if_binding ((entry,yscope),ntn_binding_ids2) sy_typ
+    | NtnRawTypeVarList typ1 -> failwith "TODO: nested recursive patterns"
   in
-  let check (x, y) =
-    let (_,scope1,_ntn_binding_ids1) = Id.Map.find x allvars in
-    let (_,scope2,_ntn_binding_ids2) = Id.Map.find y allvars in
-    if not (eq_subscope scope1 scope2) then error_not_same_scope x y
-    (* Note: binding_ids should currently be the same, and even with
-      eventually more complex notations, such as e.g.
-        Notation "!! x .. y , P .. Q" := (fun x => (P, .. (fun y => (Q, True)) ..)).
-      each occurrence of the recursive notation variables may have its own binders *)
-  in
-  let () = List.iter check recvars in
-  let useless_recvars = List.map snd recvars in
-  let mainvars =
-    Id.Map.filter (fun x _ -> not (Id.List.mem x useless_recvars)) allvars in
-  Id.Map.mapi (fun x (isonlybinding, sc, ntn_binding_ids) ->
-    let typ = Id.List.assoc x typs in
-    ((entry_relative_level_of_constr_prod_entry entry typ, sc), ntn_binding_ids,
-     make_interpretation_type (Id.List.mem_assoc x recvars) isonlybinding default_if_binding typ)) mainvars
+  List.map aux maintypes
 
 let check_rule_productivity l =
   if List.for_all (function NonTerminal _ | Break _ -> true | _ -> false) l then
@@ -1465,9 +1521,9 @@ let find_subentry_types from n assoc etyps symbols =
   let prec = List.map (assoc_of_type from n) sy_typs in
   sy_typs, prec
 
-let check_locality_compatibility local custom i_typs =
+let check_locality_compatibility local custom sy_typs =
   if not local then
-    let subcustom = List.map_filter (function _,ETConstr (InCustomEntry s,_,_) -> Some s | _ -> None) i_typs in
+    let subcustom = List.map_filter (function _,ETConstr (InCustomEntry s,_,_) -> Some s | _ -> None) sy_typs in
     let allcustoms = match custom with InCustomEntry s -> s::subcustom | _ -> subcustom in
     List.iter (fun s ->
         if Egramrocq.locality_of_custom_entry s then
@@ -1527,9 +1583,9 @@ let compute_syntax_data ~local main_data notation_symbols ntn mods =
   let open SynData in
   let open NotationMods in
   if main_data.itemscopes <> [] then user_err (str "General notations don't support 'in scope'.");
-  let {recvars;mainvars;symbols} = notation_symbols in
+  let {maintypes;symbols} = notation_symbols in
   let assoc = Option.append mods.assoc (Some Gramlib.Gramext.NonA) in
-  let _ = check_useless_entry_types recvars mainvars mods.etyps in
+  let _ = check_useless_entry_types maintypes mods.etyps in
 
   (* Notations for interp and grammar  *)
   let ntn_prefix = longest_common_prefix_level ntn in
@@ -1542,7 +1598,7 @@ let compute_syntax_data ~local main_data notation_symbols ntn mods =
   if main_data.entry = InConstrEntry && not main_data.onlyprinting then check_rule_productivity symbols_for_grammar;
   (* To globalize... *)
   let etyps = default_prefix_level_subentries ntn ntn_prefix symbols mods.etyps in
-  let etyps = join_auxiliary_recursive_types recvars etyps in
+  let etyps = join_types maintypes etyps in
   let sy_typs, prec =
     find_subentry_types main_data.entry n assoc etyps symbols in
   let sy_typs_for_grammar, prec_for_grammar =
@@ -1816,31 +1872,28 @@ let make_use reserved onlyparse onlyprint =
 (* Main functions about notations                                     *)
 
 let make_notation_interpretation ~local main_data notation_symbols ntn syntax_rules df env ?(impls=empty_internalization_env) c scope =
-  let {recvars;mainvars;symbols} = notation_symbols in
+  let {mainvars;maintypes;symbols} = notation_symbols in
   (* Recover types of variables and pa/pp rules; redeclare them if needed *)
-  let level, i_typs, main_data, sy_pp_rules =
+  let level, sy_typs, main_data, sy_pp_rules =
     match syntax_rules with
     | PrimTokenSyntax -> None, [], main_data, None
     | SpecificSyntax sy ->
     (* If the only printing flag has been explicitly requested, put it back *)
     let main_data = { main_data with onlyprinting = main_data.onlyprinting || (sy.synext_notgram = None && not main_data.onlyparsing) } in
-    Some sy.synext_level, List.combine mainvars sy.synext_nottyps, main_data, sy.synext_notprint
+    Some sy.synext_level, sy.synext_nottyps, main_data, sy.synext_notprint
   in
   (* Declare interpretation *)
-  let sy_pp_rules = make_specific_printing_rules i_typs symbols level sy_pp_rules main_data.format in
+  let sy_typs = List.combine mainvars sy_typs in
+  let interp_types = make_internalization_vars maintypes sy_typs in
+  let sy_pp_rules = make_specific_printing_rules sy_typs symbols level sy_pp_rules main_data.format in
   let path = (Lib.library_dp(), Lib.current_dirpath true) in
   let df' = ntn, (path,df) in
-  let i_vars = make_internalization_vars recvars i_typs in
-  let nenv = {
-    ninterp_var_type = Id.Map.of_list i_vars;
-    ninterp_rec_vars = Id.Map.of_list recvars;
-  } in
-  let (acvars, ac, reversibility) = interp_notation_constr env ~impls nenv c in
+  let nenv = { ninterp_var_type = interp_types; ninterp_raw_types = maintypes } in
+  let (i_varscopes, ac, reversibility) = interp_notation_constr env ~impls nenv c in
   let plevel = match level with Some (entry,l) -> (entry,l) | None (* numeral: irrelevant )*) -> (constr_lowest_level,[]) in
-  let interp = make_interpretation_vars recvars acvars plevel i_typs in
-  let map (x, _) = try Some (x, Id.Map.find x interp) with Not_found -> None in
-  let vars = List.map_filter map i_vars in (* Order of elements is important here! *)
-  let onlyparsing,coe = printability level i_typs vars main_data.onlyparsing reversibility ac in
+  let interp = make_interpretation_vars maintypes plevel i_varscopes sy_typs in
+  let vars = List.combine mainvars interp in
+  let onlyparsing,coe = printability level sy_typs vars main_data.onlyparsing reversibility ac in
   let main_data = { main_data with onlyparsing } in
   let use = make_use false onlyparsing main_data.onlyprinting in
   {
@@ -2022,7 +2075,8 @@ let interp_abbreviation_modifiers modl =
 
 let add_abbreviation ~local user_warns env ident (vars,c) modl =
   let (only_parsing, scopes) = interp_abbreviation_modifiers modl in
-  let vars = List.map (fun v -> v, List.assoc_opt v scopes) vars in
+  let maintypes = List.map (fun v -> NtnRawTypeVar v) vars in
+  let scvars = List.map (fun v -> v, List.assoc_opt v scopes) vars in
   let acvars,pat,reversibility =
     match vars, intern_name_alias c with
     | [], Some(r,u) ->
@@ -2031,18 +2085,18 @@ let add_abbreviation ~local user_warns env ident (vars,c) modl =
       Id.Map.empty, NRef(r, u), APrioriReversible
     | _ ->
       let fold accu (id,scope) = Id.Map.add id (NtnInternTypeAny scope) accu in
-      let i_vars = List.fold_left fold Id.Map.empty vars in
+      let i_vars = List.fold_left fold Id.Map.empty scvars in
       let nenv = {
         ninterp_var_type = i_vars;
-        ninterp_rec_vars = Id.Map.empty;
+        ninterp_raw_types = [];
       } in
       interp_notation_constr env nenv c
   in
   let level_arg = NumLevel 9 (* level of arguments of an application *) in
-  let in_pat (id,_) = (id,ETConstr (Constrexpr.InConstrEntry,None,(level_arg,InternalProd))) in
+  let sy_typs = List.map (fun id -> (id,ETConstr (Constrexpr.InConstrEntry,None,(level_arg,InternalProd)))) vars in
   let level = (* not relevant *) (constr_lowest_level,[]) in
-  let interp = make_interpretation_vars ~default_if_binding:AsAnyPattern [] acvars level (List.map in_pat vars) in
-  let vars = List.map (fun (x,_) -> (x, Id.Map.find x interp)) vars in
+  let interp = make_interpretation_vars ~default_if_binding:AsAnyPattern maintypes level acvars sy_typs in
+  let vars = List.combine vars interp in
   let onlyparsing = only_parsing || fst (printability None [] vars false reversibility pat) in
   Abbreviation.declare_abbreviation ~local user_warns ident ~onlyparsing (vars,pat)
 

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -312,6 +312,13 @@ let error_not_same_scope x y =
   user_err
     (str "Variables " ++ Id.print x ++ str " and " ++ Id.print y ++ str " must be in the same scope.")
 
+let error_not_same_binding_ids x y ntn_binding_ids1 ntn_binding_ids2 =
+  user_err
+    (str "Variables " ++ Id.print x ++ str " and " ++ Id.print y ++
+     str " are in the scope of a different set of binders (respectively " ++
+     pr_enum Id.print (Id.Set.elements ntn_binding_ids1) ++ str " and " ++
+     pr_enum Id.print (Id.Set.elements ntn_binding_ids1) ++ str ").")
+
 (** **************************************************************** **)
 (** Build pretty-printing rules                                      **)
 
@@ -1238,13 +1245,13 @@ let make_interp_atom_type_rec used_as_binder default_if_binding scl = function
   (* Others *)
   | ETBigint | ETGlobal -> NtnTypeVarList (NtnTypeVar (scl, NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern))
 
-let make_interp_atom_type used_as_binder default_if_binding scl = function
+let make_interp_atom_type used_as_binder default_if_binding scl is_only_in_constr = function
   (* Parsed as constr, but intended to denote a specific kind of binder, independently of the interpretation *)
   | ETConstr (_,Some bk,_) -> NtnTypeVar (scl, NtnTypeVarPattern (NtnBinderParsedAsConstr bk))
   (* Parsed as constr list but known to be used as binder (and maybe also as constr) in the interpretation *)
   | ETConstr (_,None,_) when used_as_binder -> NtnTypeVar (scl, NtnTypeVarPattern (NtnBinderParsedAsConstr default_if_binding))
   (* Parsed as constr, interpreted as constr *)
-  | ETConstr (_,None,_) -> NtnTypeVar (scl, NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern)
+  | ETConstr (_,None,_) -> NtnTypeVar (scl, NtnTypeVarConstr (if is_only_in_constr then NtnAlwaysConstr else NtnConstrForConstrAndPatternForPattern))
   (* Different way of parsing binders, maybe interpreted also as
      constr, but conventionally internally binders *)
   | ETIdent -> NtnTypeVar (scl, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind AsIdent))
@@ -1280,15 +1287,15 @@ let make_interpretation_vars
     maintypes (entry,_) i_varscopes sy_typs =
   let rec aux = function
     | NtnRawTypeVar x ->
-      let (used_as_binder, xscope, ntn_binding_ids) = Id.Map.find x i_varscopes in
+      let (used_as_binder, xscope, ntn_binding_ids, is_only_in_constr) = Id.Map.find x i_varscopes in
       let sy_typ = Id.List.assoc x sy_typs in
       let entry = entry_relative_level_of_constr_prod_entry entry sy_typ in
-      make_interp_atom_type used_as_binder default_if_binding ((entry, xscope), ntn_binding_ids) sy_typ
+      make_interp_atom_type used_as_binder default_if_binding ((entry, xscope), ntn_binding_ids) is_only_in_constr sy_typ
     | NtnRawTypeVarTuple typl -> NtnTypeVarTuple (List.map aux typl)
     | NtnRawTypeVarList (NtnRawTypeVar (x,y)) ->
       (* Maybe binders *)
-      let (used_as_binder_x, xscope, _ntn_binding_ids1) = Id.Map.find x i_varscopes in
-      let (used_as_binder_y, yscope, ntn_binding_ids2) = Id.Map.find y i_varscopes in
+      let (used_as_binder_x, xscope, ntn_binding_ids1, is_only_in_constr1) = Id.Map.find x i_varscopes in
+      let (used_as_binder_y, yscope, ntn_binding_ids2, is_only_in_constr2) = Id.Map.find y i_varscopes in
       let () =
         if used_as_binder_x <> used_as_binder_y then
           user_err Pp.(str "The two ends " ++ Id.print x ++ str " and " ++ Id.print y ++
@@ -1305,6 +1312,9 @@ let make_interpretation_vars
          eventually more complex notations, such as e.g.
           Notation "!! x .. y , P .. Q" := (fun x => (P, .. (fun y => (Q, True)) ..)).
          each occurrence of the recursive notation variables may have its own binders *)
+      (* So the following test is currently useless *)
+      if not (Id.Set.equal ntn_binding_ids1 ntn_binding_ids2) then
+        error_not_same_binding_ids x y ntn_binding_ids1 ntn_binding_ids2;
       let sy_typ = Id.List.assoc x sy_typs in
       let entry = entry_relative_level_of_constr_prod_entry entry sy_typ in
       make_interp_atom_type_rec used_as_binder_y default_if_binding ((entry,yscope),ntn_binding_ids2) sy_typ

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1459,7 +1459,7 @@ let find_precedence custom lev etyps symbols onlyprint =
       [],Option.get lev
 
 let check_curly_brackets_notation_exists () =
-  try let _ = Notation.level_of_notation (InConstrEntry,"{ _ }") in ()
+  try let _ = Notation.level_of_notation (mk_ntn_in_constr "{ _ }") in ()
   with Not_found ->
     user_err Pp.(str "Notations involving patterns of the form \"{ _ }\" are treated \n\
 specially and require that the notation \"{ _ }\" is already reserved.")
@@ -1552,7 +1552,7 @@ let default_prefix_level ntn_prefix =
     Flags.if_verbose Feedback.msg_info
       (strbrk "Setting notation at level " ++ int level ++ spc ()
        ++ str "to match previous notation with longest common prefix:"
-       ++ spc () ++ str "\"" ++ str (snd prefix) ++ str "\".");
+       ++ spc () ++ str "\"" ++ str prefix.ntn_key ++ str "\".");
     level in
   function Some n -> Some n | None ->
     Option.map (fun (prefix, level, _) -> with_prefix prefix level) ntn_prefix
@@ -1565,14 +1565,14 @@ let default_prefix_level_subentries ntn ntn_prefix symbols etyps =
         | LevelLe n | LevelLt n -> NumLevel n
         | LevelSome -> DefaultLevel in
       let e = List.assoc_opt x etyps
-        |> Option.default (ETConstr (fst ntn, None, DefaultLevel)) in
+        |> Option.default (ETConstr (ntn.ntn_entry, None, DefaultLevel)) in
       match l', e with
       | (NumLevel _ | NextLevel), ETConstr (n, b, DefaultLevel) ->
          Flags.if_verbose Feedback.msg_info
            (strbrk "Setting " ++ Id.print x ++ str " "
             ++ pr_arg_level from_level (l, e) ++ spc ()
             ++ str "to match previous notation with longest common prefix:"
-            ++ spc () ++ str "\"" ++ str (snd prefix) ++ str "\".");
+            ++ spc () ++ str "\"" ++ str prefix.ntn_key ++ str "\".");
          (x, ETConstr (n, b, l')) :: List.remove_assoc x etyps
       | _ -> etyps in
     let levels =
@@ -1759,7 +1759,7 @@ let recover_notation_syntax ntn =
     raise NoSyntaxRule
 
 let recover_squash_syntax sy =
-  let sq = recover_notation_syntax (InConstrEntry,"{ _ }") in
+  let sq = recover_notation_syntax (mk_ntn_in_constr "{ _ }") in
   match sq.synext_notgram with
   | Some gram -> sy :: gram
   | None -> raise NoSyntaxRule

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -373,6 +373,13 @@ let error_not_same_scope x y =
   user_err
     (str "Variables " ++ Id.print x ++ str " and " ++ Id.print y ++ str " must be in the same scope.")
 
+let error_not_same_binding_ids x y ntn_binding_ids1 ntn_binding_ids2 =
+  user_err
+    (str "Variables " ++ Id.print x ++ str " and " ++ Id.print y ++
+     str " are in the scope of a different set of binders (respectively " ++
+     pr_enum Id.print (Id.Set.elements ntn_binding_ids1) ++ str " and " ++
+     pr_enum Id.print (Id.Set.elements ntn_binding_ids1) ++ str ").")
+
 (** **************************************************************** **)
 (** Build pretty-printing rules                                      **)
 
@@ -1305,13 +1312,13 @@ let make_interp_atom_type_rec used_as_binder default_if_binding scl = function
   (* Others *)
   | ETBigint | ETGlobal -> NtnTypeVarList (NtnTypeVar (scl, NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern))
 
-let make_interp_atom_type used_as_binder default_if_binding scl = function
+let make_interp_atom_type used_as_binder default_if_binding scl is_only_in_constr = function
   (* Parsed as constr, but intended to denote a specific kind of binder, independently of the interpretation *)
   | ETConstr (_,Some bk,_) -> NtnTypeVar (scl, NtnTypeVarPattern (NtnBinderParsedAsConstr bk))
   (* Parsed as constr list but known to be used as binder (and maybe also as constr) in the interpretation *)
   | ETConstr (_,None,_) when used_as_binder -> NtnTypeVar (scl, NtnTypeVarPattern (NtnBinderParsedAsConstr default_if_binding))
   (* Parsed as constr, interpreted as constr *)
-  | ETConstr (_,None,_) -> NtnTypeVar (scl, NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern)
+  | ETConstr (_,None,_) -> NtnTypeVar (scl, NtnTypeVarConstr (if is_only_in_constr then NtnAlwaysConstr else NtnConstrForConstrAndPatternForPattern))
   (* Different way of parsing binders, maybe interpreted also as
      constr, but conventionally internally binders *)
   | ETIdent -> NtnTypeVar (scl, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind AsIdent))
@@ -1347,15 +1354,15 @@ let make_interpretation_vars
     maintypes (entry,_) i_varscopes sy_typs =
   let rec aux = function
     | NtnRawTypeVar x ->
-      let (used_as_binder, xscope, ntn_binding_ids) = Id.Map.find x i_varscopes in
+      let (used_as_binder, xscope, ntn_binding_ids, is_only_in_constr) = Id.Map.find x i_varscopes in
       let sy_typ = Id.List.assoc x sy_typs in
       let entry = entry_relative_level_of_constr_prod_entry entry sy_typ in
-      make_interp_atom_type used_as_binder default_if_binding ((entry, xscope), ntn_binding_ids) sy_typ
+      make_interp_atom_type used_as_binder default_if_binding ((entry, xscope), ntn_binding_ids) is_only_in_constr sy_typ
     | NtnRawTypeVarTuple typl -> NtnTypeVarTuple (List.map aux typl)
     | NtnRawTypeVarList (NtnRawTypeVar (x,y)) ->
       (* Maybe binders *)
-      let (used_as_binder_x, xscope, _ntn_binding_ids1) = Id.Map.find x i_varscopes in
-      let (used_as_binder_y, yscope, ntn_binding_ids2) = Id.Map.find y i_varscopes in
+      let (used_as_binder_x, xscope, ntn_binding_ids1, is_only_in_constr1) = Id.Map.find x i_varscopes in
+      let (used_as_binder_y, yscope, ntn_binding_ids2, is_only_in_constr2) = Id.Map.find y i_varscopes in
       let () =
         if used_as_binder_x <> used_as_binder_y then
           user_err Pp.(str "The two ends " ++ Id.print x ++ str " and " ++ Id.print y ++
@@ -1372,6 +1379,9 @@ let make_interpretation_vars
          eventually more complex notations, such as e.g.
           Notation "!! x .. y , P .. Q" := (fun x => (P, .. (fun y => (Q, True)) ..)).
          each occurrence of the recursive notation variables may have its own binders *)
+      (* So the following test is currently useless *)
+      if not (Id.Set.equal ntn_binding_ids1 ntn_binding_ids2) then
+        error_not_same_binding_ids x y ntn_binding_ids1 ntn_binding_ids2;
       let sy_typ = Id.List.assoc x sy_typs in
       let entry = entry_relative_level_of_constr_prod_entry entry sy_typ in
       make_interp_atom_type_rec used_as_binder_y default_if_binding ((entry,yscope),ntn_binding_ids2) sy_typ

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1538,7 +1538,7 @@ let find_precedence custom lev etyps symbols onlyprint =
     | _ -> msgs @ [warn_level_0_notation_not_closed], lev
 
 let check_curly_brackets_notation_exists () =
-  try let _ = Notation.level_of_notation (InConstrEntry,"{ _ }") in ()
+  try let _ = Notation.level_of_notation (mk_ntn_in_constr "{ _ }") in ()
   with Not_found ->
     user_err Pp.(str "Notations involving patterns of the form \"{ _ }\" are treated \n\
 specially and require that the notation \"{ _ }\" is already reserved.")
@@ -1637,7 +1637,7 @@ let default_prefix_level ntn_prefix =
     Flags.if_verbose Feedback.msg_info
       (strbrk "Setting notation at level " ++ int level ++ spc ()
        ++ str "to match previous notation with longest common prefix:"
-       ++ spc () ++ str "\"" ++ str (snd prefix) ++ str "\".");
+       ++ spc () ++ str "\"" ++ str prefix.ntn_key ++ str "\".");
     level in
   function Some n -> Some n | None ->
     Option.map (fun (prefix, level, _) -> with_prefix prefix level) ntn_prefix
@@ -1650,14 +1650,14 @@ let default_prefix_level_subentries ntn ntn_prefix symbols etyps =
         | LevelLe n | LevelLt n -> NumLevel n
         | LevelSome -> DefaultLevel in
       let e = List.assoc_opt x etyps
-        |> Option.default (ETConstr (fst ntn, None, DefaultLevel)) in
+        |> Option.default (ETConstr (ntn.ntn_entry, None, DefaultLevel)) in
       match l', e with
       | (NumLevel _ | NextLevel), ETConstr (n, b, DefaultLevel) ->
          Flags.if_verbose Feedback.msg_info
            (strbrk "Setting " ++ Id.print x ++ str " "
             ++ pr_arg_level from_level (l, e) ++ spc ()
             ++ str "to match previous notation with longest common prefix:"
-            ++ spc () ++ str "\"" ++ str (snd prefix) ++ str "\".");
+            ++ spc () ++ str "\"" ++ str prefix.ntn_key ++ str "\".");
          (x, ETConstr (n, b, l')) :: List.remove_assoc x etyps
       | _ -> etyps in
     let levels =
@@ -1861,7 +1861,7 @@ let recover_notation_syntax loc ntn =
 
 let recover_squash_syntax sy =
   (* use `None` because this entire function is a hack anyways... *)
-  let sq = recover_notation_syntax None (InConstrEntry,"{ _ }") in
+  let sq = recover_notation_syntax None (mk_ntn_in_constr "{ _ }") in
   match sq.synext_notgram with
   | Some gram -> sy :: gram
   | None -> raise NoSyntaxRule

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -993,7 +993,7 @@ let check_prefix_incompatible_level ntn prec nottyps =
        let pref_nottyps = Notgram_ops.non_terminals_of_notation pref in
        let pref_nottyps = CList.firstn k pref_nottyps in
        let nottyps = CList.firstn k nottyps in
-       if not (level_eq prec pref_prec && List.for_all2 Extend.constr_entry_key_eq_ignore_binder_kind nottyps pref_nottyps) then
+       if not (level_eq prec pref_prec && List.for_all2 Extend.constr_entry_key_visible_eq nottyps pref_nottyps) then
          warn_prefix_incompatible_level (pref, ntn, pref_prec, pref_nottyps, prec, nottyps);
      with Not_found | Failure _ -> ()
 
@@ -1015,7 +1015,7 @@ let cache_one_syntax_extension (ntn,synext) =
         with Not_found -> None
       in
       let oldtyps = Notgram_ops.non_terminals_of_notation ntn in
-      if not (level_eq prec oldprec && List.for_all2 Extend.constr_entry_key_eq synext.synext_nottyps oldtyps) &&
+      if not (level_eq prec oldprec && List.for_all2 Extend.constr_entry_key_visible_eq synext.synext_nottyps oldtyps) &&
          (oldparsing <> None || synext.synext_notgram = None) then
         error_incompatible_level ntn oldprec oldtyps prec synext.synext_nottyps;
       oldparsing

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -315,12 +315,21 @@ let quote_notation_token x =
   if (n > 0 && norm) || (n > 2 && x.[0] == '\'') then "'"^x^"'"
   else x
 
+let rec notation_variables : type s. (s -> Id.t list) -> s notation_raw_type -> Id.t list =
+  fun f -> function
+  | NtnRawTypeVar x -> f x
+  | NtnRawTypeVarList typ -> notation_variables (fun (x,y) -> f x @ f y) typ
+  | NtnRawTypeVarTuple typs -> List.map_append (notation_variables f) typs
+
+let all_notation_variables =
+  List.map_append (notation_variables (fun x -> [x]))
+
 let analyze_notation_tokens ~onlyprinting ~infix entry df =
   let df = if infix then quote_notation_token df else df in
-  let { recvars; mainvars; symbols } as res = decompose_raw_notation df in
+  let { maintypes; symbols } as res = decompose_raw_notation df in
     (* don't check for nonlinearity if printing only, see Bug 5526 *)
   (if not onlyprinting then
-    match List.duplicates Id.equal (mainvars @ List.map snd recvars) with
+    match List.duplicates Id.equal (all_notation_variables maintypes) with
     | id :: _ ->
         user_err
           (str "Variable " ++ Id.print id ++ str " occurs more than once.")
@@ -332,7 +341,8 @@ let adjust_symbols vars notation_symbols =
   let x = Namegen.next_ident_away (Id.of_string "x") vars in
   let y = Namegen.next_ident_away (Id.of_string "y") (Id.Set.add x vars) in
   let notation_symbols = {
-      recvars = notation_symbols.recvars; mainvars = x::notation_symbols.mainvars@[y];
+      mainvars = x :: notation_symbols.mainvars @ [y];
+      maintypes = NtnRawTypeVar x :: notation_symbols.maintypes @ [NtnRawTypeVar y];
       symbols = NonTerminal x :: notation_symbols.symbols @ [NonTerminal y];
     } in
   x, y, notation_symbols
@@ -915,7 +925,7 @@ let warn_incompatible_format =
 type syntax_extension = {
   synext_level : level;
   synext_hack_level : bool;
-  synext_nottyps : constr_entry_key list;
+  synext_nottyps : Notgram_ops.entry_types;
   synext_notgram : notation_grammar option;
   synext_notprint : generic_notation_printing_rules option;
   synext_location : Loc.t option;
@@ -1015,9 +1025,10 @@ let cache_one_syntax_extension (ntn,synext) =
         with Not_found -> None
       in
       let oldtyps = Notgram_ops.non_terminals_of_notation ntn in
-      if not (level_eq prec oldprec && List.for_all2 Extend.constr_entry_key_visible_eq synext.synext_nottyps oldtyps) &&
+      let nottyps = synext.synext_nottyps in
+      if not (level_eq prec oldprec && List.for_all2 Extend.constr_entry_key_visible_eq nottyps oldtyps) &&
          (oldparsing <> None || synext.synext_notgram = None) then
-        error_incompatible_level ntn oldprec oldtyps prec synext.synext_nottyps;
+        error_incompatible_level ntn oldprec oldtyps prec nottyps;
       oldparsing
     with Not_found ->
       check_prefix_incompatible_level ntn prec synext.synext_nottyps;
@@ -1133,8 +1144,8 @@ let interp_modifiers entry modl = let open NotationMods in
   in
   interp default modl
 
-let check_useless_entry_types recvars mainvars etyps =
-  let vars = let (l1,l2) = List.split recvars in l1@l2@mainvars in
+let check_useless_entry_types mainvars etyps =
+  let vars = all_notation_variables mainvars in
   match List.filter (fun (x,etyp) -> not (List.mem x vars)) etyps with
   | (x,_)::_ -> user_err
                   (Id.print x ++ str " is unbound in the notation.")
@@ -1241,56 +1252,75 @@ let set_entry_type from n etyps (x,typ) =
       ETConstr (from,None,(make_lev n from,typ))
   in (x,typ)
 
-let join_auxiliary_recursive_types recvars etyps =
-  List.fold_right (fun (x,y) typs ->
-    let xtyp = try Some (List.assoc x etyps) with Not_found -> None in
-    let ytyp = try Some (List.assoc y etyps) with Not_found -> None in
-    match xtyp,ytyp with
-    | None, None -> typs
-    | Some _, None -> typs
-    | None, Some ytyp -> (x,ytyp)::typs
-    | Some xtyp, Some ytyp when (=) xtyp ytyp -> typs (* FIXME *)
-    | Some xtyp, Some ytyp ->
-        user_err
-          (strbrk "In " ++ Id.print x ++ str " .. " ++ Id.print y ++
-           strbrk ", both ends have incompatible types."))
-    recvars etyps
-
 let internalization_type_of_entry_type = function
   | ETBinder _ | ETConstr (_,Some _,_) -> NtnInternTypeOnlyBinder
   | ETConstr (_,None,_) | ETBigint | ETGlobal
   | ETIdent | ETName | ETPattern _ -> NtnInternTypeAny None
 
-let make_internalization_vars recvars maintyps =
-  let maintyps = List.map (on_snd internalization_type_of_entry_type) maintyps in
-  let extratyps = List.map (fun (x,y) -> (y,List.assoc x maintyps)) recvars in
-  maintyps @ extratyps
+let default_interp_type = NtnInternTypeAny None
 
-let make_interpretation_type isrec isbinding default_if_binding typ =
-  match typ, isrec with
-  (* Parsed as constr, but interpreted as a specific kind of binder *)
-  | ETConstr (_,Some bk,_), true -> NtnTypeBinderList (NtnBinderParsedAsConstr bk)
-  | ETConstr (_,Some bk,_), false -> NtnTypeBinder (NtnBinderParsedAsConstr bk)
-  (* Parsed as constr list but interpreted as the default kind of binder *)
-  | ETConstr (_,None,_), true when isbinding -> NtnTypeBinderList (NtnBinderParsedAsConstr default_if_binding)
-  | ETConstr (_,None,_), false when isbinding -> NtnTypeBinder (NtnBinderParsedAsConstr default_if_binding)
+let join_variable_types etyps vars =
+  let typs = List.map (fun x -> (x, try Some (List.assoc x etyps) with Not_found -> None)) vars in
+  let check_and_remove x typ typs etyps =
+    List.fold_left (fun etyps (x',typ') ->
+        match typ' with
+        | None -> etyps
+        | Some typ' ->
+          if not (simple_constr_entry_key_eq typ typ') then
+            user_err
+              (strbrk "In " ++ Id.print x ++ str " .. " ++ Id.print x' ++
+               strbrk ", both ends have incompatible types.");
+          List.remove_assoc x' etyps)
+      etyps typs in
+  match typs with
+  | [] -> etyps
+  | (x, Some typ) :: typs -> (* First name is the key: it already has a type *)
+    check_and_remove x typ typs etyps
+  | (x, None) :: typs ->
+    let rec aux = function
+      | [] -> etyps
+      | (_, None) :: typs -> aux typs
+      | (x', Some typ) :: typs ->
+        (x,typ) :: check_and_remove x' typ typs (List.remove_assoc x' etyps)
+    in aux typs
+
+let join_types maintypes etyps =
+  let allvars = List.map (notation_variables (fun x -> [x])) maintypes in
+  List.fold_left join_variable_types etyps allvars
+
+let make_interp_atom_type_rec used_as_binder default_if_binding scl = function
+  (* Parsed as constr, but intended to denote a specific kind of binder, independently of the interpretation *)
+  | ETConstr (_,Some bk,_) -> NtnTypeVar (scl, NtnTypeVarBinders (NtnBinderParsedAsConstr bk))
+  (* Parsed as constr list but known to be used as binder (and maybe also as constr) in the interpretation *)
+  | ETConstr (_,None,_) when used_as_binder -> NtnTypeVar (scl, NtnTypeVarBinders (NtnBinderParsedAsConstr default_if_binding))
   (* Parsed as constr, interpreted as constr *)
-  | ETConstr (_,None,_), true -> NtnTypeConstrList
-  | ETConstr (_,None,_), false -> NtnTypeConstr
+  | ETConstr (_,None,_) -> NtnTypeVarList (NtnTypeVar (scl, NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern))
   (* Different way of parsing binders, maybe interpreted also as
      constr, but conventionally internally binders *)
-  | ETIdent, true -> NtnTypeBinderList (NtnBinderParsedAsSomeBinderKind AsIdent)
-  | ETIdent, false -> NtnTypeBinder (NtnBinderParsedAsSomeBinderKind AsIdent)
-  | ETName, true -> NtnTypeBinderList (NtnBinderParsedAsSomeBinderKind AsName)
-  | ETName, false -> NtnTypeBinder (NtnBinderParsedAsSomeBinderKind AsName)
+  | ETIdent -> NtnTypeVar (scl, NtnTypeVarBinders (NtnBinderParsedAsSomeBinderKind AsIdent))
+  | ETName -> NtnTypeVar (scl, NtnTypeVarBinders (NtnBinderParsedAsSomeBinderKind AsName))
   (* Parsed as ident/pattern, primarily interpreted as binder; maybe strict at printing *)
-  | ETPattern (ppstrict,_), true -> NtnTypeBinderList (NtnBinderParsedAsSomeBinderKind (if ppstrict then AsStrictPattern else AsAnyPattern))
-  | ETPattern (ppstrict,_), false -> NtnTypeBinder (NtnBinderParsedAsSomeBinderKind (if ppstrict then AsStrictPattern else AsAnyPattern))
-  | ETBinder _, true -> NtnTypeBinderList NtnBinderParsedAsBinder
-  | ETBinder _, false -> NtnTypeBinder NtnBinderParsedAsBinder
+  | ETPattern (ppstrict,_) -> NtnTypeVar (scl, NtnTypeVarBinders (NtnBinderParsedAsSomeBinderKind (if ppstrict then AsStrictPattern else AsAnyPattern)))
+  | ETBinder _ -> NtnTypeVar (scl, NtnTypeVarBinders NtnBinderParsedAsBinder)
   (* Others *)
-  | ETBigint, true | ETGlobal, true -> NtnTypeConstrList
-  | ETBigint, false | ETGlobal, false -> NtnTypeConstr
+  | ETBigint | ETGlobal -> NtnTypeVarList (NtnTypeVar (scl, NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern))
+
+let make_interp_atom_type used_as_binder default_if_binding scl = function
+  (* Parsed as constr, but intended to denote a specific kind of binder, independently of the interpretation *)
+  | ETConstr (_,Some bk,_) -> NtnTypeVar (scl, NtnTypeVarPattern (NtnBinderParsedAsConstr bk))
+  (* Parsed as constr list but known to be used as binder (and maybe also as constr) in the interpretation *)
+  | ETConstr (_,None,_) when used_as_binder -> NtnTypeVar (scl, NtnTypeVarPattern (NtnBinderParsedAsConstr default_if_binding))
+  (* Parsed as constr, interpreted as constr *)
+  | ETConstr (_,None,_) -> NtnTypeVar (scl, NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern)
+  (* Different way of parsing binders, maybe interpreted also as
+     constr, but conventionally internally binders *)
+  | ETIdent -> NtnTypeVar (scl, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind AsIdent))
+  | ETName -> NtnTypeVar (scl, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind AsName))
+  (* Parsed as ident/pattern, primarily interpreted as binder; maybe strict at printing *)
+  | ETPattern (ppstrict,_) -> NtnTypeVar (scl, NtnTypeVarPattern (NtnBinderParsedAsSomeBinderKind (if ppstrict then AsStrictPattern else AsAnyPattern)))
+  | ETBinder _ -> NtnTypeVar (scl, NtnTypeVarPattern NtnBinderParsedAsBinder)
+  (* Others *)
+  | ETBigint | ETGlobal -> NtnTypeVar (scl, NtnTypeVarConstr NtnConstrForConstrAndPatternForPattern)
 
 let entry_relative_level_of_constr_prod_entry from_level = function
   | ETConstr (entry,_,(_,y)) as x ->
@@ -1298,30 +1328,56 @@ let entry_relative_level_of_constr_prod_entry from_level = function
      { notation_subentry = entry; notation_relative_level = precedence_of_entry_type from_level x; notation_position = side }
   | _ -> constr_some_level
 
+let rec make_internalization_var : type s. (s -> Id.t list) -> _ -> _ -> s notation_raw_type -> _ =
+  fun f etyps typs typ -> match typ with
+  | NtnRawTypeVar x ->
+    (match f x with
+    | [] -> assert false
+    | mainname :: _ as allnames ->
+    let t = try internalization_type_of_entry_type (Id.List.assoc mainname etyps) with Not_found -> default_interp_type in
+    List.fold_left (fun typs x -> Id.Map.add x t typs) typs allnames)
+  | NtnRawTypeVarList typ -> make_internalization_var (fun (x,y) -> f x @ f y) etyps typs typ
+  | NtnRawTypeVarTuple typl -> List.fold_left (make_internalization_var f etyps) typs typl
+
+let make_internalization_vars maintyps etyps =
+  List.fold_left (make_internalization_var (fun x -> [x]) etyps) Id.Map.empty maintyps
+
 let make_interpretation_vars
   (* For binders, default is to parse only as an ident *) ?(default_if_binding=AsName)
-   recvars allvars (entry,_) typs =
-  let eq_subscope (sc1, l1) (sc2, l2) =
-    List.equal String.equal sc1 sc2 &&
-    List.equal String.equal l1 l2
+    maintypes (entry,_) i_varscopes sy_typs =
+  let rec aux = function
+    | NtnRawTypeVar x ->
+      let (used_as_binder, xscope, ntn_binding_ids) = Id.Map.find x i_varscopes in
+      let sy_typ = Id.List.assoc x sy_typs in
+      let entry = entry_relative_level_of_constr_prod_entry entry sy_typ in
+      make_interp_atom_type used_as_binder default_if_binding ((entry, xscope), ntn_binding_ids) sy_typ
+    | NtnRawTypeVarTuple typl -> NtnTypeVarTuple (List.map aux typl)
+    | NtnRawTypeVarList (NtnRawTypeVar (x,y)) ->
+      (* Maybe binders *)
+      let (used_as_binder_x, xscope, _ntn_binding_ids1) = Id.Map.find x i_varscopes in
+      let (used_as_binder_y, yscope, ntn_binding_ids2) = Id.Map.find y i_varscopes in
+      let () =
+        if used_as_binder_x <> used_as_binder_y then
+          user_err Pp.(str "The two ends " ++ Id.print x ++ str " and " ++ Id.print y ++
+                        strbrk " of a recursive notation are not both used consistently in binding position.") in
+      let () =
+        if not (eq_pair (List.equal String.equal) (List.equal String.equal) xscope yscope) then
+          user_err Pp.(str "The two ends " ++ Id.print x ++ str " and " ++ Id.print y ++
+                        strbrk " of a recursive notation are not both used consistently in the same scope.") in
+      let eq_subscope (sc1, l1) (sc2, l2) =
+        List.equal String.equal sc1 sc2 &&
+        List.equal String.equal l1 l2 in
+      if not (eq_subscope xscope yscope) then error_not_same_scope x y;
+      (* Note: binding_ids should currently be the same, and even with
+         eventually more complex notations, such as e.g.
+          Notation "!! x .. y , P .. Q" := (fun x => (P, .. (fun y => (Q, True)) ..)).
+         each occurrence of the recursive notation variables may have its own binders *)
+      let sy_typ = Id.List.assoc x sy_typs in
+      let entry = entry_relative_level_of_constr_prod_entry entry sy_typ in
+      make_interp_atom_type_rec used_as_binder_y default_if_binding ((entry,yscope),ntn_binding_ids2) sy_typ
+    | NtnRawTypeVarList typ1 -> failwith "TODO: nested recursive patterns"
   in
-  let check (x, y) =
-    let (_,scope1,_ntn_binding_ids1) = Id.Map.find x allvars in
-    let (_,scope2,_ntn_binding_ids2) = Id.Map.find y allvars in
-    if not (eq_subscope scope1 scope2) then error_not_same_scope x y
-    (* Note: binding_ids should currently be the same, and even with
-      eventually more complex notations, such as e.g.
-        Notation "!! x .. y , P .. Q" := (fun x => (P, .. (fun y => (Q, True)) ..)).
-      each occurrence of the recursive notation variables may have its own binders *)
-  in
-  let () = List.iter check recvars in
-  let useless_recvars = List.map snd recvars in
-  let mainvars =
-    Id.Map.filter (fun x _ -> not (Id.List.mem x useless_recvars)) allvars in
-  Id.Map.mapi (fun x (isonlybinding, sc, ntn_binding_ids) ->
-    let typ = Id.List.assoc x typs in
-    ((entry_relative_level_of_constr_prod_entry entry typ, sc), ntn_binding_ids,
-     make_interpretation_type (Id.List.mem_assoc x recvars) isonlybinding default_if_binding typ)) mainvars
+  List.map aux maintypes
 
 let check_rule_productivity l =
   if List.for_all (function NonTerminal _ | Break _ -> true | _ -> false) l then
@@ -1550,9 +1606,9 @@ let custom_entry_locality = Summary.ref ~name:"LOCAL-CUSTOM-ENTRY" CustomName.Se
 
 let locality_of_custom_entry s = CustomName.Set.mem s !custom_entry_locality
 
-let check_locality_compatibility local custom i_typs =
+let check_locality_compatibility local custom sy_typs =
   if not local then
-    let subcustom = List.map_filter (function _,ETConstr (InCustomEntry s,_,_) -> Some s | _ -> None) i_typs in
+    let subcustom = List.map_filter (function _,ETConstr (InCustomEntry s,_,_) -> Some s | _ -> None) sy_typs in
     let allcustoms = match custom with InCustomEntry s -> s::subcustom | _ -> subcustom in
     List.iter (fun s ->
         if locality_of_custom_entry s then
@@ -1612,9 +1668,9 @@ let compute_syntax_data ~local main_data notation_symbols ntn mods =
   let open SynData in
   let open NotationMods in
   if main_data.itemscopes <> [] then user_err (str "General notations don't support 'in scope'.");
-  let {recvars;mainvars;symbols} = notation_symbols in
+  let {maintypes;symbols} = notation_symbols in
   let assoc = Option.append mods.assoc (Some Gramlib.Gramext.NonA) in
-  let () = check_useless_entry_types recvars mainvars mods.etyps in
+  let () = check_useless_entry_types maintypes mods.etyps in
 
   (* Notations for interp and grammar  *)
   let ntn_prefix = longest_common_prefix_level ntn in
@@ -1636,7 +1692,7 @@ let compute_syntax_data ~local main_data notation_symbols ntn mods =
   if main_data.entry = InConstrEntry && not main_data.onlyprinting then check_rule_productivity symbols_for_grammar;
   (* To globalize... *)
   let etyps = default_prefix_level_subentries ntn ntn_prefix symbols mods.etyps in
-  let etyps = join_auxiliary_recursive_types recvars etyps in
+  let etyps = join_types maintypes etyps in
   let sy_typs, prec =
     find_subentry_types main_data.entry n assoc etyps symbols in
   let sy_typs_for_grammar, prec_for_grammar =
@@ -1922,31 +1978,28 @@ let make_use reserved onlyparse onlyprint =
 (* Main functions about notations                                     *)
 
 let make_notation_interpretation ~local loc main_data notation_symbols ntn syntax_rules df env ?(impls=empty_internalization_env) c scope =
-  let {recvars;mainvars;symbols} = notation_symbols in
+  let {mainvars;maintypes;symbols} = notation_symbols in
   (* Recover types of variables and pa/pp rules; redeclare them if needed *)
-  let level, i_typs, main_data, sy_pp_rules =
+  let level, sy_typs, main_data, sy_pp_rules =
     match syntax_rules with
     | PrimTokenSyntax -> None, [], main_data, None
     | SpecificSyntax sy ->
     (* If the only printing flag has been explicitly requested, put it back *)
     let main_data = { main_data with onlyprinting = main_data.onlyprinting || (sy.synext_notgram = None && not main_data.onlyparsing) } in
-    Some sy.synext_level, List.combine mainvars sy.synext_nottyps, main_data, sy.synext_notprint
+    Some sy.synext_level, sy.synext_nottyps, main_data, sy.synext_notprint
   in
   (* Declare interpretation *)
-  let sy_pp_rules = make_specific_printing_rules i_typs symbols level sy_pp_rules main_data.format in
+  let sy_typs = List.combine mainvars sy_typs in
+  let interp_types = make_internalization_vars maintypes sy_typs in
+  let sy_pp_rules = make_specific_printing_rules sy_typs symbols level sy_pp_rules main_data.format in
   let path = (Lib.library_dp(), Lib.current_dirpath true, loc) in
   let df' = ntn, (path,df) in
-  let i_vars = make_internalization_vars recvars i_typs in
-  let nenv = {
-    ninterp_var_type = Id.Map.of_list i_vars;
-    ninterp_rec_vars = Id.Map.of_list recvars;
-  } in
-  let (acvars, ac, reversibility) = interp_notation_constr env ~impls nenv c in
+  let nenv = { ninterp_var_type = interp_types; ninterp_raw_types = maintypes } in
+  let (i_varscopes, ac, reversibility) = interp_notation_constr env ~impls nenv c in
   let plevel = match level with Some (entry,l) -> (entry,l) | None (* numeral: irrelevant )*) -> (constr_lowest_level,[]) in
-  let interp = make_interpretation_vars recvars acvars plevel i_typs in
-  let map (x, _) = try Some (x, Id.Map.find x interp) with Not_found -> None in
-  let vars = List.map_filter map i_vars in (* Order of elements is important here! *)
-  let onlyparsing,coe = printability level i_typs vars main_data.onlyparsing reversibility ac in
+  let interp = make_interpretation_vars maintypes plevel i_varscopes sy_typs in
+  let vars = List.combine mainvars interp in
+  let onlyparsing,coe = printability level sy_typs vars main_data.onlyparsing reversibility ac in
   let main_data = { main_data with onlyparsing } in
   let use = make_use false onlyparsing main_data.onlyprinting in
   {
@@ -2143,7 +2196,8 @@ let interp_abbreviation_modifiers modl =
 
 let add_abbreviation ~local user_warns env ident (vars,c) modl =
   let (only_parsing, scopes) = interp_abbreviation_modifiers modl in
-  let vars = List.map (fun v -> v, List.assoc_opt v scopes) vars in
+  let maintypes = List.map (fun v -> NtnRawTypeVar v) vars in
+  let scvars = List.map (fun v -> v, List.assoc_opt v scopes) vars in
   let acvars,pat,reversibility =
     match vars, intern_name_alias c with
     | [], Some(r,u) ->
@@ -2152,18 +2206,18 @@ let add_abbreviation ~local user_warns env ident (vars,c) modl =
       Id.Map.empty, NRef(r, u), APrioriReversible
     | _ ->
       let fold accu (id,scope) = Id.Map.add id (NtnInternTypeAny scope) accu in
-      let i_vars = List.fold_left fold Id.Map.empty vars in
+      let i_vars = List.fold_left fold Id.Map.empty scvars in
       let nenv = {
         ninterp_var_type = i_vars;
-        ninterp_rec_vars = Id.Map.empty;
+        ninterp_raw_types = [];
       } in
       interp_notation_constr env nenv c
   in
   let level_arg = NumLevel 9 (* level of arguments of an application *) in
-  let in_pat (id,_) = (id,ETConstr (Constrexpr.InConstrEntry,None,(level_arg,InternalProd))) in
+  let sy_typs = List.map (fun id -> (id,ETConstr (Constrexpr.InConstrEntry,None,(level_arg,InternalProd)))) vars in
   let level = (* not relevant *) (constr_lowest_level,[]) in
-  let interp = make_interpretation_vars ~default_if_binding:AsAnyPattern [] acvars level (List.map in_pat vars) in
-  let vars = List.map (fun (x,_) -> (x, Id.Map.find x interp)) vars in
+  let interp = make_interpretation_vars ~default_if_binding:AsAnyPattern maintypes level acvars sy_typs in
+  let vars = List.combine vars interp in
   let onlyparsing = only_parsing || fst (printability None [] vars false reversibility pat) in
   Abbreviation.declare ~local user_warns ident ~onlyparsing (vars,pat)
 

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -990,10 +990,10 @@ let print_any_name access env sigma na udecl =
     print_named_decl env sigma true str
   with Not_found -> user_err ?loc:qid.loc (pr_qualid qid ++ spc () ++ str "not a defined object.")
 
-let print_notation_interpretation env sigma (entry,ntn) df sc c =
+let print_notation_interpretation env sigma ntn df sc c =
   let filter = Notation.{
-    notation_entry_pattern = [entry];
-    interp_rule_key_pattern = Some (Inl ntn);
+    notation_entry_pattern = [ntn.Constrexpr.ntn_entry];
+    interp_rule_key_pattern = Some (Inl ntn.Constrexpr.ntn_key);
     use_pattern = OnlyPrinting;
     scope_pattern = sc;
     interpretation_pattern = Some c;
@@ -1044,7 +1044,7 @@ let print_notation env sigma entry raw_ntn =
   in
   (* convert notation string to key. eg. "x + y" to "_ + _" *)
   let interp_ntn = Notation.interpret_notation_string raw_ntn in
-  let ntn = (entry, interp_ntn) in
+  let ntn = Constrexpr_ops.mk_ntn entry interp_ntn in
   try
     let lvl = Notation.level_of_notation ntn in
     let args = Notgram_ops.non_terminals_of_notation ntn in

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -984,10 +984,10 @@ let print_any_name access env sigma na udecl =
     print_named_decl env sigma true str
   with Not_found -> user_err ?loc:qid.loc (pr_qualid qid ++ spc () ++ str "not a defined object.")
 
-let print_notation_interpretation env sigma (entry,ntn) df sc c =
+let print_notation_interpretation env sigma ntn df sc c =
   let filter = Notation.{
-    notation_entry_pattern = [entry];
-    interp_rule_key_pattern = Some (Inl ntn);
+    notation_entry_pattern = [ntn.Constrexpr.ntn_entry];
+    interp_rule_key_pattern = Some (Inl ntn.Constrexpr.ntn_key);
     use_pattern = OnlyPrinting;
     scope_pattern = sc;
     interpretation_pattern = Some c;
@@ -1034,7 +1034,7 @@ let print_notation env sigma entry raw_ntn =
   let entry = Metasyntax.intern_notation_entry entry in
   (* convert notation string to key. eg. "x + y" to "_ + _" *)
   let interp_ntn = Notation.interpret_notation_string raw_ntn in
-  let ntn = (entry, interp_ntn) in
+  let ntn = Constrexpr_ops.mk_ntn entry interp_ntn in
   try
     let lvl = Notation.level_of_notation ntn in
     let args = Notgram_ops.non_terminals_of_notation ntn in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -766,18 +766,17 @@ let interp_enable_notation_rule on ntn interp flags scope =
       parse_notation_enable_flags all { query with use_pattern = use } flags
     | EnableNotationAll :: flags -> parse_notation_enable_flags true query flags in
   let interp = Option.map (fun c ->
-      let vars, recvars =
+      let vars, typs =
         match ntn with
         | None ->
           (* We expect the right-hand side to mention "_" in place of proper variables *)
           (* Or should we instead deactivate the check of free variables? *)
-          ([], [])
-        | Some (Inl ntn) -> let {recvars; mainvars} = decompose_raw_notation ntn in (mainvars, recvars)
-        | Some (Inr (vars,qid)) -> (vars, [])
+          [], []
+        | Some (Inl ntn) -> let {mainvars; maintypes} = decompose_raw_notation ntn in (mainvars, maintypes)
+        | Some (Inr (vars,qid)) -> vars, List.map (fun x -> Notation_term.NtnRawTypeVar x) vars
       in
       let ninterp_var_type = Id.Map.of_list (List.map (fun x -> (x, Notation_term.NtnInternTypeAny None)) vars) in
-      let ninterp_rec_vars = Id.Map.of_list recvars in
-      let nenv = Notation_term.{ ninterp_var_type; ninterp_rec_vars } in
+      let nenv = Notation_term.{ ninterp_var_type; ninterp_raw_types = typs } in
       let (_acvars, ac, _reversibility) = Constrintern.interp_notation_constr (Global.env ()) nenv c in
       ([], ac)) interp in
   let default_notation_enable_pattern = {
@@ -1760,7 +1759,7 @@ let vernac_abbreviation ~atts lid x only_parsing =
 
 let default_env () = {
   Notation_term.ninterp_var_type = Id.Map.empty;
-  ninterp_rec_vars = Id.Map.empty;
+  ninterp_raw_types = [];
 }
 
 let vernac_reserve bl =

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -789,18 +789,17 @@ let interp_enable_notation_rule on ntn interp flags scope =
       parse_notation_enable_flags all { query with use_pattern = use } flags
     | EnableNotationAll :: flags -> parse_notation_enable_flags true query flags in
   let interp = Option.map (fun c ->
-      let vars, recvars =
+      let vars, typs =
         match ntn with
         | None ->
           (* We expect the right-hand side to mention "_" in place of proper variables *)
           (* Or should we instead deactivate the check of free variables? *)
-          ([], [])
-        | Some (Inl ntn) -> let {recvars; mainvars} = decompose_raw_notation ntn in (mainvars, recvars)
-        | Some (Inr (vars,qid)) -> (vars, [])
+          [], []
+        | Some (Inl ntn) -> let {mainvars; maintypes} = decompose_raw_notation ntn in (mainvars, maintypes)
+        | Some (Inr (vars,qid)) -> vars, List.map (fun x -> Notation_term.NtnRawTypeVar x) vars
       in
       let ninterp_var_type = Id.Map.of_list (List.map (fun x -> (x, Notation_term.NtnInternTypeAny None)) vars) in
-      let ninterp_rec_vars = Id.Map.of_list recvars in
-      let nenv = Notation_term.{ ninterp_var_type; ninterp_rec_vars } in
+      let nenv = Notation_term.{ ninterp_var_type; ninterp_raw_types = typs } in
       let (_acvars, ac, _reversibility) = Constrintern.interp_notation_constr (Global.env ()) nenv c in
       ([], ac)) interp in
   let default_notation_enable_pattern = {
@@ -1847,7 +1846,7 @@ let vernac_abbreviation ~warn_old_notation ~atts lid x only_parsing =
 
 let default_env () = {
   Notation_term.ninterp_var_type = Id.Map.empty;
-  ninterp_rec_vars = Id.Map.empty;
+  ninterp_raw_types = [];
 }
 
 let vernac_reserve bl =


### PR DESCRIPTION
The main objective of the PR is to replace the notation arguments of possible atomic type constr, pattern, and binders by an algebra of types based on the same atoms but composable by means of lists and tuples. It is a step towards granting #7959 as well as a way to make #18531 easier (by easily supporting a new type of notation variables).

The main commit is "A richer type system for notation variables". Two structures are provided:
- `Constrexpr.notation_arg_type`: the type of instances of notation variables as known at parsing time (the atoms are: term, pattern, and binders, that is list of binders, as in `forall binders, term` or as in `match term with pattern => term end`)
- `Notation_term.notation_var_type`: the type of notation variable assigned at interpretation time
  - There are three atoms again, constr, pattern and binders, but with refinements:
    - `pattern` carries possible constraints of the forms:
      - only ident/name
      - strict, i.e. non ident/name pattern (those patterns written `` `(x,y)`` in binders and `(x,y)` in `match` patterns)
      - patterns without restriction
    - `constr` carries information on whether it becomes a pattern in notations for patterns (as in `(t,u)` vs `match term with (x,y) => term end`/``fun `(x,y) => term``, where there is a change of type), or remain constr (as in `(t,u) : typ` vs `fun `((x,y) : typ) => term` where `typ` is a constr even when parsed in a pattern expression)
  - Each of atom also comes with the information of how it was orginally parsed (which may differ from how it is interpreted)

Then, a number of correspondences are implemented to adjust an instance as parsed to its expected type as interpreted:
  - at definition time of the notation interpretation: by means of `Metasyntax.make_interp_atom_type_rec` and `Metasyntax.make_interp_atom_type` to inform of how parsing and interpretation types differ
  - at interpretation time: by means of functions `get_term`, `get_pattern`, ... in `constrintern.ml`
  - at printing time:
    - by means of functions `extern_cases_pattern_notation_substitution` and `extern_notation_substitution`  in `constrextern.ml` to build parsing-level instances from interpretation-level instances
    - by means of functions `is_term_meta`, `is_pattern_meta`, ...  in `notation_ops.ml` to take into account the possible constraints on the type (as well as to manage variables which denote both a term and a pattern, knowing that such notation variables used both as term and either pattern or binders are registered as patterns)

Another data type introduced in the PR is:
- `Notation_term.notation_raw_type` which reflects the (possibly nested, so as to grant #7959) recursive and atomic structure of the expressiong being parsed

Note: I would not say that the invariants of the code could not be improved further and comments are welcome.

Synchronous overlays:
- ejgallego/coq-lsp#810
- uds-psl/autosubst-ocaml#19
- LPCIC/coq-elpi#673
- QuickChick/QuickChick#386
- coq-tactician/coq-tactician#87
- rocq-prover/equations#730