### PR TITLE
Detect progress in a more principled way

### DIFF
--- a/dev/ci/user-overlays/21650-Yann-Leray-progress.sh
+++ b/dev/ci/user-overlays/21650-Yann-Leray-progress.sh
@@ -1,0 +1,4 @@
+overlay bedrock2 https://github.com/Yann-Leray/bedrock2 progress 21650
+# Make PRs against https://github.com/mit-plv/bedrock2 base branch master
+
+overlay cross_crypto https://github.com/Yann-Leray/cross-crypto progress 21650

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -807,7 +807,7 @@ let compare_constructor_instances evd u u' =
     equalisable universes. The term [t] is interpreted in [evd] while
     [u] is interpreted in [extended_evd]. The universe constraints in
     [extended_evd] are assumed to be an extension of those in [evd]. *)
-let eq_constr_univs_test ~evd ~extended_evd t u =
+let eq_constr_univs_test ~evd ~extended_evd ~eq_evar t u =
   (* spiwack: mild code duplication with {!Evd.eq_constr_univs}. *)
   let open Evd in
   let t = EConstr.Unsafe.to_constr t
@@ -825,9 +825,12 @@ let eq_constr_univs_test ~evd ~extended_evd t u =
       try sigma := add_constraints !sigma UnivProblem.(Set.singleton (UEq (s1, s2))); true
       with UGraph.UniverseInconsistency _ | UniversesDiffer -> false
   in
-  let eq_existential eq e1 e2 =
+  let eq_existential eq (evk1, _ as e1) (evk2, _ as e2) =
+    eq_evar evk1 evk2 &&
     let eq c1 c2 = eq 0 (EConstr.Unsafe.to_constr c1) (EConstr.Unsafe.to_constr c2) in
-    EConstr.eq_existential evd eq (EConstr.of_existential e1) (EConstr.of_existential e2)
+    let args1 = Evd.expand_existential evd (EConstr.of_existential e1) in
+    let args2 = Evd.expand_existential extended_evd (EConstr.of_existential e2) in
+    CList.for_all2eq eq args1 args2
   in
   let kind1 = kind_of_term_upto evd in
   let kind2 = kind_of_term_upto extended_evd in

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -162,14 +162,16 @@ val finalize : ?abort_on_undefined_evars:bool -> evar_map ->
 val kind_of_term_upto : evar_map -> Constr.constr ->
   (Constr.constr, Constr.types, Sorts.t, UVars.Instance.t, Sorts.relevance) kind_of_term
 
-(** [eq_constr_univs_test ~evd ~extended_evd t u] tests equality of
+(** [eq_constr_univs_test ~evd ~extended_evd ~eq_evar t u] tests equality of
     [t] and [u] up to existential variable instantiation and
     equalisable universes. The term [t] is interpreted in [evd] while
     [u] is interpreted in [extended_evd]. The universe constraints in
-    [extended_evd] are assumed to be an extension of those in [evd]. *)
+    [extended_evd] are assumed to be an extension of those in [evd].
+    Undefined evars are compared upto [eq_evar] *)
 val eq_constr_univs_test :
     evd:Evd.evar_map ->
     extended_evd:Evd.evar_map ->
+    eq_evar:(Evar.t -> Evar.t -> bool) ->
     constr ->
     constr ->
     bool

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -162,14 +162,16 @@ val finalize : ?abort_on_undefined_evars:bool -> ?poly:PolyFlags.t -> evar_map -
 val kind_of_term_upto : evar_map -> Constr.constr ->
   (Constr.constr, Constr.types, Sorts.t, UVars.Instance.t, Sorts.relevance) kind_of_term
 
-(** [eq_constr_univs_test ~evd ~extended_evd t u] tests equality of
+(** [eq_constr_univs_test ~evd ~extended_evd ~eq_evar t u] tests equality of
     [t] and [u] up to existential variable instantiation and
     equalisable universes. The term [t] is interpreted in [evd] while
     [u] is interpreted in [extended_evd]. The universe constraints in
-    [extended_evd] are assumed to be an extension of those in [evd]. *)
+    [extended_evd] are assumed to be an extension of those in [evd].
+    Undefined evars are compared upto [eq_evar] *)
 val eq_constr_univs_test :
     evd:Evd.evar_map ->
     extended_evd:Evd.evar_map ->
+    eq_evar:(Evar.t -> Evar.t -> bool) ->
     constr ->
     constr ->
     bool

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -977,7 +977,6 @@ module Progress = struct
   let goal_equal ~evd ~extended_evd evar extended_evar =
     let EvarInfo evi = Evd.find evd evar in
     let EvarInfo extended_evi = Evd.find extended_evd extended_evar in
-    if Obj.magic evi == extended_evi then true else
     if not (Evar.equal evar extended_evar) && Evd.mem evd extended_evar then false else
     if fast_eq_evar_info evi extended_evi then
       eq_evar_info evd extended_evd evi extended_evi


### PR DESCRIPTION
Fixes / closes #21598
Alternate solution from #21599

This sets the specification for progress to the following:
Starting from goal `evk` living in evar map `evd`, there was progress in `evk'` living in evar map `evd'` if `evk` and `evk'` are not considered equal as goals;
`evk` and `evk'` are equal as goals if the following hold:
- *`evk` = `evk'`, or  `evk'` is **not** declared in `evd`*
- they are both undefined, or both defined to comparable* terms
- if undefined, they both have comparable* types
- if undefined, they live in comparable* *filtered* contexts

*Terms are considered comparable if they are α,evar,universe-equivalent where universe comparisons need only be consistent, and *evars are compared as goals (recursively)*

Changes from the current status of progress are *in italics*. This proposal compares in much greater depth, so it may be prohibitively slower. Also, the code is ugly, we could probably add some cache to remember some pairs since I imagine there are repetitions. Do not merge as-is.

Overlays:
- cross_crypto: not opened
- fcf: not opened
- bedrock2: not opened