### PR TITLE
evarsolve: keep transitive dependencies of variables

### DIFF
--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1182,24 +1182,43 @@ let closure_of_filter ~can_drop evd evk = function
   | None -> None
   | Some filter ->
   let evi = Evd.find_undefined evd evk in
-  let vars = ref (collect_vars evd (evar_concl evi)) in
-  let test b decl =
-    let keep = b || Id.Set.mem (get_id decl) !vars ||
-                    match decl with
-                    | LocalAssum _ ->
-                       false
-                    | LocalDef (_,c,_) ->
-                       not (can_drop || isRel evd c || isVar evd c)
-    in
-    if keep then
-      iter_constr
-        (fun c -> vars := Id.Set.union (collect_vars evd c) !vars)
-        decl;
-    keep
+  let ctxt = evar_context evi in
+  let vars_of_decl decl =
+    fold_constr
+      (fun c vars -> Id.Set.union (collect_vars evd c) vars)
+      decl Id.Set.empty
   in
-  let newfilter = Filter.map_along test filter (evar_context evi) in
-  (* Now ensure that restriction is at least what is was originally *)
-  let newfilter = Option.cata (Filter.map_along (&&) newfilter) newfilter (Filter.repr (evar_filter evi)) in
+  (* Named contexts are ordered from innermost to outermost.  When keeping a
+     declaration, also keep the outer declarations mentioned by its body/type,
+     so the filtered context remains well-formed. *)
+  let rec close needed filter ctxt = match filter, ctxt with
+  | [], [] -> []
+  | b :: filter, decl :: ctxt ->
+    let keep = b || Id.Set.mem (get_id decl) needed ||
+               match decl with
+               | LocalAssum _ ->
+                  false
+               | LocalDef (_,c,_) ->
+                  not (can_drop || isRel evd c || isVar evd c)
+    in
+    let needed =
+      if keep then Id.Set.union needed (vars_of_decl decl)
+      else needed
+    in
+    keep :: close needed filter ctxt
+  | _ -> assert false
+  in
+  let filter =
+    Option.default (List.map (fun _ -> true) ctxt) (Filter.repr filter)
+  in
+  let needed = collect_vars evd (evar_concl evi) in
+  let newfilter = close needed filter ctxt in
+  (* Now ensure that restriction is at least what it was originally. *)
+  let newfilter = match Filter.repr (evar_filter evi) with
+  | None -> newfilter
+  | Some oldfilter -> List.map2 (fun b old -> b && old) newfilter oldfilter
+  in
+  let newfilter = Filter.make newfilter in
   if Filter.equal newfilter (evar_filter evi) then None else Some newfilter
 
 (* The filter is assumed to be at least stronger than the original one *)

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1183,14 +1183,16 @@ let closure_of_filter ~can_drop evd evk = function
   | Some filter ->
   let evi = Evd.find_undefined evd evk in
   let ctxt = evar_context evi in
-  let vars_of_decl decl =
+  let vars_of_kept_def = function
+  | LocalAssum _ -> Id.Set.empty
+  | LocalDef _ as decl ->
     fold_constr
       (fun c vars -> Id.Set.union (collect_vars evd c) vars)
       decl Id.Set.empty
   in
   (* Named contexts are ordered from innermost to outermost.  When keeping a
-     declaration, also keep the outer declarations mentioned by its body/type,
-     so the filtered context remains well-formed. *)
+     local definition, also keep the outer declarations mentioned by its
+     body/type, so the filtered context remains well-formed. *)
   let rec close needed filter ctxt = match filter, ctxt with
   | [], [] -> []
   | b :: filter, decl :: ctxt ->
@@ -1202,7 +1204,7 @@ let closure_of_filter ~can_drop evd evk = function
                   not (can_drop || isRel evd c || isVar evd c)
     in
     let needed =
-      if keep then Id.Set.union needed (vars_of_decl decl)
+      if keep then Id.Set.union needed (vars_of_kept_def decl)
       else needed
     in
     keep :: close needed filter ctxt

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1182,13 +1182,20 @@ let closure_of_filter ~can_drop evd evk = function
   | None -> None
   | Some filter ->
   let evi = Evd.find_undefined evd evk in
-  let vars = collect_vars evd (evar_concl evi) in
-  let test b decl = b || Id.Set.mem (get_id decl) vars ||
+  let vars = ref (collect_vars evd (evar_concl evi)) in
+  let test b decl =
+    let keep = b || Id.Set.mem (get_id decl) !vars ||
                     match decl with
                     | LocalAssum _ ->
                        false
                     | LocalDef (_,c,_) ->
                        not (can_drop || isRel evd c || isVar evd c)
+    in
+    if keep then
+      iter_constr
+        (fun c -> vars := Id.Set.union (collect_vars evd c) !vars)
+        decl;
+    keep
   in
   let newfilter = Filter.map_along test filter (evar_context evi) in
   (* Now ensure that restriction is at least what is was originally *)

--- a/test-suite/bugs/bug_20428.v
+++ b/test-suite/bugs/bug_20428.v
@@ -1,0 +1,81 @@
+Require Import Ltac2.Ltac2.
+Import Printf.
+Set Default Proof Mode "Classic".
+
+(* [Force] is normally used to turn an evar that is not eligible for typeclass
+   search into a (new) one that is eligible. *)
+Definition Force {T : Type} (_ : T) : Type := T.
+Hint Opaque Force : main.
+Existing Class Force.
+
+(* We create a new evar that is deemed eligible for TC search and unify that
+   with the existing evar. *)
+Hint Extern 0 (@Force ?T ?l) =>
+  assert_succeeds (idtac; is_evar l);
+  let f :=
+    ltac2:(x y |-
+      let x := Option.get (Ltac1.to_constr x) in
+      let y := Option.get (Ltac1.to_constr y) in
+      printf "before";
+      printf "x = %t" x;
+      printf "y = %t" y;
+      Unification.unify TransparentState.empty x y;
+      printf "after";
+      printf "x = %t" x;
+      printf "y = %t" y
+    )
+  in
+  (unshelve
+    let n := open_constr:(?[n] :> T) in
+    notypeclasses refine n);
+  f l ?n
+: main.
+
+(* A dummy class so that we have something to force. *)
+Class Foo  (P : Prop) := {}.
+(* We make searches for [Foo] fail in malformed contexts by calling [cbn] on all hypotheses. *)
+Hint Extern 0 (Foo _) => cbn in *; constructor : main.
+
+(* A definition that has more data than its body *)
+Definition Bar : forall {T}, T -> Type := fun _ _ => True.
+(* A "constructor" for [Bar] *)
+Definition mk : forall {T} (t : T), Bar t := fun _ _ => I.
+
+Goal True.
+Proof.
+  Set Printing Existential Instances.
+  (* We create two evars
+     1. ?x : [|- Foo False]
+     2. ?p : [a : unit; H := mk a : Bar a |- Force ?x]
+   *)
+  let x := open_constr:(?[x] :> Foo False) in
+  pose proof (a := tt);
+  pose (H := mk a);
+  unshelve epose proof (?[p] : Force x).
+  (* Creating a fresh evar ?n (in the bigger context) and unifying it with ?x
+  (no context) works fine. It is simply equated with ?x, i.e. the extended
+  context is no longer available to it. Just as expected.. *)
+  Succeed typeclasses eauto with main.
+  (*
+    before
+    x = ?x
+    y = ?n@{a:=a; H:=H}
+    after
+    x = ?x
+    y = ?x
+  *)
+  (* If we reduce [mk a] in H, unification goes terribly wrong: The fresh evar
+     has its context restricted to [H := I : Bar a]. Note that [a] is a dangling
+     reference. It is absent from the context.
+   *)
+  change (mk a) with I in H.
+  typeclasses eauto with main.
+  (*
+    before
+    x = ?x
+    y = ?n@{a:=a; H:=H}
+    after
+    x = ?n@{H:=I}
+    y = ?n@{H:=H}
+  *)
+Abort.

--- a/test-suite/success/bug_20428_minimal.v
+++ b/test-suite/success/bug_20428_minimal.v
@@ -1,0 +1,63 @@
+Require Import Ltac2.Ltac2.
+Import Printf.
+
+Set Default Proof Mode "Classic".
+
+(* A global transparent definition, made opaque while the evar context is
+   created so the assumption below keeps the dependency in its type.  There are
+   no local definitions with bodies in this example. *)
+Definition D {P : Prop} (_ : P) := unit.
+Opaque D.
+
+Ltac2 Type exn ::= [ DependencyWasNotPruned ].
+
+Goal forall (P : Prop) (p1 p2 p : P) (d : D p), True.
+Proof.
+  intros P p1 p2 p d.
+  Set Printing Existential Instances.
+
+  let e := open_constr:(?[e] : nat) in
+  let test := ltac2:(e p1 p2 |-
+    let e := Option.get (Ltac1.to_constr e) in
+    let p1 := Option.get (Ltac1.to_constr p1) in
+    let p2 := Option.get (Ltac1.to_constr p2) in
+    let rec dest_evar c :=
+      match Constr.Unsafe.kind c with
+      | Constr.Unsafe.Cast c _ _ => dest_evar c
+      | Constr.Unsafe.Evar ev args => (ev, args)
+      | _ => Control.throw Assertion_failure
+      end
+    in
+    match dest_evar e with
+    | (ev, args) =>
+      (* The evar context contains [...; p : P; d : D p].  Build the same
+         evar at two instances that differ only in the proof [p].  The [d]
+         argument is kept equal on both sides. *)
+      let args1 := Array.copy args in
+      let args2 := Array.copy args in
+      Array.set args1 1 p1;
+      Array.set args2 1 p2;
+      let x := Constr.Unsafe.make (Constr.Unsafe.Evar ev args1) in
+      let y := Constr.Unsafe.make (Constr.Unsafe.Evar ev args2) in
+      match Constr.Unsafe.check x with
+      | Val _ => ()
+      | Err _ => Control.throw Assertion_failure
+      end;
+      match Constr.Unsafe.check y with
+      | Val _ => ()
+      | Err _ => Control.throw Assertion_failure
+      end;
+
+      Unification.unify TransparentState.full x y;
+
+      (* On origin/master, restricting the evar drops [p], so [x] and [y]
+         become syntactically equal.  The new closure through LocalAssum types
+         keeps [p], so this check fails even though no local definition with a
+         body is involved. *)
+      printf "x = %t" x;
+      printf "y = %t" y;
+      if Constr.equal x y then () else Control.throw DependencyWasNotPruned
+    end
+  ) in
+  test e p1 p2.
+Abort.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

The place to insert the fix was found by GPT-5.5 ~~but the initial fix was way more verbose. The current fix is much smaller but the use of mutability looks tricky to me and probably only works when we assume something about `Filter.map_along`. Maybe somebody can come up with a better diff?~~

EDIT: I went with the more verbose version to make the code less tricky.

<details><summary>Initial fix</summary>

```
let closure_of_filter ~can_drop evd evk = function
  | None -> None
  | Some filter ->
  let evi = Evd.find_undefined evd evk in
  let ctxt = evar_context evi in
  let vars_of_decl decl =
    fold_constr
      (fun c vars -> Id.Set.union (collect_vars evd c) vars)
      decl Id.Set.empty
  in
  (* Named contexts are ordered from innermost to outermost.  When keeping a
     declaration, also keep the outer declarations mentioned by its body/type,
     so the filtered context remains well-formed. *)
  let rec close needed filter ctxt = match filter, ctxt with
  | [], [] -> []
  | b :: filter, decl :: ctxt ->
    let keep = b || Id.Set.mem (get_id decl) needed ||
               match decl with
               | LocalAssum _ ->
                  false
               | LocalDef (_,c,_) ->
                  not (can_drop || isRel evd c || isVar evd c)
    in
    let needed =
      if keep then Id.Set.union needed (vars_of_decl decl)
      else needed
    in
    keep :: close needed filter ctxt
  | _ -> assert false
  in
  let filter =
    Option.default (List.map (fun _ -> true) ctxt) (Filter.repr filter)
  in
  let needed = collect_vars evd (evar_concl evi) in
  let newfilter = close needed filter ctxt in
  (* Now ensure that restriction is at least what it was originally. *)
  let newfilter = match Filter.repr (evar_filter evi) with
  | None -> newfilter
  | Some oldfilter -> List.map2 (fun b old -> b && old) newfilter oldfilter
  in
  let newfilter = Filter.make newfilter in
  if Filter.equal newfilter (evar_filter evi) then None else Some newfilter
```

</details>

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #20428 


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
