### PR TITLE
make invert case work for non-irrelevant sorts instead of only relevant ones

### DIFF
--- a/engine/univSubst.ml
+++ b/engine/univSubst.ml
@@ -151,7 +151,10 @@ let map_universes_opt_subst_with_binders next aux frel fqual funiv k c =
     let rel' = frel rel in
     let pms' = Array.Fun1.Smart.map aux k pms in
     let p' = aux_ctx p in
-    let iv' = map_invert (aux k) iv in
+    let iv' =
+      if Sorts.relevance_equal rel' Irrelevant then NoInvert
+      else map_invert (aux k) iv
+    in
     let t' = aux k t in
     let br' = Array.Smart.map aux_ctx br in
     if rel' == rel && u' == u && pms' == pms && p' == p && iv' == iv && t' == t && br' == br then c

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -346,12 +346,15 @@ let inject c = injectu c UVars.Instance.empty
 
 let mk_irrelevant = { mark = Cstr; term = FIrrelevant }
 
-let is_irrelevant info r = match info.i_cache.i_mode with
-| Reduction -> false
-| Conversion -> match r with
+let is_irrelevant0 info r =
+  match r with
   | Sorts.Irrelevant -> true
   | Sorts.RelevanceVar q -> info.i_cache.i_sigma.qvar_irrelevant q
   | Sorts.Relevant -> false
+
+let is_irrelevant info r = match info.i_cache.i_mode with
+| Reduction -> false
+| Conversion -> is_irrelevant0 info r
 
 let eq_quality info q1 q2 =
   info.i_cache.i_sigma.qual_equal q1 q2
@@ -1400,8 +1403,11 @@ and knht info e t stk =
       else
         knht info e t (ZcaseT(ci, u, pms, p, br, e)::stk)
     | Case(ci,u,pms,(_,r as p),CaseInvert{indices},t,br) ->
-      if is_irrelevant info (usubst_relevance e r) then
+      let ur = usubst_relevance e r in
+      if is_irrelevant info ur then
         (mk_irrelevant, skip_irrelevant_stack info stk)
+      else if is_irrelevant0 info ur then
+        knht info e t (ZcaseT(ci, u, pms, p, br, e)::stk)
       else
         let term = FCaseInvert (ci, u, pms, p, (Array.map (mk_clos e) indices), mk_clos e t, br, e) in
         { mark = Red; term }, stk

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -492,7 +492,7 @@ let check_branch_types env (_mib, mip) ci u pms c _ct lft (pctx, p) =
     error_ill_formed_branch env c ((ci.ci_ind, i + 1), u) brt expbrt
 
 let should_invert_case env r ci =
-  check_relevance env r Sorts.Relevant &&
+  not (check_relevance env r Sorts.Irrelevant) &&
   let mib,mip = lookup_mind_specif env ci.ci_ind in
   (* mind_relevance cannot be a pseudo sort poly variable so don't use check_relevance *)
   Sorts.relevance_equal mip.mind_relevance Sorts.Irrelevant &&

--- a/kernel/vars.ml
+++ b/kernel/vars.ml
@@ -309,10 +309,11 @@ let map_constr_relevance f c =
 
   | Case (ci,u,params,(ret,r),iv,v,brs) ->
     let r' = f r in
+    let iv' = if Sorts.relevance_equal r' Irrelevant then NoInvert else iv in
     let ret' = map_case_under_context_relevance f ret in
     let brs' = CArray.Smart.map (map_case_under_context_relevance f) brs in
-    if r' == r && ret' == ret && brs' == brs then c
-    else mkCase (ci,u,params,(ret',r'),iv,v,brs')
+    if r' == r && iv' == iv && ret' == ret && brs' == brs then c
+    else mkCase (ci,u,params,(ret',r'),iv',v,brs')
 
   | Fix data ->
     let data' = map_rec_declaration_relevance f data in

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -470,7 +470,7 @@ let nf_relevance sigma = function
   | (Sorts.Irrelevant | Sorts.Relevant) as r -> r
 
 let should_invert_case env sigma r (ci : Constr.case_info) =
-  Sorts.relevance_equal (nf_relevance sigma r) Sorts.Relevant &&
+  not (Sorts.relevance_equal (nf_relevance sigma r) Sorts.Irrelevant) &&
     let mib,mip = Inductive.lookup_mind_specif env ci.ci_ind in
     (* mind_relevance cannot be a pseudo sort poly variable so don't use check_relevance *)
     Sorts.relevance_equal mip.mind_relevance Sorts.Irrelevant &&

--- a/test-suite/bugs/bug_19070.v
+++ b/test-suite/bugs/bug_19070.v
@@ -1,0 +1,20 @@
+Set Definitional UIP.
+
+Inductive test : nat -> SProp := T : test 0.
+
+Polymorphic Definition bla@{s;+} (A:nat -> Type@{s;_}) (x:A 0) (y:nat) (e:test y) : A y
+  := match e with T => x end.
+
+Arguments bla /.
+
+Definition blo := Eval lazy in bla@{SProp;_}.
+Definition bli := Eval lazy in bla@{Type;_}.
+
+Definition blocbv := Eval cbv in bla@{SProp;_}.
+Definition blicbv := Eval cbv in bla@{Type;_}.
+
+Definition blosimpl := Eval simpl in bla@{SProp;_}.
+Definition blisimpl := Eval simpl in bla@{Type;_}.
+
+Definition blocbn := Eval cbn in bla@{SProp;_}.
+Definition blicbn := Eval cbn in bla@{Type;_}.

--- a/test-suite/bugs/bug_20016.v
+++ b/test-suite/bugs/bug_20016.v
@@ -1,0 +1,13 @@
+Set Definitional UIP.
+
+Inductive eq {A} (x : A) : A -> SProp := refl : eq x x.
+
+Definition cast {A B} (e : eq A B) (x : A) : B :=
+match e in eq _ C return C with refl _ => x end. (* Bad case inversion (maybe a bugged tactic). *)
+
+Polymorphic Definition pcast@{q|u|+} {A B:Type@{q|u}} (e : eq A B) (x : A) : B :=
+  match e in eq _ C return C with refl _ => x end.
+
+Definition cast0 := @pcast@{SProp|Set}.
+
+Definition cast0' := Eval lazy in cast0.

--- a/test-suite/bugs/bug_22042_1.v
+++ b/test-suite/bugs/bug_22042_1.v
@@ -1,0 +1,6 @@
+Set Definitional UIP.
+Inductive test : nat -> SProp := T : test 0.
+Axiom TT : SProp -> SProp.
+
+Definition blo (A : nat -> _) (x : A 0) (y:nat) (e:test y)
+  := let a := match e with T => x end in TT (A 0).

--- a/test-suite/success/sprop_uip_sort_poly.v
+++ b/test-suite/success/sprop_uip_sort_poly.v
@@ -1,0 +1,14 @@
+
+Set Definitional UIP.
+Set Universe Polymorphism.
+
+Inductive seq@{s;i} {A:Type@{s;i}} (a:A) : A -> SProp :=
+  srefl : seq a a.
+
+Definition transport@{s s'; i j} (A:Type@{s;i}) (P:A -> Type@{s';j}) {x y} (e:seq x y) (v:P x) : P y :=
+  match e with srefl _ => v end.
+
+Lemma test@{s s'; i j} (A:Type@{s;i}) (P:A -> Type@{s';j}) x t (e:seq x x) : seq (transport A P e t) t.
+Proof.
+  reflexivity.
+Defined.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->

This permits case_invert to apply to any non-irrelevant sort instead of only 
relevant ones. Thus treating sort variables as relevant for that purpose. 

That way, we can have generic sort poly lemma such as 

```rocq
Set Definitional UIP.
Set Universe Polymorphism.

Inductive seq@{s;i} {A:Type@{s;i}} (a:A) : A -> SProp :=
  srefl : seq a a.

Definition transport@{s s'; i j} (A:Type@{s;i}) (P:A -> Type@{s';j}) {x y} (e:seq x y) (v:P x) : P y :=
  match e with srefl _ => v end.

Lemma test@{s s'; i j} (A:Type@{s;i}) (P:A -> Type@{s';j}) x t (e:seq x x) : seq (transport A P e t) t.
Proof.
  reflexivity.
Defined.
```
