### PR TITLE
Add Set Printing Sorts option

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/22155-printing-sorts-Added.rst
+++ b/doc/changelog/08-vernac-commands-and-options/22155-printing-sorts-Added.rst
@@ -1,0 +1,9 @@
+- **Added:**
+  Added ``Printing Sorts`` flag, which displays sort variables that are
+  otherwise hidden (e.g. ``Type@{s;_}``) as well as universe instances
+  carrying sort qualities, with universe level variables replaced by ``_``,
+  making the sort structure visible without exposing internal universe
+  level names
+  (`#22155 <https://github.com/rocq-prover/rocq/pull/22155>`_,
+  fixes `#22153 <https://github.com/rocq-prover/rocq/issues/22153>`_,
+  by Jason Gross).

--- a/doc/sphinx/addendum/universe-polymorphism.rst
+++ b/doc/sphinx/addendum/universe-polymorphism.rst
@@ -596,6 +596,18 @@ Printing universes
    terms apparently identical but internally different in the Calculus of Inductive
    Constructions.
 
+.. flag:: Printing Sorts
+
+   Turn this :term:`flag` on to display sort variables that are otherwise
+   hidden, with universe level variables replaced by ``_``.  Sorts without
+   sort variables (:g:`Type`, :g:`SProp`, :g:`Prop`, :g:`Set`) are printed
+   as usual, while sorts at a sort variable are printed like ``Type@{s;_}``
+   (or ``Type@{_}`` when :flag:`Printing Sort Qualities` is off).  Universe
+   instances of polymorphic references are displayed when they contain sort
+   qualities (with ``_`` in place of the universe levels) and stay hidden
+   otherwise.  Compared to :flag:`Printing Universes`, this makes the sort
+   structure visible without exposing internal universe level names.
+
 .. cmd:: Print {? Sorted } Universes {? Subgraph ( {* @debug_univ_name } ) } {? {| With | Without } Constraint Sources } {? @string }
    :name: Print Universes
 

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1346,9 +1346,9 @@ let extern_type ?(goal_concl_style=false) ~(flags:PrintingFlags.t) env sigma ?im
   let r = Detyping.detype Detyping.Later ~isgoal:goal_concl_style ~avoid ~flags:flags.detype env sigma t in
   extern_glob_type ?impargs (extern_env ~flags:flags.extern env sigma) r
 
-let extern_sort ~universes ~qualities sigma s =
+let extern_sort ~universes ~sorts ~qualities sigma s =
   extern_glob_sort (Evd.universe_binders sigma)
-    (detype_sort ~universes ~qualities sigma s)
+    (detype_sort ~universes ~sorts ~qualities sigma s)
 
 let extern_closed_glob ?(goal_concl_style=false) ?(inctx=false) ?scope ~(flags:PrintingFlags.t) env sigma t =
   let avoid = make_avoid goal_concl_style env in

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -53,7 +53,7 @@ val extern_reference : ?loc:Loc.t -> Id.Set.t -> GlobRef.t -> qualid
 val extern_type : ?goal_concl_style:bool ->
   flags:PrintingFlags.t -> env -> Evd.evar_map ->
   ?impargs:Glob_term.binding_kind list -> types -> constr_expr
-val extern_sort : universes:bool -> qualities:bool -> Evd.evar_map -> Sorts.t -> sort_expr
+val extern_sort : universes:bool -> sorts:bool -> qualities:bool -> Evd.evar_map -> Sorts.t -> sort_expr
 val extern_rel_context : flags:PrintingFlags.t -> env -> Evd.evar_map ->
   rel_context -> local_binder_expr list
 

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -273,18 +273,19 @@ let detype_quality sigma q =
 let detype_universe sigma u =
   UNamed (List.map (on_fst (detype_level_name sigma)) (Univ.Universe.repr u))
 
-let detype_sort ~universes ~qualities sigma = function
+let anon_univ = UAnonymous {rigid=UState.univ_flexible}
+
+let detype_sort ~universes ~sorts ~qualities sigma = function
   | SProp -> glob_SProp_sort
   | Prop -> glob_Prop_sort
   | Set -> glob_Set_sort
   | Type u ->
-      (if universes
-       then None, detype_universe sigma u
+      (if universes then None, detype_universe sigma u
        else glob_Type_sort)
   | GSort (q, u) ->
     let q = Some (GQuality (QGlobal q)) in
     if universes then q, detype_universe sigma u
-    else q, UAnonymous {rigid=UState.univ_flexible}
+    else q, anon_univ
   | VSort (q, u) ->
     if universes then
       let q = if qualities || Evd.is_rigid_qvar sigma q then
@@ -293,11 +294,14 @@ let detype_sort ~universes ~qualities sigma = function
       in
       q, detype_universe sigma u
     else if Evd.is_rigid_qvar sigma q then
-      Some (detype_qvar sigma q), UAnonymous {rigid=UState.univ_flexible}
+      Some (detype_qvar sigma q), anon_univ
+    else if sorts then
+      let q = if qualities then Some (detype_qvar sigma q) else None in
+      q, anon_univ
     else glob_Type_sort
 
 let detype_sort_f ~flags sigma s =
-  detype_sort ~universes:flags.flg.universes ~qualities:flags.flg.qualities sigma s
+  detype_sort ~universes:flags.flg.universes ~sorts:flags.flg.sorts ~qualities:flags.flg.qualities sigma s
 
 let detype_relevance_info ~flags sigma na =
   if not flags.DetypeFlags.relevances then None
@@ -740,15 +744,22 @@ type binder_kind = BProd | BLambda | BLetIn
 (* Main detyping function                                             *)
 
 let detype_instance ~flags sigma l =
-  if not flags.flg.universes then None
+  if not flags.flg.universes && not flags.flg.sorts then None
   else
     let l = EInstance.kind sigma l in
     if UVars.Instance.is_empty l then None
-    else
+    else if flags.flg.universes then
       let qs, us = UVars.Instance.to_array l in
       let qs = List.map (detype_quality sigma) (Array.to_list qs) in
       let us = List.map (detype_level sigma) (Array.to_list us) in
       Some (qs, us)
+    else
+      let qs, us = UVars.Instance.to_array l in
+      if Array.is_empty qs then None
+      else
+        let qs = List.map (detype_quality sigma) (Array.to_list qs) in
+        let us = List.map (fun _ -> anon_univ) (Array.to_list us) in
+        Some (qs, us)
 
 let delay (type a) (d : a delay) (f : a delay -> _ -> _ -> _ -> _ -> _ -> a glob_constr_r) flags env avoid sigma t : a glob_constr_g =
   match d with

--- a/pretyping/detyping.mli
+++ b/pretyping/detyping.mli
@@ -36,7 +36,7 @@ val detype : 'a delay ->
   flags:PrintingFlags.Detype.t -> ?isgoal:bool -> ?avoid:'g Namegen.Generator.input ->
   env -> evar_map -> constr -> 'a glob_constr_g
 
-val detype_sort : universes:bool -> qualities:bool -> evar_map -> Sorts.t -> glob_sort
+val detype_sort : universes:bool -> sorts:bool -> qualities:bool -> evar_map -> Sorts.t -> glob_sort
 
 val detype_rel_context : 'a delay ->
   flags:PrintingFlags.Detype.t ->

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -28,6 +28,9 @@ let raw_print = make_flag ["Printing";"All"] false
 (* XXX why does extern look at this flag? *)
 let print_universes = make_flag ["Printing";"Universes"] false
 
+(* detyping: like Printing Universes but anonymizes universe variables *)
+let print_sorts = make_flag ["Printing";"Sorts"] false
+
 (* detyping *)
 let { Goptions.get = print_sort_quality } =
   Goptions.declare_bool_option_and_ref
@@ -229,6 +232,7 @@ module PrintingConstructor = Goptions.MakeRefTable(PrintingRecordConstructor)
 module Detype = struct
   type t = {
     universes : bool;
+    sorts : bool;
     qualities : bool;
     relevances : bool;
     evar_instances : bool;
@@ -246,6 +250,7 @@ module Detype = struct
 
   let current_ignore_raw () = {
     universes = !print_universes;
+    sorts = !print_sorts;
     qualities = print_sort_quality();
     relevances = print_relevances();
     evar_instances = !print_evar_arguments;

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -11,6 +11,7 @@
 module Detype : sig
   type t = {
     universes : bool;
+    sorts : bool;
     (** Should we print hidden sort quality variables? *)
     qualities : bool;
     relevances : bool;
@@ -112,8 +113,9 @@ val current : unit -> t
 
 val current_ignore_raw : unit -> t
 
-(** The following flag is still accessed directly, but not when printing constr. *)
+(** The following flags are still accessed directly, but not when printing constr. *)
 val print_universes : bool ref
+val print_sorts : bool ref
 
 module PrintingInductiveMake (_ : sig
     val encode : Environ.env -> Libnames.qualid -> Names.inductive

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -131,11 +131,12 @@ let pr_cases_pattern ?(flags=current_extern()) t =
   pr_cases_pattern_expr ~flags:ppflags
     (extern_cases_pattern ~flags Names.Id.Set.empty t)
 
-let pr_sort ?universes ?qualities sigma s =
+let pr_sort ?universes ?sorts ?qualities sigma s =
   let flags = PrintingFlags.Detype.current() in
   let universes = Option.default flags.universes universes in
+  let sorts = Option.default flags.sorts sorts in
   let qualities = Option.default flags.qualities qualities in
-  pr_sort_expr (extern_sort ~universes ~qualities sigma s)
+  pr_sort_expr (extern_sort ~universes ~sorts ~qualities sigma s)
 
 let () = Termops.Internal.set_print_constr
   (fun env sigma t -> pr_leconstr_env ~flags:(current_combined()) env sigma t)

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -138,7 +138,7 @@ val pr_uninstantiated_constr_pattern_env : ?flags:PrintingFlags.Extern.t ->
 
 val pr_cases_pattern : ?flags:PrintingFlags.Extern.t -> cases_pattern -> Pp.t
 
-val pr_sort : ?universes:bool -> ?qualities:bool -> evar_map -> Sorts.t -> Pp.t
+val pr_sort : ?universes:bool -> ?sorts:bool -> ?qualities:bool -> evar_map -> Sorts.t -> Pp.t
 
 (** Universe constraints *)
 

--- a/test-suite/output/PrintingSorts.out
+++ b/test-suite/output/PrintingSorts.out
@@ -1,0 +1,87 @@
+S
+     : Type@{s ; _}
+T
+     : Type
+S
+     : Type@{s ; _}
+T
+     : Type
+S
+     : Type@{s ; Set}
+T
+     : Type@{T.u0}
+P
+     : Prop
+Q
+     : Set
+R
+     : SProp
+pid
+     : forall A : Type, A -> A
+plist
+     : Type -> Type
+pid
+     : forall A : Type, A -> A
+pid
+     : forall A : Type, A -> A
+plist
+     : Type -> Type
+pnil
+     : forall A : Type, plist A
+pcons
+     : forall A : Type, A -> plist A -> plist A
+pid@{PrintingSorts.39}
+     : forall A : Type@{PrintingSorts.39}, A -> A
+(* {PrintingSorts.39} | 
+Normalized constraints:
+ {PrintingSorts.39} |  *)
+plist@{PrintingSorts.40}
+     : Type@{PrintingSorts.40} -> Type@{max(Set,PrintingSorts.40)}
+(* {PrintingSorts.40} | 
+Normalized constraints:
+ {PrintingSorts.40} |  *)
+spid
+     : forall A : Type, A -> A
+sbox
+     : Type -> Type
+spid@{α12 ; _}
+     : forall A : Type@{α12 ; _}, A -> A
+spid@{α13 ; _}
+     : forall A : Type@{α13 ; _}, A -> A
+sbox@{α14 ; _}
+     : Type@{α14 ; _} -> Type
+spack@{α15 ; _}
+     : forall A : Type@{α15 ; _}, A -> sbox@{α15 ; _} A
+spid@{α16 ; PrintingSorts.56}
+     : forall A : Type@{α16 ; PrintingSorts.56}, A -> A
+(* {α16}; {PrintingSorts.56} | 
+Collapsed sorts:
+ α16 := Type
+Normalized constraints:
+ {PrintingSorts.56} |  *)
+spid@{α17 ; PrintingSorts.57}
+     : forall A : Type@{α17 ; PrintingSorts.57}, A -> A
+(* {α17}; {PrintingSorts.57} | 
+Collapsed sorts:
+ α17 := Type
+Normalized constraints:
+ {PrintingSorts.57} |  *)
+sbox@{α18 ; PrintingSorts.58}
+     : Type@{α18 ; PrintingSorts.58} -> Type@{PrintingSorts.58}
+(* {α18}; {PrintingSorts.58} | 
+Collapsed sorts:
+ α18 := Type
+Normalized constraints:
+ {PrintingSorts.58} |  *)
+spack@{α19 ; PrintingSorts.59}
+     : forall A : Type@{α19 ; PrintingSorts.59},
+       A -> sbox@{α19 ; PrintingSorts.59} A
+(* {α19}; {PrintingSorts.59} | 
+Collapsed sorts:
+ α19 := Type
+Normalized constraints:
+ {PrintingSorts.59} |  *)
+spid@{Prop ; _}
+     : forall A : Prop, A -> A
+spid@{Type ; _}
+     : forall A : Set, A -> A

--- a/test-suite/output/PrintingSorts.v
+++ b/test-suite/output/PrintingSorts.v
@@ -1,0 +1,79 @@
+Sort s.
+Axiom S : Type@{s;Set}.
+Axiom T : Type.
+
+(* Without Printing Sorts or Printing Universes *)
+Check S.
+Check T.
+
+(* With Printing Sorts: sort variables visible, universe levels anonymized *)
+Set Printing Sorts.
+Check S.
+Check T.
+Unset Printing Sorts.
+
+(* With Printing Universes: full names *)
+Set Printing Universes.
+Check S.
+Check T.
+Unset Printing Universes.
+
+(* Set, Prop, SProp still print as usual with Printing Sorts on,
+   not as Type@{Prop ; _} or similar *)
+Axiom P : Prop.
+Axiom Q : Set.
+Axiom R : SProp.
+
+Set Printing Sorts.
+Check P.
+Check Q.
+Check R.
+Unset Printing Sorts.
+
+(* Universe-polymorphic definitions and inductives *)
+#[universes(polymorphic)] Definition pid@{u} (A : Type@{u}) (a : A) := a.
+#[universes(polymorphic)] Inductive plist@{u} (A : Type@{u}) := pnil | pcons (a : A) (l : plist A).
+
+Check pid.
+Check plist.
+
+Set Printing Sorts.
+Check pid.
+Check @pid.
+Check plist.
+Check pnil.
+Check pcons.
+Unset Printing Sorts.
+
+Set Printing Universes.
+Check pid.
+Check plist.
+Unset Printing Universes.
+
+(* Sort-polymorphic definitions and inductives *)
+#[universes(polymorphic)] Definition spid@{s;u} (A : Type@{s;u}) (a : A) := a.
+#[universes(polymorphic)] Inductive sbox@{s;u} (A : Type@{s;u}) := spack (a : A).
+
+Check spid.
+Check sbox.
+
+Set Printing Sorts.
+Check spid.
+Check @spid.
+Check sbox.
+Check spack.
+Unset Printing Sorts.
+
+Set Printing Universes.
+Check spid.
+Check @spid.
+Check sbox.
+Check spack.
+Unset Printing Universes.
+
+(* Instances at concrete qualities: the quality shows in the instance,
+   but the sorts in the type still print as usual *)
+Set Printing Sorts.
+Check spid@{Prop;Set}.
+Check spid@{Type;Set}.
+Unset Printing Sorts.


### PR DESCRIPTION
Adds `Set Printing Sorts`, which exposes sort structure without internal universe level names. Plain `Type`, `SProp`, `Prop`, and `Set` remain unchanged; hidden levels print as `_`. Polymorphic reference instances appear only when they carry sort qualities.

Fixes #22153.

```coq
Sort s.
Axiom S : Type@{s;Set}.
Axiom T : Type.
#[universes(polymorphic)] Definition spid@{s;u} (A : Type@{s;u}) (a : A) := a.

(* Set Printing Sorts *)
Check S.     (* S : Type@{s ; _} *)
Check T.     (* T : Type *)
Check spid.  (* spid@{α ; _} : forall A : Type@{α ; _}, A -> A *)

(* Set Printing Universes *)
Check S.     (* S : Type@{s ; Set} *)
Check T.     (* T : Type@{T.u0} *)
```

`test-suite/output/PrintingSorts.v` covers the printing modes across plain sorts and global, universe-polymorphic, and sort-polymorphic definitions and inductives. The full `test-suite/output` directory passes locally against current master base; `make world` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Wordsmithed by Codex.
