### PR TITLE
Detect progress in a more specified manner

### DIFF
--- a/dev/ci/user-overlays/22072-Yann-Leray-progress-bisimilar.sh
+++ b/dev/ci/user-overlays/22072-Yann-Leray-progress-bisimilar.sh
@@ -1,0 +1,4 @@
+overlay bedrock2 https://github.com/Yann-Leray/bedrock2 progress-bisimilar 22072
+# Make PRs against https://github.com/mit-plv/bedrock2 base branch master
+
+overlay hott https://github.com/Yann-Leray/Coq-HoTT progress-bisimilar 22072

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -783,37 +783,3 @@ let compare_constructor_instances evd u u' =
         Set.empty us us'
     in
     Inl (Evd.add_constraints evd soft)
-
-(** [eq_constr_univs_test ~evd ~extended_evd t u] tests equality of
-    [t] and [u] up to existential variable instantiation and
-    equalisable universes. The term [t] is interpreted in [evd] while
-    [u] is interpreted in [extended_evd]. The universe constraints in
-    [extended_evd] are assumed to be an extension of those in [evd]. *)
-let eq_constr_univs_test ~evd ~extended_evd t u =
-  (* spiwack: mild code duplication with {!Evd.eq_constr_univs}. *)
-  let open Evd in
-  let t = EConstr.Unsafe.to_constr t
-  and u = EConstr.Unsafe.to_constr u in
-  let sigma = ref extended_evd in
-  let eq_universes _ u1 u2 =
-    let u1 = EConstr.EInstance.(kind !sigma (make u1)) in
-    let u2 = EConstr.EInstance.(kind !sigma (make u2)) in
-    let check_qeq q1 q2 = UState.check_eq_quality (Evd.ustate !sigma) q1 q2 in
-    UGraph.check_eq_instances check_qeq (universes !sigma) u1 u2
-  in
-  let eq_sorts s1 s2 =
-    if Sorts.equal s1 s2 then true
-    else
-      try sigma := add_constraints !sigma UnivProblem.(Set.singleton (UEq (s1, s2))); true
-      with UGraph.UniverseInconsistency _ | UniversesDiffer -> false
-  in
-  let eq_existential eq e1 e2 =
-    let eq c1 c2 = eq 0 (EConstr.Unsafe.to_constr c1) (EConstr.Unsafe.to_constr c2) in
-    EConstr.eq_existential evd eq (EConstr.of_existential e1) (EConstr.of_existential e2)
-  in
-  let kind1 = kind_of_term_upto evd in
-  let kind2 = kind_of_term_upto extended_evd in
-  let rec eq_constr' nargs m n =
-    Constr.compare_head_gen_with kind1 kind2 eq_universes eq_sorts (eq_existential eq_constr') eq_constr' nargs m n
-  in
-  Constr.compare_head_gen_with kind1 kind2 eq_universes eq_sorts (eq_existential eq_constr') eq_constr' 0 t u

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -149,18 +149,6 @@ val finalize : ?abort_on_undefined_evars:bool -> ?poly:PolyFlags.t -> evar_map -
 val kind_of_term_upto : evar_map -> Constr.constr ->
   (Constr.constr, Constr.types, Sorts.t, UVars.Instance.t, Sorts.relevance) kind_of_term
 
-(** [eq_constr_univs_test ~evd ~extended_evd t u] tests equality of
-    [t] and [u] up to existential variable instantiation and
-    equalisable universes. The term [t] is interpreted in [evd] while
-    [u] is interpreted in [extended_evd]. The universe constraints in
-    [extended_evd] are assumed to be an extension of those in [evd]. *)
-val eq_constr_univs_test :
-    evd:Evd.evar_map ->
-    extended_evd:Evd.evar_map ->
-    constr ->
-    constr ->
-    bool
-
 (** [compare_cumulative_instances cv_pb variance u1 u2 sigma] Returns
    [Inl sigma'] where [sigma'] is [sigma] augmented with universe
    constraints such that [u1 cv_pb? u2] according to [variance].

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -909,11 +909,64 @@ let give_up =
 
 module Progress = struct
 
-  let eq_constr evd extended_evd =
-    Evarutil.eq_constr_univs_test ~evd ~extended_evd
+  (** [eq_constr_upto eq_evar sigma1 sigma2 t u] tests equality of
+      [t] and [u] up to existential variable instantiation. The term
+      [t] is interpreted in [sigma1] while [u] is interpreted in [sigma2]. *)
+  let eq_constr_upto eq_evar sigma1 sigma2 t u =
+    (* spiwack: mild code duplication with {!Evd.eq_constr_univs}. *)
+    let t = EConstr.Unsafe.to_constr t
+    and u = EConstr.Unsafe.to_constr u in
+    let kind1 = EConstr.kind_upto sigma1
+    and kind2 = EConstr.kind_upto sigma2 in
+    let is_flexible_qvar sigma = function Sorts.Quality.QVar q -> not (Evd.is_rigid_qvar sigma q) | _ -> false in
+    let eq_universes _ u1 u2 =
+      let u1 = EConstr.EInstance.(kind sigma1 (make u1)) in
+      let u2 = EConstr.EInstance.(kind sigma2 (make u2)) in
+      let open UVars.Instance in
+      if is_empty u1 && is_empty u2 then true
+      else if not (UVars.eq_sizes (length u1) (length u2)) then false
+      else
+        let (q1, l1) = to_array u1 and (q2, l2) = to_array u2 in
+        Array.equal (fun q1 q2 -> match is_flexible_qvar sigma1 q1, is_flexible_qvar sigma2 q2 with
+          | true, true -> true
+          | true, false | false, true -> false
+          | false, false -> Sorts.Quality.equal q1 q2)
+          q1 q2 &&
+        Array.equal (fun l1 l2 -> match Evd.is_flexible_level sigma1 l1, Evd.is_flexible_level sigma2 l2 with
+          | true, true -> true
+          | true, false | false, true -> false
+          | false, false -> Univ.Level.equal l1 l2)
+          l1 l2
+    in
+    let eq_sorts s1 s2 =
+      let s1 = EConstr.ESorts.(kind sigma1 (make s1)) in
+      let s2 = EConstr.ESorts.(kind sigma2 (make s2)) in
+      let open Sorts in
+      let q1 = quality s1 and q2 = quality s2 in
+      let l1 = Sorts.levels s1 and l2 = Sorts.levels s2 in
+      begin match is_flexible_qvar sigma1 q1, is_flexible_qvar sigma2 q2 with
+      | true, true -> true
+      | true, false | false, true -> false
+      | false, false -> Sorts.Quality.equal q1 q2
+      end &&
+      match Univ.Level.Set.exists (fun l -> Evd.is_flexible_level sigma1 l) l1, Univ.Level.Set.exists (fun l -> Evd.is_flexible_level sigma2 l) l2 with
+      | true, true -> true
+      | true, false | false, true -> false
+      | false, false -> Univ.Universe.equal (univ_of_sort s1) (univ_of_sort s2)
+    in
+    let rec eq_existential (evk1, _ as ev1) (evk2, _ as ev2) =
+      eq_evar evk1 evk2 &&
+      let args1 = Evd.expand_existential0 sigma1 ev1 in
+      let args2 = Evd.expand_existential0 sigma2 ev2 in
+      List.for_all2eq eq_constr args1 args2
+    and eq_constr_nargs nargs m n =
+      Constr.compare_head_gen_with kind1 kind2 eq_universes eq_sorts eq_existential eq_constr_nargs nargs m n
+    and eq_constr m n = eq_constr_nargs 0 m n
+    in
+    eq_constr t u
 
   (** equality function on hypothesis contexts *)
-  let eq_named_context_val sigma1 sigma2 ctx1 ctx2 =
+  let eq_named_context_val eq_evar sigma1 sigma2 ctx1 ctx2 =
     let r_eq _ _ = true (* ignore relevances *) in
     let c1 = EConstr.named_context_of_val ctx1 and c2 = EConstr.named_context_of_val ctx2 in
     (* should we check variable status? if x is secvar,
@@ -923,34 +976,34 @@ module Progress = struct
     let eq_named_declaration d1 d2 =
       match d1, d2 with
       | LocalAssum (i1,t1), LocalAssum (i2,t2) ->
-        Context.eq_annot Names.Id.equal r_eq i1 i2 && eq_constr sigma1 sigma2 t1 t2
+        Context.eq_annot Names.Id.equal r_eq i1 i2 && eq_constr_upto eq_evar sigma1 sigma2 t1 t2
       | LocalDef (i1,c1,t1), LocalDef (i2,c2,t2) ->
-        Context.eq_annot Names.Id.equal r_eq i1 i2 && eq_constr sigma1 sigma2 c1 c2 &&
-        eq_constr sigma1 sigma2 t1 t2
+        Context.eq_annot Names.Id.equal r_eq i1 i2 && eq_constr_upto eq_evar sigma1 sigma2 c1 c2 &&
+        eq_constr_upto eq_evar sigma1 sigma2 t1 t2
       | _ ->
         false
     in
     (* NB: can't use List.equal because it shortcuts on physical equality *)
     List.for_all2eq eq_named_declaration c1 c2
 
-  let eq_evar_body (type a1 a2) sigma1 sigma2 (b1 : a1 Evd.evar_body) (b2 : a2 Evd.evar_body) =
+  let eq_evar_body (type a1 a2) eq_evar sigma1 sigma2 (b1 : a1 Evd.evar_body) (b2 : a2 Evd.evar_body) =
     let open Evd in
     match b1, b2 with
     | Evar_empty, Evar_empty -> true
-    | Evar_defined t1, Evar_defined t2 -> eq_constr sigma1 sigma2 t1 t2
+    | Evar_defined t1, Evar_defined t2 -> eq_constr_upto eq_evar sigma1 sigma2 t1 t2
     | _ -> false
 
-  let eq_evar_concl (type a1 a2) sigma1 sigma2 (e1 : a1 Evd.evar_info) (e2 : a2 Evd.evar_info) =
+  let eq_evar_concl (type a1 a2) eq_evar sigma1 sigma2 (e1 : a1 Evd.evar_info) (e2 : a2 Evd.evar_info) =
     let open Evd in
     match Evd.evar_body e1, Evd.evar_body e2 with
-    | Evar_empty, Evar_empty -> eq_constr sigma1 sigma2 (Evd.evar_concl e1) (Evd.evar_concl e2)
+    | Evar_empty, Evar_empty -> eq_constr_upto eq_evar sigma1 sigma2 (Evd.evar_concl e1) (Evd.evar_concl e2)
     | Evar_defined _, Evar_defined _ -> true
     | _ -> false
 
-  let eq_evar_info sigma1 sigma2 ei1 ei2 =
-    eq_evar_concl sigma1 sigma2 ei1 ei2 &&
-    eq_named_context_val sigma1 sigma2 (Evd.evar_hyps ei1) (Evd.evar_hyps ei2) &&
-    eq_evar_body sigma1 sigma2 (Evd.evar_body ei1) (Evd.evar_body ei2)
+  let eq_evar_info eq_evar sigma1 sigma2 ei1 ei2 =
+    eq_evar_concl eq_evar sigma1 sigma2 ei1 ei2 &&
+    eq_named_context_val eq_evar sigma1 sigma2 (Evd.evar_hyps ei1) (Evd.evar_hyps ei2) &&
+    eq_evar_body eq_evar sigma1 sigma2 (Evd.evar_body ei1) (Evd.evar_body ei2)
 
   let fast_eq_evar_body (type a1 a2) (e1 : a1 Evd.evar_info) (e2 : a2 Evd.evar_info) =
     let open Evd in
@@ -977,13 +1030,40 @@ module Progress = struct
     fast_eq_named_context_val (Evd.evar_hyps ei1) (Evd.evar_hyps ei2)
 
   (** Equality function on goals *)
-  let goal_equal ~evd ~extended_evd evar extended_evar =
-    let EvarInfo evi = Evd.find evd evar in
-    let EvarInfo extended_evi = Evd.find extended_evd extended_evar in
-    if fast_eq_evar_info evi extended_evi then
-      eq_evar_info evd extended_evd evi extended_evi
+  let goal_equal eq_evar sigma1 sigma2 evk1 evk2 =
+    let EvarInfo evi1 = Evd.find sigma1 evk1 in
+    let EvarInfo evi2 = Evd.find sigma2 evk2 in
+    if fast_eq_evar_info evi1 evi2 then
+      eq_evar_info eq_evar sigma1 sigma2 evi1 evi2
     else false
 
+  let same_goals evd extended_evd init_goals final_goals =
+    List.same_length init_goals final_goals &&
+    let assoc_for = ref Evar.Map.empty in
+    let assoc_back = ref Evar.Map.empty in
+    let rec eq evk evk' =
+      match Evar.Map.find_opt evk !assoc_for, Evar.Map.find_opt evk' !assoc_back with
+      | Some evk1, Some evk2 when Evar.equal evk' evk1 && Evar.equal evk evk2 -> true
+      | Some _, _ | _, Some _ -> false
+      | None, None ->
+        assoc_for := Evar.Map.add evk evk' !assoc_for;
+        assoc_back := Evar.Map.add evk' evk !assoc_back;
+        goal_equal eq evd extended_evd evk evk'
+    in
+    let () = List.iter2 (fun evk evk' ->
+        assoc_for := Evar.Map.add evk evk' !assoc_for;
+        assoc_back := Evar.Map.add evk' evk !assoc_back
+      ) init_goals final_goals
+    in
+    List.for_all2 (fun evk evk' -> goal_equal eq evd extended_evd evk evk') init_goals final_goals
+
+  let progress initial final =
+    if Evd.defined_map initial.solution == Evd.defined_map final.solution && initial.comb == final.comb
+    then false
+    else
+      let init_goals = List.map drop_state initial.comb in
+      let final_goals = List.map drop_state final.comb in
+      not (same_goals initial.solution final.solution init_goals final_goals)
 end
 
 let tclPROGRESS t =
@@ -991,20 +1071,8 @@ let tclPROGRESS t =
   Pv.get >>= fun initial ->
   t >>= fun res ->
   Pv.get >>= fun final ->
-  (* [*_test] test absence of progress. [quick_test] is approximate
-     whereas [exhaustive_test] is complete. *)
-  let quick_test =
-    Evd.defined_map initial.solution == Evd.defined_map final.solution && initial.comb == final.comb
-  in
-  let test =
-    quick_test ||
-    (CList.same_length initial.comb final.comb &&
-    Util.List.for_all2eq begin fun i f ->
-      Progress.goal_equal ~evd:initial.solution
-        ~extended_evd:final.solution (drop_state i) (drop_state f)
-    end initial.comb final.comb)
-  in
-  if not test then
+  let progress = Progress.progress initial final in
+  if progress then
     tclUNIT res
   else
     let info = Exninfo.reify () in

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -422,17 +422,15 @@ val give_up : unit tactic
 val tclPROGRESS : 'a tactic -> 'a tactic
 
 module Progress : sig
-(** [goal_equal ~evd ~extended_evd evar extended_evar] tests whether
-    the [evar_info] from [evd] corresponding to [evar] is equal to that
-    from [extended_evd] corresponding to [extended_evar], up to
-    existential variable instantiation and equalisable universes. The
-    universe constraints in [extended_evd] are assumed to be an
-    extension of the universe constraints in [evd]. *)
-  val goal_equal :
-    evd:Evd.evar_map ->
-    extended_evd:Evd.evar_map ->
-    Evar.t ->
-    Evar.t ->
+(** [same_goals evd extended_evd init_goals final_goals] tests whether
+    the goals in both lits are one-to-one indistinguishable.
+    Goals in [init_goals] live in [evd] whereas goals in [final_goals]
+    live in [extended_evd]. *)
+  val same_goals :
+    Evd.evar_map ->
+    Evd.evar_map ->
+    Evar.t list ->
+    Evar.t list ->
     bool
 end
 

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -217,8 +217,8 @@ let tclNOTSAMEGOAL tac =
     Proofview.Goal.goals >>= fun gls ->
     let check accu gl' =
       gl' >>= fun gl' ->
-      let accu = accu || Proofview.Progress.goal_equal
-                            ~evd:sigma ~extended_evd:(Proofview.Goal.sigma gl') ev (goal gl')
+      let accu = accu ||
+        Proofview.Progress.same_goals sigma (Proofview.Goal.sigma gl') [ev] [goal gl']
       in
       Proofview.tclUNIT accu
     in


### PR DESCRIPTION
Fixes / closes #21598
Yet another solution different from #21599 and #21650

Goals are compared as in a bisimulation, but we also mandate injectivity (as-in, an evar can only be related to one other evar). Quality and universe comparisons are approximated to: if flexible then similar else equal.
