### PR TITLE
Add Constr.map_with_full_binders to Ltac2

### DIFF
--- a/doc/changelog/06-Ltac2-language/22060-in-context-variants-Added.rst
+++ b/doc/changelog/06-Ltac2-language/22060-in-context-variants-Added.rst
@@ -1,0 +1,10 @@
+- **Added:**
+  `Constr.Unsafe.in_context`, `Constr.in_context_prod`, and
+  `Constr.in_context_letin` in Ltac2.
+  `Constr.Unsafe.in_context` is a primitive that extends the proof
+  context and returns a `binder * constr` pair.
+  `Constr.in_context`, `Constr.in_context_prod`, and
+  `Constr.in_context_letin` are wrappers that construct
+  `Lambda`, `Prod`, and `LetIn` terms respectively
+  (`#22060 <https://github.com/rocq-prover/rocq/pull/22060>`_,
+  by Jason Gross).

--- a/doc/changelog/06-Ltac2-language/22062-map-with-full-binders-Added.rst
+++ b/doc/changelog/06-Ltac2-language/22062-map-with-full-binders-Added.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  `Constr.map_with_full_binders` and `Constr.Unsafe.map_with_full_binders` in Ltac2,
+  which map a function on the immediate subterms of a constr, using
+  `Unsafe.in_context` to traverse under binders so that the mapped
+  function operates on well-typed terms in proper contexts
+  (`#22062 <https://github.com/rocq-prover/rocq/pull/22062>`_,
+  by Jason Gross).

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -769,6 +769,51 @@ let () =
   | _ ->
     throw Tac2ffi.err_notfocussed
 
+let () =
+  define "constr_unsafe_in_context" (ident @-> constr @-> option constr @-> thunk unit @-> tac (pair binder constr)) @@ fun id t body_opt c ->
+  Proofview.Goal.goals >>= function
+  | [gl] ->
+    gl >>= fun gl ->
+    let env = Proofview.Goal.env gl in
+    let sigma = Proofview.Goal.sigma gl in
+    let has_var =
+      try
+        let _ = Environ.lookup_named id env in
+        true
+      with Not_found -> false
+    in
+    if has_var then
+      Tacticals.tclZEROMSG (str "Variable already exists")
+    else
+      let open Context.Named.Declaration in
+      let sigma, t_rel =
+        let t_ty = Retyping.get_type_of env sigma t in
+        (* If the user passed eg ['_] for the type we force it to indeed be a type *)
+        let sigma, j = Typing.type_judgment env sigma {uj_val=t; uj_type=t_ty} in
+        sigma, EConstr.ESorts.relevance_of_sort j.utj_type
+      in
+      let annot = Context.make_annot id t_rel in
+      let sigma, nenv = match body_opt with
+        | None -> sigma, EConstr.push_named ProofVar (LocalAssum (annot, t)) env
+        | Some body ->
+          let sigma = Typing.check env sigma body t in
+          sigma, EConstr.push_named ProofVar (LocalDef (annot, body, t)) env
+      in
+      let (sigma, (evt, s)) = Evarutil.new_type_evar nenv sigma Evd.univ_flexible in
+      let relevance = EConstr.ESorts.relevance_of_sort s in
+      let (sigma, evk) = Evarutil.new_pure_evar (Environ.named_context_val nenv) sigma ~relevance evt in
+      Proofview.Unsafe.tclEVARS sigma >>= fun () ->
+      Proofview.Unsafe.tclSETGOALS [Proofview.with_empty_state evk] >>= fun () ->
+      thaw c >>= fun _ ->
+      Proofview.Unsafe.tclSETGOALS [Proofview.goal_with_state (Proofview.Goal.goal gl) (Proofview.Goal.state gl)] >>= fun () ->
+      let args = EConstr.identity_subst_val (Environ.named_context_val env) in
+      let args = SList.cons (EConstr.mkRel 1) args in
+      let ans = EConstr.mkEvar (evk, args) in
+      let binder_annot = Context.make_annot (Name id) t_rel in
+      return ((binder_annot, t), ans)
+  | _ ->
+    throw Tac2ffi.err_notfocussed
+
 (** preterm -> constr *)
 
 let () = define "constr_flags" (ret pretype_flags) constr_flags

--- a/test-suite/ltac2/in_context_variants.v
+++ b/test-suite/ltac2/in_context_variants.v
@@ -1,0 +1,86 @@
+Require Import Ltac2.Ltac2.
+Import Constr.Unsafe.
+
+(** Test Unsafe.in_context with None (LocalAssum) *)
+Goal True.
+  let r := Constr.Unsafe.in_context @x 'nat None (fun () =>
+    Control.refine (fun () => 'True)) in
+  let (b, body) := r in
+  (* Reconstruct Lambda to check the result *)
+  let c := make (Lambda b body) in
+  let expected := '(fun x : nat => True) in
+  if Constr.equal c expected then ()
+  else Control.throw (Invalid_argument (Some (Message.concat
+    (Message.of_string "Unsafe.in_context None: expected ")
+    (Message.concat (Message.of_constr expected)
+    (Message.concat (Message.of_string " but got ")
+    (Message.of_constr c))))));
+  exact I.
+Qed.
+
+(** Test Unsafe.in_context with Some (LocalDef) *)
+Goal True.
+  let r := Constr.Unsafe.in_context @x 'nat (Some '0) (fun () =>
+    Control.refine (fun () => 'True)) in
+  let (b, body) := r in
+  (* Reconstruct LetIn to check the result *)
+  let c := make (LetIn b '0 body) in
+  let expected := '(let x : nat := 0 in True) in
+  if Constr.equal c expected then ()
+  else Control.throw (Invalid_argument (Some (Message.concat
+    (Message.of_string "Unsafe.in_context Some: expected ")
+    (Message.concat (Message.of_constr expected)
+    (Message.concat (Message.of_string " but got ")
+    (Message.of_constr c))))));
+  exact I.
+Qed.
+
+(** Test in_context_prod *)
+Goal True.
+  let c := Constr.in_context_prod @x 'nat (fun () =>
+    Control.refine (fun () => 'True)) in
+  match kind c with
+  | Prod _ _ => ()
+  | _ => Control.throw (Invalid_argument (Some (Message.of_string "expected Prod")))
+  end;
+  (* Check that the result is [forall x : nat, True] *)
+  let expected := '(forall x : nat, True) in
+  if Constr.equal c expected then ()
+  else Control.throw (Invalid_argument (Some (Message.concat
+    (Message.of_string "in_context_prod: expected ")
+    (Message.concat (Message.of_constr expected)
+    (Message.concat (Message.of_string " but got ")
+    (Message.of_constr c))))));
+  exact I.
+Qed.
+
+(** Test in_context_letin *)
+Goal True.
+  let c := Constr.in_context_letin @x 'nat '0 (fun () =>
+    Control.refine (fun () => 'True)) in
+  match kind c with
+  | LetIn _ _ _ => ()
+  | _ => Control.throw (Invalid_argument (Some (Message.of_string "expected LetIn")))
+  end;
+  (* Check that the result is [let x : nat := 0 in True] *)
+  let expected := '(let x : nat := 0 in True) in
+  if Constr.equal c expected then ()
+  else Control.throw (Invalid_argument (Some (Message.concat
+    (Message.of_string "in_context_letin: expected ")
+    (Message.concat (Message.of_constr expected)
+    (Message.concat (Message.of_string " but got ")
+    (Message.of_constr c))))));
+  exact I.
+Qed.
+
+(** Test that in_context_letin makes the body available in the context *)
+Goal True.
+  let c := Constr.in_context_letin @x 'nat '0 (fun () =>
+    (* x should be definitionally equal to 0 *)
+    Control.refine (fun () => '(eq_refl : x = 0))) in
+  match kind c with
+  | LetIn _ _ _ => ()
+  | _ => Control.throw (Invalid_argument (Some (Message.of_string "expected LetIn")))
+  end;
+  exact I.
+Qed.

--- a/test-suite/ltac2/map_with_full_binders.v
+++ b/test-suite/ltac2/map_with_full_binders.v
@@ -1,0 +1,134 @@
+Require Import Ltac2.Ltac2.
+Import Constr.Unsafe.
+
+(** Helper: check two constrs are equal, raise informative error if not *)
+Local Ltac2 assert_constr_equal (msg : string) (expected : constr) (actual : constr) :=
+  if Constr.equal expected actual then ()
+  else Control.throw (Invalid_argument (Some (Message.concat
+    (Message.of_string msg)
+    (Message.concat (Message.of_string ": expected ")
+    (Message.concat (Message.of_constr expected)
+    (Message.concat (Message.of_string " but got ")
+    (Message.of_constr actual))))))).
+
+(** Test 1: identity map on various term shapes preserves the term *)
+Goal True.
+  (* Lambda *)
+  let c := '(fun x : nat => x) in
+  let c' := Constr.map_with_full_binders (fun x => x) c in
+  assert_constr_equal "Lambda identity" c c';
+
+  (* Prod *)
+  let c := '(forall x : nat, x = x) in
+  let c' := Constr.map_with_full_binders (fun x => x) c in
+  assert_constr_equal "Prod identity" c c';
+
+  (* LetIn *)
+  let c := '(let x : nat := 0 in x) in
+  let c' := Constr.map_with_full_binders (fun x => x) c in
+  assert_constr_equal "LetIn identity" c c';
+
+  (* App *)
+  let c := '(S (S O)) in
+  let c' := Constr.map_with_full_binders (fun x => x) c in
+  assert_constr_equal "App identity" c c';
+
+  (* Constant *)
+  let c := 'Nat.add in
+  let c' := Constr.map_with_full_binders (fun x => x) c in
+  assert_constr_equal "Constant identity" c c';
+
+  (* App of const *)
+  let c := '(negb true) in
+  let c' := Constr.map_with_full_binders (fun x => x) c in
+  assert_constr_equal "App of const identity" c c';
+
+  exact I.
+Qed.
+
+(** Test 2: mapping a transformation through Lambda *)
+Goal True.
+  let c := '(fun x : nat => x) in
+  let c' := Constr.map_with_full_binders (fun t =>
+    match Constr.equal t 'nat with
+    | true => 'bool
+    | false => t
+    end) c in
+  let expected := '(fun x : bool => x) in
+  assert_constr_equal "Lambda nat->bool" expected c';
+  exact I.
+Qed.
+
+(** Test 3: mapping a transformation through Prod *)
+Goal True.
+  (* Map on immediate subterms of a Prod: the binder type and the body.
+     Use a body that does not mention the binder variable so that
+     changing the binder type does not create a type mismatch. *)
+  let c := '(forall x : nat, True) in
+  let c' := Constr.map_with_full_binders (fun t =>
+    match Constr.equal t 'nat with
+    | true => 'bool
+    | false => t
+    end) c in
+  let expected := '(forall x : bool, True) in
+  assert_constr_equal "Prod nat->bool" expected c';
+  exact I.
+Qed.
+
+(** Test 4: mapping through LetIn *)
+Goal True.
+  let c := '(let x : nat := 0 in x) in
+  let c' := Constr.map_with_full_binders (fun t =>
+    match Constr.equal t '0 with
+    | true => '1
+    | false => t
+    end) c in
+  let expected := '(let x : nat := 1 in x) in
+  assert_constr_equal "LetIn 0->1" expected c';
+  exact I.
+Qed.
+
+(** Test 5: mapping through App *)
+Goal True.
+  let c := '(Nat.add 0 1) in
+  let c' := Constr.map_with_full_binders (fun t =>
+    match Constr.equal t '0 with
+    | true => '2
+    | false => t
+    end) c in
+  let expected := '(Nat.add 2 1) in
+  assert_constr_equal "App 0->2" expected c';
+  exact I.
+Qed.
+
+(** Test 6: mapping through Fix *)
+Goal True.
+  let c := '(fix add (n m : nat) : nat :=
+    match n with
+    | O => m
+    | S p => S (add p m)
+    end) in
+  let c' := Constr.map_with_full_binders (fun x => x) c in
+  assert_constr_equal "Fix identity" c c';
+  exact I.
+Qed.
+
+(** Test 7: non-recursive: f is applied only to immediate subterms *)
+Goal True.
+  (* For a Lambda, f is applied to the binder type and the body.
+     If we map nat->bool on (fun x : nat => (fun y : nat => y)),
+     only the outer nat and the body (fun y : nat => y) are touched.
+     The inner (fun y : nat => y) is not recursively processed. *)
+  let c := '(fun x : nat => (fun y : nat => y)) in
+  let c' := Constr.map_with_full_binders (fun t =>
+    match Constr.equal t 'nat with
+    | true => 'bool
+    | false => t
+    end) c in
+  (* Only the outer binder type nat should change to bool.
+     The body (fun y : nat => y) is passed to f which sees it as a whole
+     and since it's not equal to nat, it's returned unchanged. *)
+  let expected := '(fun x : bool => (fun y : nat => y)) in
+  assert_constr_equal "non-recursive Lambda" expected c';
+  exact I.
+Qed.

--- a/theories/Ltac2/Constr.v
+++ b/theories/Ltac2/Constr.v
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 Require Import Ltac2.Init.
-Require Ltac2.Ind Ltac2.Array.
+Require Ltac2.Ind Ltac2.Array Ltac2.Control Ltac2.Message Ltac2.Fresh Ltac2.List.
 
 Ltac2 @ external type : constr -> constr := "rocq-runtime.plugins.ltac2" "constr_type".
 (** Return the type of a term *)
@@ -437,6 +437,97 @@ Ltac2 @ external in_context : ident -> constr -> constr option -> (unit -> unit)
     a pair [(binder, t)] where [binder] is the binder and [t] is the proof
     built by the tactic. *)
 
+(** [map_with_full_binders f c] maps [f] on the immediate subterms of [c];
+    it uses [in_context] at each binder traversal;
+    it is not recursive and the order with which subterms are processed
+    is not specified. *)
+Ltac2 map_with_full_binders (f : constr -> constr) (c : constr) : constr :=
+  let default_name := @x in
+  let name_of (b : binder) : ident :=
+    match Binder.name b with
+    | Some id => id
+    | None => default_name
+    end
+  in
+  let fresh_name (b : binder) : ident :=
+    Fresh.in_goal (name_of b)
+  in
+  let map_under_lambda (b : binder) (body : constr) : constr :=
+    let bty' := f (Binder.type b) in
+    let id := fresh_name b in
+    let (b', body') := in_context id bty' None (fun () =>
+      let h := Control.hyp id in
+      Control.refine (fun () => f (substnl [h] 0 body))) in
+    make (Lambda b' body')
+  in
+  let map_under_prod (b : binder) (body : constr) : constr :=
+    let bty' := f (Binder.type b) in
+    let id := fresh_name b in
+    let (b', body') := in_context id bty' None (fun () =>
+      let h := Control.hyp id in
+      Control.refine (fun () => f (substnl [h] 0 body))) in
+    make (Prod b' body')
+  in
+  let map_under_letin (b : binder) (value : constr) (body : constr) : constr :=
+    let (bty', v') := (f (Binder.type b), f value) in
+    let id := fresh_name b in
+    let (b', body') := in_context id bty' (Some v') (fun () =>
+      let h := Control.hyp id in
+      Control.refine (fun () => f (substnl [h] 0 body))) in
+    make (LetIn b' v' body')
+  in
+  let map_under_fix_body (binders : binder array) (body : constr) : constr :=
+    let nbinders := Array.length binders in
+    let rec open_binders (i : int) (ids : ident list) : constr :=
+      if Int.ge i nbinders then
+        let hyps := List.map Control.hyp ids in
+        f (substnl hyps 0 body)
+      else
+        let b := Array.get binders i in
+        let id := fresh_name b in
+        let (_, result) := in_context id (Binder.type b) None (fun () =>
+          Control.refine (fun () =>
+            open_binders (Int.add i 1) (id :: ids))) in
+        result
+    in
+    open_binders 0 []
+  in
+  match kind c with
+  | Rel _ | Meta _ | Var _ | Sort _
+  | Constant _ _ | Ind _ _ | Constructor _ _
+  | Uint63 _ | Float _ | String _ => c
+  | Evar _ _ => c
+  | Cast v k ty =>
+      let (v', ty') := (f v, f ty) in
+      make (Cast v' k ty')
+  | Lambda b body => map_under_lambda b body
+  | Prod b body => map_under_prod b body
+  | LetIn b value body => map_under_letin b value body
+  | App head args =>
+      let (head', args') := (f head, Array.map f args) in
+      make (App head' args')
+  | Case ci (ret, rel) iv scrut branches =>
+      let (ret', scrut', branches') := (f ret, f scrut, Array.map f branches) in
+      make (Case ci (ret', rel) iv scrut' branches')
+  | Fix structs which types bodies =>
+      let types' := Array.map (fun b =>
+        Binder.make (Binder.name b) (f (Binder.type b))) types in
+      let bodies' := Array.init (Array.length bodies) (fun i =>
+        map_under_fix_body types' (Array.get bodies i)) in
+      make (Fix structs which types' bodies')
+  | CoFix which types bodies =>
+      let types' := Array.map (fun b =>
+        Binder.make (Binder.name b) (f (Binder.type b))) types in
+      let bodies' := Array.init (Array.length bodies) (fun i =>
+        map_under_fix_body types' (Array.get bodies i)) in
+      make (CoFix which types' bodies')
+  | Proj p r v =>
+      make (Proj p r (f v))
+  | Array u arr def ty =>
+      let (arr', def', ty') := (Array.map f arr, f def, f ty) in
+      make (Array u arr' def' ty')
+  end.
+
 End Unsafe.
 
 Module Cast.
@@ -471,6 +562,17 @@ Ltac2 in_context_letin (id : ident) (ty : constr) (defn : constr) (f : unit -> u
     [let id : ty := defn in t] where [t] is the proof built by the tactic.
     [id] is the bound variable name, [ty] is its type, and [defn] is its
     definition. *)
+
+(** [map_with_full_binders f c] maps [f] on the immediate subterms of [c];
+    it uses [in_context] at each binder traversal;
+    it is not recursive and the order with which subterms are processed
+    is not specified.
+    Checks the result with [Unsafe.check] and raises on failure. *)
+Ltac2 map_with_full_binders (f : constr -> constr) (c : constr) : constr :=
+  match Unsafe.check (Unsafe.map_with_full_binders f c) with
+  | Val c => c
+  | Err e => Control.zero e
+  end.
 
 Module Pretype.
   Module Flags.

--- a/theories/Ltac2/Constr.v
+++ b/theories/Ltac2/Constr.v
@@ -430,6 +430,13 @@ Ltac2 map_with_binders (lift : 'a -> binder -> 'a) (f : 'a -> constr -> constr) 
       make (Array u t def ty)
   end.
 
+Ltac2 @ external in_context : ident -> constr -> constr option -> (unit -> unit) -> binder * constr := "rocq-runtime.plugins.ltac2" "constr_unsafe_in_context".
+(** On a focused goal [Γ ⊢ A], [in_context id ty body_opt tac] evaluates [tac]
+    in a focused goal [Γ, id : ty ⊢ ?X] (when [body_opt] is [None]) or
+    [Γ, id : ty := body ⊢ ?X] (when [body_opt] is [Some body]) and returns
+    a pair [(binder, t)] where [binder] is the binder and [t] is the proof
+    built by the tactic. *)
+
 End Unsafe.
 
 Module Cast.
@@ -442,10 +449,28 @@ Module Cast.
 
 End Cast.
 
-Ltac2 @ external in_context : ident -> constr -> (unit -> unit) -> constr := "rocq-runtime.plugins.ltac2" "constr_in_context".
+Ltac2 in_context (id : ident) (ty : constr) (f : unit -> unit) : constr :=
+  let (b, body) := Unsafe.in_context id ty None f in
+  Unsafe.make (Unsafe.Lambda b body).
 (** On a focused goal [Γ ⊢ A], [in_context id c tac] evaluates [tac] in a
     focused goal [Γ, id : c ⊢ ?X] and returns [fun (id : c) => t] where [t] is
     the proof built by the tactic. *)
+
+Ltac2 in_context_prod (id : ident) (ty : constr) (f : unit -> unit) : constr :=
+  let (b, body) := Unsafe.in_context id ty None f in
+  Unsafe.make (Unsafe.Prod b body).
+(** On a focused goal [Γ ⊢ A], [in_context_prod id c tac] evaluates [tac] in a
+    focused goal [Γ, id : c ⊢ ?X] and returns [forall (id : c), t] where [t] is
+    the proof built by the tactic. *)
+
+Ltac2 in_context_letin (id : ident) (ty : constr) (defn : constr) (f : unit -> unit) : constr :=
+  let (b, body) := Unsafe.in_context id ty (Some defn) f in
+  Unsafe.make (Unsafe.LetIn b defn body).
+(** On a focused goal [Γ ⊢ A], [in_context_letin id ty defn tac] evaluates
+    [tac] in a focused goal [Γ, id : ty := defn ⊢ ?X] and returns
+    [let id : ty := defn in t] where [t] is the proof built by the tactic.
+    [id] is the bound variable name, [ty] is its type, and [defn] is its
+    definition. *)
 
 Module Pretype.
   Module Flags.


### PR DESCRIPTION
Adds the non-recursive `Constr.map_with_full_binders` to Ltac2:

```
Ltac2 map_with_full_binders (f : constr -> constr) (c : constr) : constr
```

It maps `f` over a constr's immediate subterms while using `in_context` / `in_context_letin` beneath binders, so `f` receives well-typed terms in the proper contexts. The caller controls recursion by passing a recursive `f`.

For `Lambda` and `Prod`, it opens the binder before mapping the body; for `LetIn`, it opens the let binding. For `Fix` and `CoFix`, it opens all mutual binders before processing each body. It also maps the sub-constrs of `App`, `Cast`, `Case`, `Proj`, and `Array`; leaf constructors remain unchanged.

The name follows OCaml's `map_constr_with_full_binders` in `termops.ml`, unlike `Constr.map_with_binders`, which operates with a de Bruijn shift. Stacked on #22060 (`Constr.in_context_prod` and `Constr.in_context_letin`).

`test-suite/ltac2/map_with_full_binders.v` covers identity mapping and transformations through `Lambda`, `Prod`, `LetIn`, `App`, and `Fix`.

🤖 Generated with [Claude Code](https://claude.ai/code)

Wordsmithed by Codex.
