### PR TITLE
Inline Inductive.abstract_constructor_type_relatively_to_inductive_types_context

### DIFF
--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -25,6 +25,17 @@ let check mind field b = if not b then raise (InductiveMismatch (mind,field))
 let template_univ_entry {template_context; template_defaults=default_univs; _} =
   Entries.Template_ind_entry {uctx = AbstractContext.repr template_context; default_univs}
 
+let abstract_constructor_type_relatively_to_inductive_types_context ntyps mind t =
+  let open Constr in
+  let rec replace_ind k c =
+    let hd, args = decompose_app c in
+    match kind hd with
+    | Ind ((mind',i),_) when MutInd.CanOrd.equal mind mind' ->
+       mkApp (mkRel (ntyps+k-i), Array.map (replace_ind k) args)
+    | _ -> map_with_binders succ replace_ind k c
+  in
+  replace_ind 0 t
+
 let to_entry mind (mb:mutual_inductive_body) : Entries.mutual_inductive_entry =
   let open Entries in
   let nparams = List.length mb.mind_params_ctxt in (* include letins *)
@@ -90,7 +101,7 @@ let to_entry mind (mb:mutual_inductive_body) : Entries.mutual_inductive_entry =
         mind_entry_arity;
         mind_entry_consnames = Array.to_list ind.mind_consnames;
         mind_entry_lc = Array.map_to_list (fun c ->
-            let c = Inductive.abstract_constructor_type_relatively_to_inductive_types_context ntyps mind c in
+            let c = abstract_constructor_type_relatively_to_inductive_types_context ntyps mind c in
             let ctx, c = Term.decompose_prod_n_decls nparams c in
             ignore ctx; (* we will check that the produced user_lc is equal to the input *)
             c

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -386,16 +386,6 @@ let arities_of_constructors (_,u) (_,mip) =
 let type_of_constructors (_,u) (_,mip) =
   Array.map (subst_instance_constr u) mip.mind_user_lc
 
-let abstract_constructor_type_relatively_to_inductive_types_context ntyps mind t =
-  let rec replace_ind k c =
-    let hd, args = decompose_app c in
-    match kind hd with
-    | Ind ((mind',i),_) when MutInd.CanOrd.equal mind mind' ->
-       mkApp (mkRel (ntyps+k-i), Array.map (replace_ind k) args)
-    | _ -> map_with_binders succ replace_ind k c
-  in
-  replace_ind 0 t
-
 (************************************************************************)
 
 (** Elimination functions *)

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -130,14 +130,6 @@ val arities_of_constructors : pinductive -> mind_specif -> types array
 (** Return constructor types in user form *)
 val type_of_constructors : pinductive -> mind_specif -> types array
 
-(** Turns a constructor type recursively referring to inductive types
-    into the same constructor type referring instead to a context made
-    from the abstract declaration of the inductive types (e.g. turns
-    [nat->nat] into [mkArrowR (Rel 1) (Rel 2)]); takes as arguments the number
-    of inductive types in the block and the name of the block *)
-val abstract_constructor_type_relatively_to_inductive_types_context :
-  int -> MutInd.t -> types -> types
-
 val inductive_params : mind_specif -> int
 
 (** Given an inductive type and its parameters, builds the context of the return


### PR DESCRIPTION
This function was only used once in the checker, and its name was horrendous enough for it to be blasted away.