### PR TITLE
Let progress detect forward evar definitions to other evars.

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -825,9 +825,14 @@ let eq_constr_univs_test ~evd ~extended_evd t u =
       try sigma := add_constraints !sigma UnivProblem.(Set.singleton (UEq (s1, s2))); true
       with UGraph.UniverseInconsistency _ | UniversesDiffer -> false
   in
-  let eq_existential eq e1 e2 =
-    let eq c1 c2 = eq 0 (EConstr.Unsafe.to_constr c1) (EConstr.Unsafe.to_constr c2) in
-    EConstr.eq_existential evd eq (EConstr.of_existential e1) (EConstr.of_existential e2)
+  let eq_existential eq (e1:existential) (e2:existential) =
+    let t = mkEvar e1 in
+    match kind_of_term_upto extended_evd t with
+    | Evar e1' ->
+      let eq c1 c2 = eq 0 (EConstr.Unsafe.to_constr c1) (EConstr.Unsafe.to_constr c2) in
+      (* the evar map is only used to expand the skip list if Evar.equal e1' e2 *)
+      EConstr.eq_existential extended_evd eq (EConstr.of_existential e1') (EConstr.of_existential e2)
+    | _ -> false
   in
   let kind1 = kind_of_term_upto evd in
   let kind2 = kind_of_term_upto extended_evd in

--- a/test-suite/bugs/bug_21598.v
+++ b/test-suite/bugs/bug_21598.v
@@ -1,0 +1,5 @@
+Goal True.
+  eassert ?[T].
+  Fail progress (eassert ?[T'] as H; [|let _ := constr:(eq_refl _ :> ?T = ?T') in exact H]).
+  Fail progress (eassert ?[T'] as H; [|instantiate (T := ?T'); exact H]).
+Abort.


### PR DESCRIPTION
`progress` will now detect that an evar in the old goal's conclusion was defined to a new evar.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #21598.


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [*] Added / updated **test-suite**.