### PR TITLE
Slightly less nonsensical term equality test in progress tactical.

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -806,16 +806,16 @@ let eq_constr_univs_test ~evd ~extended_evd t u =
   let open Evd in
   let t = EConstr.Unsafe.to_constr t
   and u = EConstr.Unsafe.to_constr u in
-  let sigma = ref extended_evd in
+  let sigma = extended_evd in
   let eq_universes _ u1 u2 =
-    let u1 = EConstr.EInstance.(kind !sigma (make u1)) in
-    let u2 = EConstr.EInstance.(kind !sigma (make u2)) in
-    let check_qeq q1 q2 = UState.check_eq_quality (Evd.ustate !sigma) q1 q2 in
-    UGraph.check_eq_instances check_qeq (universes !sigma) u1 u2
+    let u1 = EConstr.EInstance.(kind sigma (make u1)) in
+    let u2 = EConstr.EInstance.(kind sigma (make u2)) in
+    let check_qeq q1 q2 = UState.check_eq_quality (Evd.ustate sigma) q1 q2 in
+    UGraph.check_eq_instances check_qeq (universes sigma) u1 u2
   in
   let eq_sorts s1 s2 =
     if Sorts.equal s1 s2 then true
-    else Sorts.equal (EConstr.ESorts.(kind !sigma (make s1))) (EConstr.ESorts.(kind !sigma (make s2)))
+    else Sorts.equal (EConstr.ESorts.(kind sigma (make s1))) (EConstr.ESorts.(kind sigma (make s2)))
   in
   let eq_existential eq e1 e2 =
     let eq c1 c2 = eq 0 (EConstr.Unsafe.to_constr c1) (EConstr.Unsafe.to_constr c2) in

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -815,9 +815,7 @@ let eq_constr_univs_test ~evd ~extended_evd t u =
   in
   let eq_sorts s1 s2 =
     if Sorts.equal s1 s2 then true
-    else
-      try sigma := add_constraints !sigma UnivProblem.(Set.singleton (UEq (s1, s2))); true
-      with UGraph.UniverseInconsistency _ | UniversesDiffer -> false
+    else Sorts.equal (EConstr.ESorts.(kind !sigma (make s1))) (EConstr.ESorts.(kind !sigma (make s2)))
   in
   let eq_existential eq e1 e2 =
     let eq c1 c2 = eq 0 (EConstr.Unsafe.to_constr c1) (EConstr.Unsafe.to_constr c2) in

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -789,20 +789,18 @@ let compare_constructor_instances evd u u' =
 
 (** [eq_constr_univs_test ~evd ~extended_evd t u] tests equality of
     [t] and [u] up to existential variable instantiation and
-    equalisable universes. The term [t] is interpreted in [evd] while
+    equal universes. The term [t] is interpreted in [evd] while
     [u] is interpreted in [extended_evd]. The universe constraints in
     [extended_evd] are assumed to be an extension of those in [evd]. *)
 let eq_constr_univs_test ~evd ~extended_evd t u =
   (* spiwack: mild code duplication with {!Evd.eq_constr_univs}. *)
-  let open Evd in
   let t = EConstr.Unsafe.to_constr t
   and u = EConstr.Unsafe.to_constr u in
   let sigma = extended_evd in
   let eq_universes _ u1 u2 =
     let u1 = EConstr.EInstance.(kind sigma (make u1)) in
     let u2 = EConstr.EInstance.(kind sigma (make u2)) in
-    let check_qeq q1 q2 = UState.check_eq_quality (Evd.ustate sigma) q1 q2 in
-    UGraph.check_eq_instances check_qeq (universes sigma) u1 u2
+    UVars.Instance.equal u1 u2
   in
   let eq_sorts s1 s2 =
     if Sorts.equal s1 s2 then true

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -797,16 +797,16 @@ let eq_constr_univs_test ~evd ~extended_evd t u =
   let open Evd in
   let t = EConstr.Unsafe.to_constr t
   and u = EConstr.Unsafe.to_constr u in
-  let sigma = ref extended_evd in
+  let sigma = extended_evd in
   let eq_universes _ u1 u2 =
-    let u1 = EConstr.EInstance.(kind !sigma (make u1)) in
-    let u2 = EConstr.EInstance.(kind !sigma (make u2)) in
-    let check_qeq q1 q2 = UState.check_eq_quality (Evd.ustate !sigma) q1 q2 in
-    UGraph.check_eq_instances check_qeq (universes !sigma) u1 u2
+    let u1 = EConstr.EInstance.(kind sigma (make u1)) in
+    let u2 = EConstr.EInstance.(kind sigma (make u2)) in
+    let check_qeq q1 q2 = UState.check_eq_quality (Evd.ustate sigma) q1 q2 in
+    UGraph.check_eq_instances check_qeq (universes sigma) u1 u2
   in
   let eq_sorts s1 s2 =
     if Sorts.equal s1 s2 then true
-    else Sorts.equal (EConstr.ESorts.(kind !sigma (make s1))) (EConstr.ESorts.(kind !sigma (make s2)))
+    else Sorts.equal (EConstr.ESorts.(kind sigma (make s1))) (EConstr.ESorts.(kind sigma (make s2)))
   in
   let eq_existential eq e1 e2 =
     let eq c1 c2 = eq 0 (EConstr.Unsafe.to_constr c1) (EConstr.Unsafe.to_constr c2) in

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -806,9 +806,7 @@ let eq_constr_univs_test ~evd ~extended_evd t u =
   in
   let eq_sorts s1 s2 =
     if Sorts.equal s1 s2 then true
-    else
-      try sigma := add_constraints !sigma UnivProblem.(Set.singleton (UEq (s1, s2))); true
-      with UGraph.UniverseInconsistency _ | UniversesDiffer -> false
+    else Sorts.equal (EConstr.ESorts.(kind !sigma (make s1))) (EConstr.ESorts.(kind !sigma (make s2)))
   in
   let eq_existential eq e1 e2 =
     let eq c1 c2 = eq 0 (EConstr.Unsafe.to_constr c1) (EConstr.Unsafe.to_constr c2) in


### PR DESCRIPTION
For what seems to amount to historical reasons, the progress tactical considered that two unifiable sorts were equal and thus not resulting in a progress. This is very weird and unlike the corresponding treatment of instances. A quick blame indicates that the intended behaviour may have been to *check* quotient by universe unification through the evarmap, which is weaker than *enforcing* this quotient. This commit precisely does that and makes the sort code behave like the instance code.