### PR TITLE
PIDENT with exact ident and PKEYWORD have type `unit p`

### DIFF
--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -140,6 +140,10 @@ let print_opt fmt pr = function
 | None -> fprintf fmt "None"
 | Some x -> fprintf fmt "Some@ @[(%a)@]" pr x
 
+let print_exact fmt pr = function
+| None -> fprintf fmt "Any"
+| Some x -> fprintf fmt "Exact@ @[(%a)@]" pr x
+
 module GramExt :
 sig
 
@@ -254,9 +258,10 @@ let print_fun fmt (vars, body) =
     violates value restriction *)
 let print_tok fmt =
 let print_pat fmt = print_opt fmt print_string in
+let print_pat_exact fmt = print_exact fmt print_string in
 function
 | "", Some s -> fprintf fmt "Tok.PKEYWORD (%a)" print_string s
-| "IDENT", s -> fprintf fmt "Tok.PIDENT (%a)" print_pat s
+| "IDENT", s -> fprintf fmt "Tok.PIDENT (%a)" print_pat_exact s
 | "FIELD", s -> fprintf fmt "Tok.PFIELD (%a)" print_pat s
 | "NUMBER", None -> fprintf fmt "Tok.PNUMBER None"
 | "NUMBER", Some s -> fprintf fmt "Tok.PNUMBER (Some (Option.get (NumTok.Unsigned.parse_string %a)))" print_string s

--- a/dev/ci/user-overlays/22161-SkySkimmer-tok-pat.sh
+++ b/dev/ci/user-overlays/22161-SkySkimmer-tok-pat.sh
@@ -1,0 +1,3 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi tok-pat 22161
+
+overlay rocq_lsp https://github.com/SkySkimmer/rocq-lsp tok-pat 22161

--- a/parsing/cLexer.ml
+++ b/parsing/cLexer.ml
@@ -732,10 +732,10 @@ let next_token ~diff_mode ttree loc s : (Tok.t * Loc.t, Exninfo.iexn) Result.t =
 let pattern_strings : type c. _ -> c p -> string * string option =
   fun kwstate -> function
   | PKEYWORD s -> "", Some s
-  | PIDENT (Some s as os) ->
+  | PIDENT (Exact s) ->
     let kind = if is_keyword kwstate s then "" else "IDENT" in
-    kind, os
-  | PIDENT None -> "IDENT", None
+    kind, Some s
+  | PIDENT Any -> "IDENT", None
   | PFIELD s -> "FIELD", s
   | PNUMBER None -> "NUMBER", None
   | PNUMBER (Some n) -> "NUMBER", Some (NumTok.Unsigned.sprint n)
@@ -827,7 +827,7 @@ let strip s =
 let terminal s =
   let s = strip s in
   let () = match s with "" -> failwith "empty token." | _ -> () in
-  if is_ident s then PIDENT (Some s)
+  if is_ident s then PIDENT (Exact s)
   else PKEYWORD s
 
 (* Precondition: the input is a number (c.f. [NumTok.t]) *)

--- a/parsing/cLexer.mli
+++ b/parsing/cLexer.mli
@@ -51,7 +51,7 @@ val add_keyword_tok : keyword_state -> 'c Tok.p -> keyword_state
     (returns [PIDENT (Some _)] for idents which have been declared as keywords,
     as the keyword state is not checked)
 *)
-val terminal : string -> string Tok.p
+val terminal : string -> unit Tok.p
 
 (** Precondition: the input is a number (c.f. [NumTok.t]) *)
 val terminal_number : string -> NumTok.Unsigned.t Tok.p

--- a/parsing/tok.ml
+++ b/parsing/tok.ml
@@ -12,9 +12,23 @@
 
 let string_equal (s1 : string) s2 = s1 = s2
 
+type (_,_) exact =
+  | Any : ('a,'a) exact
+  | Exact : 'a -> ('a,unit) exact
+
+let is_exact (type a b) : (a,b) exact -> bool = function
+  | Any -> false
+  | Exact _ -> true
+
+let exact_eq (type a b b') (eq:a -> a -> bool) (a:(a,b) exact) (b:(a,b') exact) : (b,b') Util.eq option =
+  match a, b with
+  | Any, Any -> Some Refl
+  | Exact a, Exact b -> if eq a b then Some Refl else None
+  | (Any | Exact _), _ -> None
+
 type 'c p =
-  | PKEYWORD : string -> string p
-  | PIDENT : string option -> string p
+  | PKEYWORD : string -> unit p
+  | PIDENT : (string,'v) exact -> 'v p
   | PFIELD : string option -> string p
   | PNUMBER : NumTok.Unsigned.t option -> NumTok.Unsigned.t p
   | PSTRING : string option -> string p
@@ -25,7 +39,7 @@ type 'c p =
 
 let pattern_exact : type c. c p -> bool = function
   | PKEYWORD _ -> true
-  | PIDENT id -> Option.has_some id
+  | PIDENT id -> is_exact id
   | PFIELD s -> Option.has_some s
   | PNUMBER n -> Option.has_some n
   | PSTRING s -> Option.has_some s
@@ -49,10 +63,11 @@ let equal_p (type a b) (t1 : a p) (t2 : b p) : (a, b) Util.eq option =
   let streq s1 s2 = match s1, s2 with None, None -> true
     | Some s1, Some s2 -> string_equal s1 s2 | _ -> false in
   match t1, t2 with
-  | PIDENT s1, PIDENT s2 when streq s1 s2 -> Some Util.Refl
+  | PIDENT s1, PIDENT s2 ->
+    begin match exact_eq string_equal s1 s2 with Some Refl -> Some Util.Refl | None -> None end
   | PKEYWORD s1, PKEYWORD s2 when string_equal s1 s2 -> Some Util.Refl
-  | PIDENT (Some s1), PKEYWORD s2 when string_equal s1 s2 -> Some Util.Refl
-  | PKEYWORD s1, PIDENT (Some s2) when string_equal s1 s2 -> Some Util.Refl
+  | PIDENT (Exact s1), PKEYWORD s2 when string_equal s1 s2 -> Some Util.Refl
+  | PKEYWORD s1, PIDENT (Exact s2) when string_equal s1 s2 -> Some Util.Refl
   | PFIELD s1, PFIELD s2 when streq s1 s2 -> Some Util.Refl
   | PNUMBER None, PNUMBER None -> Some Util.Refl
   | PNUMBER (Some n1), PNUMBER (Some n2) when NumTok.Unsigned.equal n1 n2 -> Some Util.Refl
@@ -65,12 +80,12 @@ let equal_p (type a b) (t1 : a p) (t2 : b p) : (a, b) Util.eq option =
 
 let compare_p (type a b) (t1 : a p) (t2 : b p) : int =
   match t1, t2 with
-  | PIDENT None, PIDENT None -> 0
-  | PIDENT None, _ -> -1
-  | _, PIDENT None -> 1
-  | (PIDENT (Some s1) | PKEYWORD s1), (PIDENT (Some s2) | PKEYWORD s2) -> String.compare s1 s2
-  | (PIDENT (Some _) | PKEYWORD _), _ -> -1
-  | _, (PIDENT (Some _) | PKEYWORD _) -> 1
+  | PIDENT Any, PIDENT Any -> 0
+  | PIDENT Any, _ -> -1
+  | _, PIDENT Any -> 1
+  | (PIDENT (Exact s1) | PKEYWORD s1), (PIDENT (Exact s2) | PKEYWORD s2) -> String.compare s1 s2
+  | (PIDENT (Exact _) | PKEYWORD _), _ -> -1
+  | _, (PIDENT (Exact _) | PKEYWORD _) -> 1
   | PFIELD s1, PFIELD s2 -> Option.compare String.compare s1 s2
   | PFIELD _, _ -> -1
   | _, PFIELD _ -> 1
@@ -93,8 +108,8 @@ let compare_p (type a b) (t1 : a p) (t2 : b p) : int =
 
 let token_text : type c. c p -> string = function
   | PKEYWORD t -> "'" ^ t ^ "'"
-  | PIDENT None -> "identifier"
-  | PIDENT (Some t) -> "'" ^ t ^ "'"
+  | PIDENT Any -> "identifier"
+  | PIDENT (Exact t) -> "'" ^ t ^ "'"
   | PNUMBER None -> "number"
   | PNUMBER (Some n) -> "'" ^ NumTok.Unsigned.sprint n ^ "'"
   | PSTRING None -> "string"
@@ -149,12 +164,12 @@ let match_pattern (type c) (p : c p) : t -> c option =
   let seq = string_equal in
   match p with
   | PKEYWORD s ->
-    (function KEYWORD s' when seq s s' -> Some s'
-            | NUMBER n when seq s (NumTok.Unsigned.sprint n) -> Some s
-            | STRING s' when seq s (CString.quote_coq_string s') -> Some s
+    (function KEYWORD s' when seq s s' -> Some ()
+            | NUMBER n when seq s (NumTok.Unsigned.sprint n) -> Some ()
+            | STRING s' when seq s (CString.quote_coq_string s') -> Some ()
             | _ -> None)
-  | PIDENT None -> (function IDENT s' -> Some s' | _ -> None)
-  | PIDENT (Some s) -> (function (IDENT s' | KEYWORD s') when seq s s' -> Some s' | _ -> None)
+  | PIDENT Any -> (function IDENT s' -> Some s' | _ -> None)
+  | PIDENT (Exact s) -> (function (IDENT s' | KEYWORD s') when seq s s' -> Some () | _ -> None)
   | PFIELD None -> (function FIELD s -> Some s| _ -> None)
   | PFIELD (Some s) -> (function FIELD s' when seq s s' -> Some s' | _ -> None)
   | PNUMBER None -> (function NUMBER s -> Some s| _ -> None)

--- a/parsing/tok.mli
+++ b/parsing/tok.mli
@@ -10,9 +10,13 @@
 
 (** The type of token for the Rocq lexer and parser *)
 
+type (_,_) exact =
+  | Any : ('a,'a) exact
+  | Exact : 'a -> ('a,unit) exact
+
 type 'c p =
-  | PKEYWORD : string -> string p
-  | PIDENT : string option -> string p
+  | PKEYWORD : string -> unit p
+  | PIDENT : (string, 'v) exact -> 'v p
   | PFIELD : string option -> string p
   | PNUMBER : NumTok.Unsigned.t option -> NumTok.Unsigned.t p
   | PSTRING : string option -> string p

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -971,7 +971,7 @@ let rules = [
 
   Procq.(
     Production.make
-      (Rule.stop ++ Symbol.token (PIDENT (Some "ltac2")) ++ Symbol.token (PKEYWORD ":") ++
+      (Rule.stop ++ Symbol.token (PIDENT (Exact "ltac2")) ++ Symbol.token (PKEYWORD ":") ++
        Symbol.token (PKEYWORD "(") ++ Symbol.nterm ltac2_expr ++ Symbol.token (PKEYWORD ")"))
     begin fun _ tac _ _ _ loc ->
       CAst.make ~loc (CGenarg (Raw (Tac2env.wit_ltac2_constr, tac)))

--- a/plugins/ltac2/tac2syn.ml
+++ b/plugins/ltac2/tac2syn.ml
@@ -529,7 +529,7 @@ let terminal_synclass_tag : string SynclassDyn.tag = SynclassDyn.create "<termin
 
 let interp_terminal str : syntax_class_rule =
   let v_unit = CAst.make @@ CTacCst (AbsKn (Tuple 0)) in
-  SyntaxRule (Syntax.token (Tok.PIDENT (Some str)), (fun _ -> v_unit))
+  SyntaxRule (Syntax.token (Tok.PIDENT (Exact str)), (fun _ -> v_unit))
 
 let () =
   syntax_class_interps := SynclassInterpMap.add terminal_synclass_tag interp_terminal !syntax_class_interps

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -783,7 +783,7 @@ let prod_entry_type = function
 let terminal need_keyword s : Procq.ty_pattern =
   (* Ensure that IDENT articulation terminal symbols are keywords *)
   match CLexer.terminal s with
-  | Tok.PIDENT (Some k) as p ->
+  | Tok.PIDENT (Exact k) as p ->
     if need_keyword then begin
       Flags.if_verbose Feedback.msg_info (str "Identifier '" ++ str k ++ str "' now a keyword");
       TPattern (PKEYWORD s)


### PR DESCRIPTION
This means `x = IDENT "bla"` binds x to `()` instead of `"bla"`.

Since binding to an exact value is useless no such code appears in the code base.

TODO same transformation for FIELD NUMBER etc

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/1096
- https://github.com/rocq-community/rocq-lsp/pull/1109