### PR TITLE
Add a default bidirectional hint after params for record constructors

### DIFF
--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1099,7 +1099,7 @@ struct
              before typing the argument, so we replace it by an
              existential variable *)
           let sigma, c_hole = new_evar env sigma ~src:(loc,Evar_kinds.InternalHole) tycon in
-          sigma, c_hole, (c_hole, tycon, arg, trace) :: bidiargs
+          sigma, c_hole, (c_hole, tycon, arg, na, trace) :: bidiargs
         else
           let sigma, j = pretype (Some tycon) env sigma arg in
           sigma, j_val j, bidiargs
@@ -1183,18 +1183,19 @@ struct
       apply_rec env sigma arg_state body (subst,typ) args
     in
     let sigma, resj, otrace = inh_conv_coerce_to_tycon ?loc ~flags env sigma resj tycon in
-    let refine_arg (sigma,t) (newarg,ty,origarg,trace) =
+    let refine_arg (sigma,t) (newarg,ty,origarg,na,trace) =
       (* Refine an argument (originally `origarg`) represented by an evar
          (`newarg`) to use typing information from the context *)
       (* Type the argument using the expected type *)
       let sigma, j = pretype (Some ty) env sigma origarg in
+      let sigma, c = adjust_evar_source sigma na (j_val j) in
       (* Unify the (possibly refined) existential variable with the
          (typechecked) original value *)
-      let sigma = try Evarconv.unify_delay !!env sigma newarg (j_val j)
+      let sigma = try Evarconv.unify_delay !!env sigma newarg c
         with Evarconv.UnableToUnify (sigma,e) ->
-          raise (PretypeError (!!env,sigma,CannotUnify (newarg,j_val j,Some e)))
+          raise (PretypeError (!!env,sigma,CannotUnify (newarg,c,Some e)))
       in
-      sigma, Coercion.push_arg (Coercion.reapply_coercions_body sigma trace t) (j_val j)
+      sigma, Coercion.push_arg (Coercion.reapply_coercions_body sigma trace t) c
     in
     (* We now refine any arguments whose typing was delayed for
        bidirectionality *)

--- a/test-suite/bugs/bug_7825.v
+++ b/test-suite/bugs/bug_7825.v
@@ -18,8 +18,8 @@ Goal forall a : nat,  exists x, T x.
    (** Here ?x := ?x0 which is shelved, so ?x becomes shelved even if it would
    not be by default (refine ?x and _ produce non-shelved evars by default)*)
    simple refine (Build_T ?x _).
+   exact 0.
    reflexivity.
-   Unshelve. exact 0.
 Qed.
 
 Goal { A : _ & { P : _ & @sigT A P } }.

--- a/test-suite/output/InductiveMainName.out
+++ b/test-suite/output/InductiveMainName.out
@@ -25,5 +25,5 @@ Declared in library InductiveMainName, line 5, characters 23-28
 Record foo''' : Set := Build_foo''' { bar''' : nat } as id.
 
 foo''' has primitive projections with eta conversion.
-Arguments Build_foo''' bar'''%_nat_scope
+Arguments Build_foo''' & bar'''%_nat_scope
 Arguments bar''' id

--- a/test-suite/output/Projections.out
+++ b/test-suite/output/Projections.out
@@ -14,7 +14,7 @@ Record U (A : Type) (B : Type := A) (C : Type) : Type := Build_U
 
 U has primitive projections with eta conversion.
 Arguments U (A C)%_type_scope
-Arguments Build_U (A C)%_type_scope c b
+Arguments Build_U (A C)%_type_scope & c b
 Arguments c (A C)%_type_scope u
 Arguments a (A C)%_type_scope u
 Arguments b (A C)%_type_scope u

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -6,7 +6,7 @@ Record PWrap@{uu} (A : Type@{uu}) : Type@{uu} := pwrap
 
 PWrap has primitive projections with eta conversion.
 Arguments PWrap A%_type_scope
-Arguments pwrap A%_type_scope punwrap
+Arguments pwrap A%_type_scope & punwrap
 Arguments punwrap A%_type_scope p
 Record PWrap@{uu} (A : Type@{uu}) : Type@{uu} := pwrap
   { punwrap : A }.
@@ -14,14 +14,14 @@ Record PWrap@{uu} (A : Type@{uu}) : Type@{uu} := pwrap
 
 PWrap has primitive projections with eta conversion.
 Arguments PWrap A%_type_scope
-Arguments pwrap A%_type_scope punwrap
+Arguments pwrap A%_type_scope & punwrap
 Arguments punwrap A%_type_scope p
 Record RWrap@{uu} (A : Type@{uu}) : Type@{uu} := rwrap
   { runwrap : A }.
 (* uu |=  *)
 
 Arguments RWrap A%_type_scope
-Arguments rwrap A%_type_scope runwrap
+Arguments rwrap A%_type_scope & runwrap
 Arguments runwrap A%_type_scope r
 runwrap@{uu} =
 fun (A : Type@{uu}) (r : RWrap@{uu} A) => let (runwrap) := r in runwrap
@@ -100,7 +100,7 @@ Record PWrap@{E} (A : Type@{E}) : Type@{E} := pwrap
 
 PWrap has primitive projections with eta conversion.
 Arguments PWrap A%_type_scope
-Arguments pwrap A%_type_scope punwrap
+Arguments pwrap A%_type_scope & punwrap
 Arguments punwrap A%_type_scope p
 punwrap@{K} : forall A : Type@{K}, PWrap@{K} A -> A
 (* K |=  *)
@@ -226,10 +226,10 @@ Inductive MutualR1@{u} (A : Type@{u}) : Prop := Build_MutualR1
 (* u |=  *)
 
 Arguments MutualR1 A%_type_scope
-Arguments Build_MutualR1 A%_type_scope p1
+Arguments Build_MutualR1 A%_type_scope & p1
 Arguments p1 A%_type_scope m
 Arguments MutualR2 A%_type_scope
-Arguments Build_MutualR2 A%_type_scope p2
+Arguments Build_MutualR2 A%_type_scope & p2
 Arguments p2 A%_type_scope m
 Inductive MutualI1@{u u0} (A : Type@{u}) : Type@{u0} :=
     C1 : MutualI2@{u u0} A -> MutualI1@{u u0} A
@@ -248,10 +248,10 @@ CoInductive MutualR1'@{u} (A : Type@{u}) : Prop := Build_MutualR1'
 (* u |=  *)
 
 Arguments MutualR1' A%_type_scope
-Arguments Build_MutualR1' A%_type_scope p1'
+Arguments Build_MutualR1' A%_type_scope & p1'
 Arguments p1' A%_type_scope m
 Arguments MutualR2' A%_type_scope
-Arguments Build_MutualR2' A%_type_scope p2'
+Arguments Build_MutualR2' A%_type_scope & p2'
 Arguments p2' A%_type_scope m
 CoInductive MutualI1'@{u u0} (A : Type@{u}) : Type@{u0} :=
     C1' : MutualI2'@{u u0} A -> MutualI1'@{u u0} A

--- a/test-suite/output/sort_poly_elab.out
+++ b/test-suite/output/sort_poly_elab.out
@@ -946,12 +946,12 @@ Arguments sexists A%_type_scope B%_function_scope
 Expands to: Inductive sort_poly_elab.Records.sexists
 Declared in library sort_poly_elab, line 611, characters 12-19
 sexists_ind@{Type ;
-sort_poly_elab.396}
-     : forall (A : Type@{sort_poly_elab.396}) (B : forall _ : A, Prop)
+sort_poly_elab.395}
+     : forall (A : Type@{sort_poly_elab.395}) (B : forall _ : A, Prop)
          (P : Prop) (_ : forall (a : A) (_ : B a), P)
-         (_ : sexists@{Type ; sort_poly_elab.396} A B),
+         (_ : sexists@{Type ; sort_poly_elab.395} A B),
        P
-(* {sort_poly_elab.396} |=  *)
+(* {sort_poly_elab.395} |=  *)
 R8@{α α0 ; u} : Type@{α ; u+1}
 (* α α0 ; u |=  *)
 

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -47,6 +47,8 @@ let inBidiHints =
                    discharge_function = discharge_bidi_hints;
                  }
 
+let register_bidi_hints gr n =
+  Lib.add_leaf (inBidiHints (gr, n))
 
 let warn_arguments_assert =
   CWarnings.create ~name:"arguments-assert" ~category:CWarnings.CoreCategories.vernacular
@@ -313,14 +315,14 @@ let vernac_arguments ~section_local reference args more_implicits flags =
     if section_local then
       Pretyping.add_bidirectionality_hint env sr n
     else
-      Lib.add_leaf (inBidiHints (sr, Some n))
+      register_bidi_hints sr (Some n)
   end;
 
   if clear_bidi_hint then begin
     if section_local then
       Pretyping.clear_bidirectionality_hint env sr
     else
-      Lib.add_leaf (inBidiHints (sr, None))
+      register_bidi_hints sr None
   end;
 
   if not (renaming_specified ||

--- a/vernac/comArguments.mli
+++ b/vernac/comArguments.mli
@@ -8,6 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+val register_bidi_hints : Names.GlobRef.t -> int option -> unit
+
 val vernac_arguments
   : section_local:bool
   -> Libnames.qualid Constrexpr.or_by_notation

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -919,6 +919,16 @@ let declare_structure (decl:Record_decl.t) ~schemes =
       ~default_dep_elim
       ~schemes
   in
+  let nparams = Context.Rel.nhyps decl.entry.mie.mind_entry_params in
+  let () =
+    List.iteri (fun i ind_entry ->
+      let ind = kn, i in
+      List.iteri (fun j ctor_entry ->
+        let gr = GlobRef.ConstructRef (ind, succ j) in
+        ComArguments.register_bidi_hints gr (Some nparams))
+        ind_entry.mind_entry_lc)
+      decl.entry.mie.mind_entry_inds
+  in
   let map i ({ RecordEntry.inhabitant_id; implfs; fieldlocs }, { Data.is_coercion; proj_flags; }) =
     let rsp = (kn, i) in (* This is ind path of idstruc *)
     let cstr = (rsp, 1) in


### PR DESCRIPTION
Record constructors have type `∀ params, ∀args, I params` since records don't have indices.
Therefore, unification will not be better after all arguments than after only the params arguments, but conversely unification after only params can help typecheck the arguments.

That's why I propose to add a default bidirectional hint for all record constructors, to trigger after all parameter arguments.

Hopefully this is backwards compatible.