### PR TITLE
feat: fine-grained tracking of reliance on impredicative Set

### DIFF
--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -175,7 +175,8 @@ let check_packet mind ind
     { mind_typename; mind_arity_ctxt; mind_user_arity; mind_record; mind_sort; mind_consnames; mind_user_lc;
       mind_nrealargs; mind_nrealdecls; mind_squashed; mind_nf_lc;
       mind_consnrealargs; mind_consnrealdecls; mind_automaton; mind_relevance;
-      mind_relies_on_indices_not_mattering; mind_nb_constant; mind_nb_args; mind_reloc_tbl } =
+      mind_relies_on_indices_not_mattering; mind_uses_impredicative_set;
+      mind_nb_constant; mind_nb_args; mind_reloc_tbl } =
   let check = check mind in
 
   ignore mind_typename; (* passed through *)
@@ -206,6 +207,7 @@ let check_packet mind ind
      graph has all final constraints, so the check may compute false.
      Accept when the original is conservatively true but re-check computes false. *)
   check "mind_relies_on_indices_not_mattering" (ind.mind_relies_on_indices_not_mattering || not mind_relies_on_indices_not_mattering);
+  check "mind_uses_impredicative_set" (ind.mind_uses_impredicative_set || not mind_uses_impredicative_set);
   check "mind_nb_args" Int.(equal ind.mind_nb_args mind_nb_args);
   check "mind_nb_constant" Int.(equal ind.mind_nb_constant mind_nb_constant);
   check "mind_reloc_tbl" (eq_reloc_tbl ind.mind_reloc_tbl mind_reloc_tbl);

--- a/checker/checkLibrary.ml
+++ b/checker/checkLibrary.ml
@@ -109,9 +109,9 @@ let indirect_accessor o =
   | None ->  CErrors.user_err Pp.(str "Cannot access opaque delayed proof.")
   | Some c -> c
   in
-  let (c, prv) = Discharge.cook_opaque_proofterm ci c in
+  let (c, prv, uses) = Discharge.cook_opaque_proofterm ci c in
   let c = Mod_subst.subst_mps_list sub c in
-  (c, prv)
+  (c, prv, uses)
 
 let () = Mod_checking.set_indirect_accessor indirect_accessor
 

--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -70,26 +70,40 @@ let check_constant_declaration env opac kn cb opacify =
       true, env
   in
   let ty = cb.const_type in
-  let jty = Typeops.infer_type env ty in
+  let jty, ty_uses = Typeops.infer_type_usage env ty in
+  let () =
+    (* The usage bits are only meaningful for constants typechecked with
+       -impredicative-set: the checker applies impredicativity
+       session-wide, so a predicative constant checked in an
+       impredicative session may spuriously fire the rule *)
+    if cb.const_typing_flags.impredicative_set
+       && ty_uses && not cb.const_uses_impredicative_set then
+      raise Pp.(BadConstant (kn, str "incorrect const_uses_impredicative_set"))
+  in
   if not (Sorts.relevance_equal cb.const_relevance (Sorts.relevance_of_sort jty.utj_type))
   then raise Pp.(BadConstant (kn, str "incorrect const_relevance"));
   let body, env = match cb.const_body with
     | Undef _ | Primitive _ | Symbol _ -> None, env
-    | Def c -> Some c, env
+    | Def c -> Some (c, cb.const_uses_impredicative_set), env
     | OpaqueDef o ->
-      let c, u = !indirect_accessor o in
+      let c, u, uses = !indirect_accessor o in
       let env = match u, cb.const_universes with
         | Opaqueproof.PrivateMonomorphic (), Monomorphic -> env
         | Opaqueproof.PrivatePolymorphic local, Polymorphic _ ->
           push_subgraph local env
         | _ -> assert false
       in
-      Some c, env
+      Some (c, uses), env
   in
   let () =
     match body with
-    | Some bd ->
-      let j = Typeops.infer env bd in
+    | Some (bd, stored_uses) ->
+      let j, body_uses = Typeops.infer_usage env bd in
+      let () =
+        if cb.const_typing_flags.impredicative_set
+           && body_uses && not stored_uses then
+          raise Pp.(BadConstant (kn, str "incorrect impredicative Set usage bit"))
+      in
       begin match conv_leq env j.uj_type ty with
       | Result.Ok () -> ()
       | Result.Error () -> Type_errors.error_actual_type env j ty
@@ -104,7 +118,7 @@ let check_constant_declaration env opac kn cb opacify =
     Some retro, opac
   in
   match body with
-  | Some body when opacify -> retro, register_opacified_constant env opac kn body
+  | Some (body, _) when opacify -> retro, register_opacified_constant env opac kn body
   | Some _ | None -> retro, opac
 
 let check_constant_declaration env opac kn cb opacify =

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -422,7 +422,8 @@ let v_cb = v_tuple "constant_body"
     v_vm_indirect_code;
     v_univs;
     v_bool;
-    v_typing_flags|]
+    v_typing_flags;
+    v_bool|]
 
 let v_recarg_type = v_sum "recarg_type" 0
   [|[|v_ind|] (* Mrec *);[|v_cst|] (* NestedPrimitive *)|]
@@ -622,6 +623,6 @@ let v_lib =
 let v_delayed_universes =
   v_sum_c ("delayed_universes", 0, [| [| v_unit |]; [| v_univ_context_set |] |])
 
-let v_opaquetable = v_array (v_opt (v_pair v_constr v_delayed_universes))
+let v_opaquetable = v_array (v_opt (v_tuple "opaque_proofterm" [|v_constr; v_delayed_universes; v_bool|]))
 
 let v_vmlib = v_tuple "vmlibrary" [|v_dp; v_array v_vm_to_patch|]

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -458,6 +458,7 @@ let v_one_ind = v_tuple "one_inductive_body"
     v_automaton;
     v_relevance;
     v_bool;
+    v_bool;
     v_int;
     v_int;
     v_vm_reloc_table|]

--- a/dev/ci/user-overlays/22166-JasonGross-print-assumptions-fine-grained.sh
+++ b/dev/ci/user-overlays/22166-JasonGross-print-assumptions-fine-grained.sh
@@ -1,0 +1,1 @@
+overlay metarocq https://github.com/JasonGross/metacoq print-assumptions-fine-grained 22166

--- a/dev/ci/user-overlays/22166-JasonGross-print-assumptions-fine-grained.sh
+++ b/dev/ci/user-overlays/22166-JasonGross-print-assumptions-fine-grained.sh
@@ -1,1 +1,2 @@
 overlay metarocq https://github.com/JasonGross/metacoq print-assumptions-fine-grained 22166
+overlay paramcoq https://github.com/JasonGross/paramcoq print-assumptions-fine-grained 22166

--- a/doc/changelog/08-vernac-commands-and-options/22166-print-assumptions-fine-grained-Changed.rst
+++ b/doc/changelog/08-vernac-commands-and-options/22166-print-assumptions-fine-grained-Changed.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  :cmd:`Print Assumptions` reports the impredicativity of :g:`Set` as an
+  assumption of a definition or inductive type only when it actually
+  relies on it (to typecheck at all, or for its elimination rules),
+  rather than for anything typechecked with ``-impredicative-set``
+  (`#22166 <https://github.com/rocq-prover/rocq/pull/22166>`_,
+  by Jason Gross).

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -461,9 +461,11 @@ Requests to the environment
    disabled universe checking, indices not mattering) according to the
    typing flags each dependency was typechecked with, in addition to
    the settings of the current environment.  For instance, a definition
-   typechecked with ``-impredicative-set`` is reported as assuming the
-   impredicativity of :g:`Set` even when it is imported into a
-   predicative environment, and an inductive type relying on indices
+   or inductive type that relies on the impredicativity of :g:`Set` --
+   to typecheck at all, or for its elimination rules -- is reported as
+   assuming it even when it is imported into a predicative environment
+   (definitions that were merely typechecked with ``-impredicative-set``
+   without relying on it are not reported), and an inductive type relying on indices
    not mattering is reported even when :flag:`Indices Matter` is off in
    the current environment (without this flag, such inductive types are
    reported only when :flag:`Indices Matter` is currently on, since an

--- a/kernel/constant_typing.ml
+++ b/kernel/constant_typing.ml
@@ -134,7 +134,7 @@ let adjust_primitive_univ_entry p auctx = function
 let infer_primitive env { prim_entry_type = utyp; prim_entry_content = p; } =
   let open CPrimitives in
   let auctx = CPrimitives.op_or_type_univs p in
-  let univs, typ =
+  let univs, typ, uses =
     match utyp with
     | None ->
       let u = UContext.instance (AbstractContext.repr auctx) in
@@ -142,15 +142,16 @@ let infer_primitive env { prim_entry_type = utyp; prim_entry_content = p; } =
       let univs = if AbstractContext.is_empty auctx then Monomorphic
         else Polymorphic auctx
       in
-      univs, typ
+      univs, typ, false
 
     | Some (typ, univ_entry) ->
       let univ_entry = adjust_primitive_univ_entry p auctx univ_entry in
       let env, usubst, u, univs = process_universes env univ_entry in
       let typ = Vars.subst_univs_level_constr usubst typ in
-      let typ = (Typeops.infer_type env typ).utj_val in
+      let typj, uses = Typeops.infer_type_usage env typ in
+      let typ = typj.utj_val in
       let () = check_primitive_type env p u typ in
-      univs, typ
+      univs, typ, uses
   in
   let body = match p with
     | OT_op op -> Declarations.Primitive op
@@ -169,12 +170,13 @@ let infer_primitive env { prim_entry_type = utyp; prim_entry_content = p; } =
     const_relevance = Sorts.Relevant;
     const_inline_code = false;
     const_typing_flags = Environ.typing_flags env;
+    const_uses_impredicative_set = uses;
   }
 
 let infer_symbol env { symb_entry_universes; symb_entry_unfold_fix; symb_entry_type } =
   let env, usubst, _, univs = process_universes env symb_entry_universes in
   let symb_entry_type = Vars.subst_univs_level_constr usubst symb_entry_type in
-  let j = Typeops.infer env symb_entry_type in
+  let j, uses = Typeops.infer_usage env symb_entry_type in
   let r = Typeops.assumption_of_judgment env j in
   {
     const_hyps = [];
@@ -186,6 +188,7 @@ let infer_symbol env { symb_entry_universes; symb_entry_unfold_fix; symb_entry_t
     const_relevance = r;
     const_inline_code = false;
     const_typing_flags = Environ.typing_flags env;
+    const_uses_impredicative_set = uses;
   }
 
 
@@ -196,7 +199,7 @@ let make_univ_hyps = function
 let infer_parameter ~sec_univs env entry =
   let env, usubst, _, univs = process_universes env entry.parameter_entry_universes in
   let typ = Vars.subst_univs_level_constr usubst entry.parameter_entry_type in
-  let j = Typeops.infer env typ in
+  let j, uses = Typeops.infer_usage env typ in
   let r = Typeops.assumption_of_judgment env j in
   let typ = j.uj_val in
   let undef = Undef entry.parameter_entry_inline_code in
@@ -211,22 +214,31 @@ let infer_parameter ~sec_univs env entry =
     const_relevance = r;
     const_inline_code = false;
     const_typing_flags = Environ.typing_flags env;
+    const_uses_impredicative_set = uses;
   }
 
 let infer_definition ~sec_univs env entry =
   let env, usubst, _, univs = process_universes env entry.definition_entry_universes in
   let body = Vars.subst_univs_level_constr usubst entry.definition_entry_body in
   let hbody = HConstr.of_constr env body in
-  let j = Typeops.infer_hconstr env hbody in
-  let typ = match entry.definition_entry_type with
+  let j, uses_body = Typeops.infer_hconstr_usage env hbody in
+  let typ, uses_typ = match entry.definition_entry_type with
     | None ->
-      j.uj_type
+      (* [j.uj_type] is assembled from abstractions without going
+         through [sort_of_product], so it must be re-inferred for the
+         usage bit to cover the stored type (cf the checker) *)
+      let uses_typ =
+        Environ.is_impredicative_set env
+        && snd (Typeops.infer_type_usage env j.uj_type)
+      in
+      j.uj_type, uses_typ
     | Some t ->
       let t = Vars.subst_univs_level_constr usubst t in
-      let tj = Typeops.infer_type env t in
+      let tj, uses_typ = Typeops.infer_type_usage env t in
       let () = Typeops.check_cast env j DEFAULTcast tj in
-      tj.utj_val
+      tj.utj_val, uses_typ
   in
+  let uses = uses_body || uses_typ in
   let body = j.uj_val in
   let hbody = Some hbody in
   let def = Def body in
@@ -241,13 +253,14 @@ let infer_definition ~sec_univs env entry =
     const_relevance = Relevanceops.relevance_of_term env body;
     const_inline_code = entry.definition_entry_inline_code;
     const_typing_flags = Environ.typing_flags env;
+    const_uses_impredicative_set = uses;
   }
 
 (** Definition is opaque (Qed), so we delay the typing of its body. *)
 let infer_opaque ~sec_univs env entry =
   let env, usubst, _, univs = process_universes env entry.opaque_entry_universes in
   let typ = Vars.subst_univs_level_constr usubst entry.opaque_entry_type in
-  let typj = Typeops.infer_type env typ in
+  let typj, uses = Typeops.infer_type_usage env typ in
   let context = TyCtx (env, typj, entry.opaque_entry_secctx, usubst, univs) in
   let def = OpaqueDef () in
   let typ = typj.utj_val in
@@ -262,9 +275,10 @@ let infer_opaque ~sec_univs env entry =
     const_relevance = Sorts.relevance_of_sort typj.utj_type;
     const_inline_code = false;
     const_typing_flags = Environ.typing_flags env;
+    const_uses_impredicative_set = uses;
   }, context
 
-let check_delayed (type a) (handle : a effect_handler) tyenv (body : a proof_output) =
+let check_delayed_usage (type a) (handle : a effect_handler) tyenv (body : a proof_output) =
   let TyCtx (env, tyj, declared, usubst, univs) = tyenv in
   let ((body, uctx), side_eff) = body in
   let (body, uctx', valid_signatures) = handle env body side_eff in
@@ -282,12 +296,15 @@ let check_delayed (type a) (handle : a effect_handler) tyenv (body : a proof_out
   let body = Vars.subst_univs_level_constr usubst body in
   let hbody = HConstr.of_constr env body in
   (* Note: non-trivial trusted side-effects only in monomorphic case *)
-  let () =
+  let uses =
     let eff_body, eff_env = skip_trusted_seff valid_signatures hbody env in
-    let j = Typeops.infer_hconstr eff_env eff_body in
+    let j, uses = Typeops.infer_hconstr_usage eff_env eff_body in
     let () = assert (HConstr.self eff_body == j.uj_val) in
     let j = { uj_val = HConstr.self hbody; uj_type = j.uj_type } in
-    Typeops.check_cast eff_env j DEFAULTcast tyj
+    let () = Typeops.check_cast eff_env j DEFAULTcast tyj in
+    (* conservative: the skipped trusted side-effect prefix was not
+       re-inferred here *)
+    uses || (valid_signatures > 0 && Environ.is_impredicative_set env)
   in
   let declared =
     if List.is_empty (named_context env) then declared
@@ -297,6 +314,10 @@ let check_delayed (type a) (handle : a effect_handler) tyenv (body : a proof_out
   let () = assert (Id.Set.equal declared declared') in
   let def = HConstr.self hbody in
   let hbody = Some hbody in
+  hbody, def, univs, uses
+
+let check_delayed handle tyenv body =
+  let (hbody, def, univs, _uses) = check_delayed_usage handle tyenv body in
   hbody, def, univs
 
 (*s Global and local constant declaration. *)

--- a/kernel/constant_typing.mli
+++ b/kernel/constant_typing.mli
@@ -47,3 +47,9 @@ val infer_opaque :
 
 val check_delayed : 'a effect_handler -> typing_context -> 'a proof_output ->
   HConstr.t option * Constr.t * Univ.ContextSet.t Opaqueproof.delayed_universes
+
+(** Same as {!check_delayed}, also reporting whether the impredicativity
+    of [Set] was used in a load-bearing way when checking the body (see
+    {!Typeops.infer_usage}). *)
+val check_delayed_usage : 'a effect_handler -> typing_context -> 'a proof_output ->
+  HConstr.t option * Constr.t * Univ.ContextSet.t Opaqueproof.delayed_universes * bool

--- a/kernel/declarations.mli
+++ b/kernel/declarations.mli
@@ -257,6 +257,11 @@ type one_inductive_body = {
     (** true if this inductive relies on indices not mattering,
         i.e. its behavior would change under -indices-matter. *)
 
+    mind_uses_impredicative_set : bool;
+    (** true if this inductive relies on [Set] being impredicative:
+        without [-impredicative-set] it would fail to typecheck or its
+        elimination constraints would change. *)
+
 (** {8 Datas for bytecode compilation } *)
 
     mind_nb_constant : int; (** number of constant constructor *)

--- a/kernel/declarations.mli
+++ b/kernel/declarations.mli
@@ -126,6 +126,14 @@ type ('opaque, 'bytecode) pconstant_body = {
     const_typing_flags : typing_flags; (** The typing options which
                                            were used for
                                            type-checking. *)
+    const_uses_impredicative_set : bool;
+    (** Over-approximation of whether type-checking this constant used
+        the impredicativity of [Set] in a load-bearing way.  [false]
+        guarantees that the constant does not rely on
+        [-impredicative-set]; [true] may be a false alarm, since
+        cumulativity may absorb the difference.  For opaque definitions
+        this covers the type only; the bit for the delayed body is
+        stored with the opaque proof term. *)
 }
 
 type constant_body = (Opaqueproof.opaque, Vmlibrary.indirect_code) pconstant_body

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -115,7 +115,8 @@ let subst_const_body subst cb =
         const_universes = cb.const_universes;
         const_relevance = cb.const_relevance;
         const_inline_code = cb.const_inline_code;
-        const_typing_flags = cb.const_typing_flags }
+        const_typing_flags = cb.const_typing_flags;
+        const_uses_impredicative_set = cb.const_uses_impredicative_set }
 
 (** {7 Hash-consing of constants } *)
 

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -239,6 +239,7 @@ let subst_mind_packet subst mbp =
     mind_automaton = subst_automaton subst mbp.mind_automaton;
     mind_relevance = mbp.mind_relevance;
     mind_relies_on_indices_not_mattering = mbp.mind_relies_on_indices_not_mattering;
+    mind_uses_impredicative_set = mbp.mind_uses_impredicative_set;
     mind_nb_constant = mbp.mind_nb_constant;
     mind_nb_args = mbp.mind_nb_args;
     mind_reloc_tbl = mbp.mind_reloc_tbl }

--- a/kernel/discharge.ml
+++ b/kernel/discharge.ml
@@ -45,10 +45,13 @@ let lift_private_univs info = function
     Opaqueproof.PrivatePolymorphic ctx
 
 let cook_opaque_proofterm info c =
-  let fold info (c, priv) =
+  let fold info (c, priv, uses) =
     let priv = lift_private_univs info priv in
     let c = abstract_as_body (create_cache info) c in
-    (c, priv)
+    (* conservative: the types of the abstracted section hypotheses
+       become part of the proof term *)
+    let uses = uses || not (Id.Set.is_empty (names_info info)) in
+    (c, priv, uses)
   in
   List.fold_right fold info c
 
@@ -81,6 +84,12 @@ let cook_constant _env info cb =
     const_relevance =  lift_relevance info cb.const_relevance;
     const_inline_code = cb.const_inline_code;
     const_typing_flags = cb.const_typing_flags;
+    const_uses_impredicative_set =
+      (* conservative: the types of the abstracted section hypotheses
+         become part of the constant *)
+      cb.const_uses_impredicative_set
+      || (cb.const_typing_flags.impredicative_set
+          && List.exists (fun d -> Id.Set.mem (NamedDecl.get_id d) names) cb.const_hyps);
   }
 
 (********************************)

--- a/kernel/discharge.ml
+++ b/kernel/discharge.ml
@@ -158,6 +158,7 @@ let cook_one_ind info cache ~params ~ntypes mip =
     mind_automaton = mip.mind_automaton;
     mind_relevance = lift_relevance info mip.mind_relevance;
     mind_relies_on_indices_not_mattering = mip.mind_relies_on_indices_not_mattering;
+    mind_uses_impredicative_set = mip.mind_uses_impredicative_set;
     mind_nb_constant = mip.mind_nb_constant;
     mind_nb_args = mip.mind_nb_args;
     mind_reloc_tbl = mip.mind_reloc_tbl;

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -81,6 +81,7 @@ type univ_info =
   ; ind_template : bool
   ; ind_univ : Sorts.t
   ; missing : Sorts.t list (* missing u <= ind_univ constraints *)
+  ; uses_impredicative_set : bool
   }
 
 let add_squash q info =
@@ -116,7 +117,10 @@ let compute_elim_squash ?(is_real_arg=false) env u info =
   let indu = info.ind_univ in
 
   if not @@ UGraph.check_leq (universes env) (Sorts.univ_of_sort u) (Sorts.univ_of_sort indu) then
-    if Environ.is_impredicative_sort env indu then add_squash (Sorts.quality u) info
+    if Environ.is_impredicative_sort env indu then
+      let info = add_squash (Sorts.quality u) info in
+      if Sorts.is_set indu then { info with uses_impredicative_set = true }
+      else info
     else { info with missing = u :: info.missing }
   else if Inductive.eliminates_to (Environ.qualities env) (Sorts.quality indu) (Sorts.quality u) then
     info
@@ -168,6 +172,7 @@ let check_arity ~template env_params env_ar (na, arity) =
     ind_template = template;
     ind_univ=ind_sort;
     missing=[];
+    uses_impredicative_set=false;
   }
   in
   (* We do not need to generate the universe of the arity with params;
@@ -182,6 +187,58 @@ let check_arity ~template env_params env_ar (na, arity) =
 let check_constructor_univs env_ar_par info (args,_) =
   (* We ignore the output, positivity will check that it's the expected inductive type *)
   check_context_univs ~ctor:true env_ar_par info args
+
+(* Detect reliance on impredicative [Set] beyond what the main analysis
+   already recorded in [univ_info.uses_impredicative_set] (a constructor
+   argument fitting its [Set]-sorted inductive only impredicatively):
+   - the arity or the types of the constructors may fail to typecheck at
+     all in a predicative environment (e.g. when a subterm needs to fit
+     in [Set]);
+   - the squashing/elimination analysis may differ in a predicative
+     environment. *)
+let check_uses_impredicative_set env_ar_par isrecord params indices arity lc splayed_lc univ_info =
+  if not (Environ.is_impredicative_set env_ar_par)
+     || univ_info.uses_impredicative_set
+  then univ_info
+  else
+    let env_pred = Environ.set_impredicative_set false env_ar_par in
+    let fresh_info = { univ_info with ind_squashed = None; missing = []; uses_impredicative_set = false } in
+    let analyze env =
+      let info =
+        if isrecord then fresh_info
+        else match Array.length splayed_lc with
+        | 0 -> compute_elim_squash env Sorts.sprop fresh_info
+        | 1 ->
+          if (Environ.typing_flags env).allow_uip
+               && fst (splayed_lc.(0)) = []
+               && List.for_all Context.Rel.Declaration.is_local_assum params
+               && List.for_all Context.Rel.Declaration.is_local_assum indices
+               && Sorts.is_sprop fresh_info.ind_univ
+          then fresh_info
+          else compute_elim_squash env Sorts.prop fresh_info
+        | _ -> compute_elim_squash env Sorts.set fresh_info
+      in
+      Array.fold_left (check_constructor_univs env) info splayed_lc
+    in
+    match
+      (* The full arity re-binds the parameters and indices, so their
+         types are covered here; the constructor types are checked
+         without generalization, in the environment where the
+         parameters and the block's inductives are bound. *)
+      let () = ignore (Typeops.infer_type env_pred arity) in
+      let () = Array.iter (fun c -> ignore (Typeops.infer_type env_pred c)) lc in
+      analyze env_pred
+    with
+    | exception e when CErrors.noncritical e ->
+      { univ_info with uses_impredicative_set = true }
+    | pred_info ->
+      let imp_info = analyze env_ar_par in
+      let differs =
+        not (Option.equal eq_squashed pred_info.ind_squashed imp_info.ind_squashed)
+        || not (List.equal Sorts.equal pred_info.missing imp_info.missing)
+      in
+      if differs then { univ_info with uses_impredicative_set = true }
+      else univ_info
 
 let check_constructors ~env_params ~env_ar_par isrecord params lc (arity,indices,univ_info) =
   let lc = Array.map_of_list (fun c -> (Typeops.infer_type env_ar_par c).utj_val) lc in
@@ -216,6 +273,7 @@ let check_constructors ~env_params ~env_ar_par isrecord params lc (arity,indices
       | Some (SometimesSquashed _) ->
       CErrors.user_err Pp.(str "Cannot handle sometimes squashed template polymorphic type.")
   in
+  let univ_info = check_uses_impredicative_set env_ar_par isrecord params indices arity lc splayed_lc univ_info in
   (* generalize the constructors over the parameters *)
   let lc = Array.map (fun c -> Term.it_mkProd_or_LetIn c params) lc in
   let univ_info, relies_on_indices_not_mattering = check_indices_matter env_params univ_info indices in
@@ -591,7 +649,7 @@ let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
   let () = List.iter (fun pkt -> check_packet env pkt) data in
   let map ((arity, lc), b, univs, relies_on_indices_not_mattering) =
     let arity = { user_arity = arity; sort = univs.ind_univ } in
-    ((arity, lc), b, univs.ind_squashed, relies_on_indices_not_mattering)
+    ((arity, lc), b, univs.ind_squashed, relies_on_indices_not_mattering, univs.uses_impredicative_set)
   in
   let data = List.map map data in
 

--- a/kernel/indTyping.mli
+++ b/kernel/indTyping.mli
@@ -51,5 +51,6 @@ val typecheck_inductive : env -> sec_univs:UVars.Instance.t option
   * ((inductive_arity * Constr.types array) *
      (Constr.rel_context * (Constr.rel_context * Constr.types) array) *
      squash_info option *
-     bool (** true if the inductive relies on indices not mattering *))
+     bool (** true if the inductive relies on indices not mattering *) *
+     bool (** true if the inductive uses impredicative Set *))
     array

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -426,7 +426,7 @@ let check_positivity ~chkpos kn names env_ar_par paramsctxt finite inds =
 (* Build the inductive packet *)
 
 let fold_inductive_blocks f acc inds =
-  Array.fold_left (fun acc ((arity,lc),_,_,_) ->
+  Array.fold_left (fun acc ((arity,lc),_,_,_,_) ->
       f (Array.fold_left f acc lc) arity.IndTyping.user_arity)
     acc inds
 
@@ -503,7 +503,7 @@ let build_inductive env ~sec_univs names prv univs template variance
   let u = UVars.make_abstract_instance (universes_context univs) in
   let subst = List.init ntypes (fun i -> mkIndU ((kn, ntypes - i - 1), u)) in
   (* Check one inductive *)
-  let build_one_packet i (id,cnames) ((arity,lc),(indices,splayed_lc),squashed,relies_on_indices_not_mattering) recarg =
+  let build_one_packet i (id,cnames) ((arity,lc),(indices,splayed_lc),squashed,relies_on_indices_not_mattering,uses_impredicative_set) recarg =
     let lc = Array.map (substl subst) lc in
     (* Type of constructors in normal form *)
     let nf_lc =
@@ -575,6 +575,7 @@ let build_inductive env ~sec_univs names prv univs template variance
         mind_automaton = automaton;
         mind_relevance;
         mind_relies_on_indices_not_mattering = relies_on_indices_not_mattering;
+        mind_uses_impredicative_set = uses_impredicative_set;
         mind_nb_constant = !nconst;
         mind_nb_args = !nblock;
         mind_reloc_tbl = rtbl;
@@ -625,7 +626,7 @@ let check_inductive env ~sec_univs kn mie =
   in
   let (nmr,recargs) = check_positivity ~chkpos kn names
       env_ar_par paramsctxt mie.mind_entry_finite
-      (Array.map (fun ((_,lc),(indices,_),_,_) -> Context.Rel.nhyps indices,lc) inds)
+      (Array.map (fun ((_,lc),(indices,_),_,_,_) -> Context.Rel.nhyps indices,lc) inds)
   in
   (* Build the inductive packets *)
   let mib =

--- a/kernel/opaqueproof.ml
+++ b/kernel/opaqueproof.ml
@@ -16,7 +16,7 @@ type 'a delayed_universes =
 | PrivateMonomorphic of 'a
 | PrivatePolymorphic of Univ.ContextSet.t
 
-type opaque_proofterm = Constr.t * unit delayed_universes
+type opaque_proofterm = Constr.t * unit delayed_universes * bool
 
 type opaque =
 | Indirect of substitution list * cooking_info list * DirPath.t * int (* subst, discharge, lib, index *)

--- a/kernel/opaqueproof.mli
+++ b/kernel/opaqueproof.mli
@@ -28,7 +28,10 @@ val empty_opaquetab : opaquetab
 
 val create : DirPath.t -> opaquetab -> opaque * opaquetab
 
-type opaque_proofterm = Constr.t * unit delayed_universes
+type opaque_proofterm = Constr.t * unit delayed_universes * bool
+(** The boolean is an over-approximation of whether checking the proof
+    term used the impredicativity of [Set] in a load-bearing way,
+    cf {!Typeops.infer_usage}. *)
 
 type opaque_handle
 

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -864,6 +864,7 @@ let update_resolver f senv = { senv with modresolver = f senv.modresolver }
 type exported_opaque = {
   exp_handle : Opaqueproof.opaque_handle;
   exp_body : Constr.t;
+  exp_uses_impredicative_set : bool;
   exp_univs : (int * int) option;
   (* Minimal amount of data needed to rebuild the private universes. We enforce
      in the API that private constants have no internal constraints. *)
@@ -875,7 +876,7 @@ let repr_exported_opaque o =
   | None -> Opaqueproof.PrivateMonomorphic ()
   | Some _ -> Opaqueproof.PrivatePolymorphic Univ.ContextSet.empty
   in
-  (o.exp_handle, (o.exp_body, priv))
+  (o.exp_handle, (o.exp_body, priv, o.exp_uses_impredicative_set))
 
 let set_vm_library lib senv =
   { senv with env = Environ.set_vm_library lib senv.env }
@@ -1075,10 +1076,11 @@ let infer_direct_opaque ~sec_univs env ce =
   let cb, ctx = Constant_typing.infer_opaque ~sec_univs env ce in
   let body = ce.Entries.opaque_entry_body, Univ.ContextSet.empty in
   let handle _env c () = (c, Univ.ContextSet.empty, 0) in
-  let (hbody, c, u) = Constant_typing.check_delayed handle ctx (body, ()) in
+  let (hbody, c, u, uses) = Constant_typing.check_delayed_usage handle ctx (body, ()) in
   (* No constraints can be generated, we set it empty everywhere *)
   let () = assert (is_empty_private u) in
-  hbody, { cb with const_body = OpaqueDef c }
+  hbody, { cb with const_body = OpaqueDef c;
+                   const_uses_impredicative_set = cb.const_uses_impredicative_set || uses }
 
 let export_side_effects senv eff =
   let sec_univs = Option.map Section.all_poly_univs senv.sections in
@@ -1147,7 +1149,8 @@ let export_private_constants eff senv =
       let () = assert (HConstr.self hbody == body) in
       HConstr.hcons hbody
     in
-    let opaque = { exp_body = body; exp_handle = h; exp_univs = univs } in
+    let opaque = { exp_body = body; exp_handle = h; exp_univs = univs;
+                   exp_uses_impredicative_set = c.const_uses_impredicative_set } in
     senv, (kn, { c with const_body = OpaqueDef o }, Some opaque, None)
   | Def _ | Undef _ | Primitive _ | Symbol _ as body ->
     (* Hashconsing is handled by {!add_constant_aux}, propagate hbody *)
@@ -1196,6 +1199,7 @@ let add_constant ?typing_flags l decl senv =
 
 type opaque_certificate = {
   opq_body : Constr.t;
+  opq_uses_impredicative_set : bool;
   opq_univs : Univ.ContextSet.t Opaqueproof.delayed_universes;
   opq_handle : Opaqueproof.opaque_handle;
   opq_nonce : Nonce.t;
@@ -1216,7 +1220,7 @@ let check_opaque senv (i : Opaqueproof.opaque_handle) pf =
     in
     body, uctx, trusted
   in
-  let (hbody, c, ctx) = Constant_typing.check_delayed handle ty_ctx pf in
+  let (hbody, c, ctx, uses) = Constant_typing.check_delayed_usage handle ty_ctx pf in
   let _, c = match hbody with
     | Some hbody -> assert (c == HConstr.self hbody); HConstr.hcons hbody
     | None -> Constr.hcons c
@@ -1227,7 +1231,7 @@ let check_opaque senv (i : Opaqueproof.opaque_handle) pf =
   | Opaqueproof.PrivatePolymorphic u ->
     Opaqueproof.PrivatePolymorphic (snd @@ Univ.ContextSet.hcons u)
   in
-  { opq_body = c; opq_univs = ctx; opq_handle = i; opq_nonce = nonce }
+  { opq_body = c; opq_uses_impredicative_set = uses; opq_univs = ctx; opq_handle = i; opq_nonce = nonce }
 
 let fill_opaque { opq_univs = ctx; opq_handle = i; opq_nonce = n; _ } senv =
   let () = if not @@ HandleMap.mem i senv.future_cst then
@@ -1253,6 +1257,9 @@ let is_filled_opaque i senv =
 
 let repr_certificate { opq_body = body; opq_univs = ctx; _ } =
   body, ctx
+
+let repr_certificate_usage { opq_body = body; opq_univs = ctx; opq_uses_impredicative_set = uses; _ } =
+  body, ctx, uses
 
 let check_constraints uctx = function
 | Entries.Polymorphic_entry _ -> Univ.ContextSet.is_empty uctx

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -127,6 +127,12 @@ val is_filled_opaque : Opaqueproof.opaque_handle -> safe_environment -> bool
 val repr_certificate : opaque_certificate ->
   Constr.t * Univ.ContextSet.t Opaqueproof.delayed_universes
 
+(** Same as {!repr_certificate}, also reporting whether the
+    impredicativity of [Set] was used in a load-bearing way when
+    checking the body (cf {!Typeops.infer_usage}). *)
+val repr_certificate_usage : opaque_certificate ->
+  Constr.t * Univ.ContextSet.t Opaqueproof.delayed_universes * bool
+
 (** {5 Rewrite rules} *)
 
 (** Add a rewrite rule corresponding to the equality witnessed by the constant. *)

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -302,13 +302,29 @@ let type_of_array env u =
 
 (* Type of product *)
 
-let sort_of_product env domsort rangsort =
-  if is_impredicative_sort env rangsort then rangsort
+(* The boolean records whether the impredicativity of [Set] was used in
+   a load-bearing way: the product was assigned sort [Set] where
+   predicative inference would have assigned a larger sort. *)
+let sort_of_product_usage env domsort rangsort =
+  if is_impredicative_sort env rangsort then
+    let used = match rangsort with
+      | Set ->
+        (* [Set] is impredicative only with [-impredicative-set] *)
+        begin match domsort with
+          | SProp | Prop -> false
+          | _ -> not (UGraph.check_leq (universes env) (univ_of_sort domsort) Universe.type0)
+        end
+      | _ -> false
+    in
+    rangsort, used
   else match domsort with
-    | SProp | Prop -> rangsort
+    | SProp | Prop -> rangsort, false
     | _ ->
     let u1 = univ_of_sort domsort and u2 = univ_of_sort rangsort in
-    Sorts.make (quality rangsort) (Universe.sup u1 u2)
+    Sorts.make (quality rangsort) (Universe.sup u1 u2), false
+
+let sort_of_product env domsort rangsort =
+  fst (sort_of_product_usage env domsort rangsort)
 
 (* [judge_of_product env name (typ1,s1) (typ2,s2)] implements the rule
 
@@ -318,9 +334,10 @@ let sort_of_product env domsort rangsort =
 
   where j.uj_type is convertible to a sort s2
 *)
-let type_of_product env _name s1 s2 =
-  let s = sort_of_product env s1 s2 in
-    mkSort s
+let type_of_product usage env _name s1 s2 =
+  let s, used = sort_of_product_usage env s1 s2 in
+  let () = if used then usage := true in
+  mkSort s
 
 (* Type of a type cast *)
 
@@ -599,17 +616,17 @@ let push_rec_types (lna,typarray,_) env =
   Array.fold_left (fun e assum -> push_rel assum e) env ctxt
 
 (* The typing machine. *)
-let rec execute tbl env cstr =
-  if Int.equal (HConstr.refcount cstr) 1 then execute_aux tbl env cstr
+let rec execute ((tbl, _) as st) env cstr =
+  if Int.equal (HConstr.refcount cstr) 1 then execute_aux st env cstr
   else begin match HConstr.Tbl.find_opt tbl cstr with
     | Some v -> v
     | None ->
-      let v = execute_aux tbl env cstr in
+      let v = execute_aux st env cstr in
       HConstr.Tbl.add tbl cstr v;
       v
   end
 
-and execute_aux tbl env cstr =
+and execute_aux ((_, usage) as tbl) env cstr =
   let open Context.Rel.Declaration in
   let self = HConstr.self in
   match HConstr.kind cstr with
@@ -664,7 +681,7 @@ and execute_aux tbl env cstr =
       let () = check_assum_annot env vars name (self c1) in
       let env1 = push_rel (LocalAssum (name,self c1)) env in
       let vars' = execute_is_type tbl env1 c2 in
-      type_of_product env name vars vars'
+      type_of_product usage env name vars vars'
 
     | LetIn (name,c1,c2,c3) ->
       let c1t = execute tbl env c1 in
@@ -822,8 +839,8 @@ and execute_recdef tbl env (names,lar,vdef) i =
 and execute_array tbl env cs =
   Array.map (fun c -> execute tbl env c) cs
 
-let execute env c =
-  NewProfile.profile "Typeops.execute" (fun () -> execute (HConstr.Tbl.create ()) env c) ()
+let execute usage env c =
+  NewProfile.profile "Typeops.execute" (fun () -> execute (HConstr.Tbl.create (), usage) env c) ()
 
 (* Derived functions *)
 
@@ -844,26 +861,34 @@ let check_wellformed_universes env c =
 let check_wellformed_universes env c =
   NewProfile.profile "check-wf-univs" (fun () -> check_wellformed_universes env c) ()
 
-let infer_hconstr env hconstr =
+let infer_hconstr_usage env hconstr =
   let constr = HConstr.self hconstr in
   let () = check_wellformed_universes env constr in
-  let t = execute env hconstr in
-  make_judge constr t
+  let usage = ref false in
+  let t = execute usage env hconstr in
+  make_judge constr t, !usage
 
-let infer env c =
+let infer_hconstr env hconstr = fst (infer_hconstr_usage env hconstr)
+
+let infer_usage env c =
   let c = HConstr.of_constr env c in
-  infer_hconstr env c
+  infer_hconstr_usage env c
+
+let infer env c = fst (infer_usage env c)
 
 let assumption_of_judgment env {uj_val=c; uj_type=t} =
   infer_assumption env c t
 
-let infer_type env constr =
+let infer_type_usage env constr =
   let () = check_wellformed_universes env constr in
   let hconstr = HConstr.of_constr env constr in
   let constr = HConstr.self hconstr in
-  let t = execute env hconstr in
+  let usage = ref false in
+  let t = execute usage env hconstr in
   let s = check_type env constr t in
-  {utj_val = constr; utj_type = s}
+  {utj_val = constr; utj_type = s}, !usage
+
+let infer_type env constr = fst (infer_type_usage env constr)
 
 (* Typing of several terms. *)
 

--- a/kernel/typeops.mli
+++ b/kernel/typeops.mli
@@ -26,6 +26,16 @@ val infer      : env -> constr       -> unsafe_judgment
 val infer_hconstr : env -> HConstr.t -> unsafe_judgment
 val infer_type : env -> types        -> unsafe_type_judgment
 
+(** Variants also reporting whether the impredicativity of [Set] was
+    used in a load-bearing way during inference: some product was
+    assigned sort [Set] where predicative inference would have assigned
+    a larger sort.  [false] guarantees that the term does not rely on
+    [-impredicative-set]; [true] may be a false alarm, since
+    cumulativity may absorb the difference. *)
+val infer_usage : env -> constr -> unsafe_judgment * bool
+val infer_hconstr_usage : env -> HConstr.t -> unsafe_judgment * bool
+val infer_type_usage : env -> types -> unsafe_type_judgment * bool
+
 val check_context :
   env -> Constr.rel_context -> env * Constr.rel_context
 
@@ -54,6 +64,7 @@ val type_of_projection : env -> Projection.t -> constr -> types -> Sorts.relevan
 
 (** {6 Type of a product. } *)
 val sort_of_product : env -> Sorts.t -> Sorts.t -> Sorts.t
+val sort_of_product_usage : env -> Sorts.t -> Sorts.t -> Sorts.t * bool
 
 (** {6 Type of a cast. } *)
 val check_cast :

--- a/library/global.ml
+++ b/library/global.ml
@@ -185,7 +185,7 @@ type indirect_accessor = {
 
 let force_proof access o = match access.access_proof o with
 | None -> CErrors.user_err Pp.(str "Cannot access opaque delayed proof")
-| Some (c, u) -> (c, u)
+| Some pt -> pt
 
 let body_of_constant_body access cb =
   let open Declarations in
@@ -199,7 +199,7 @@ let body_of_constant_body access cb =
     in
     Some (c, u, Declareops.constant_polymorphic_context cb)
   | OpaqueDef o ->
-    let c, u = force_proof access o in
+    let c, u, _uses = force_proof access o in
     Some (c, u, Declareops.constant_polymorphic_context cb)
 
 let body_of_constant access cst = body_of_constant_body access (lookup_constant cst)

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -115,8 +115,8 @@ let qmono uctx inst lconstr = match uctx with
   EConstr.of_constr lconstr
 
 let get_opaque access env c =
-  EConstr.of_constr
-    (fst (Global.force_proof access c))
+  let (body, _, _) = Global.force_proof access c in
+  EConstr.of_constr body
 
 let applistc c args = EConstr.mkApp (c, Array.of_list args)
 

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -623,6 +623,8 @@ type axiom =
   | TypeInType of GlobRef.t
   | UIP of MutInd.t
   | IndicesNotMattering of MutInd.t
+  | ImpredicativeSet of GlobRef.t
+  | RewriteRules of Constant.t
 
 type context_object =
   | Variable of Id.t (* A section variable or a Let definition *)
@@ -637,14 +639,16 @@ struct
 
   let compare_axiom x y =
     match x,y with
-    | Constant k1 , Constant k2 ->
+    | Constant k1 , Constant k2
+    | RewriteRules k1, RewriteRules k2 ->
       Constant.UserOrd.compare k1 k2
     | Positive m1 , Positive m2
     | UIP m1, UIP m2
     | IndicesNotMattering m1, IndicesNotMattering m2 ->
       MutInd.UserOrd.compare m1 m2
     | Guarded k1 , Guarded k2
-    | TypeInType k1, TypeInType k2 ->
+    | TypeInType k1, TypeInType k2
+    | ImpredicativeSet k1, ImpredicativeSet k2 ->
       GlobRef.UserOrd.compare k1 k2
     | Constant _, _ -> -1
     | _, Constant _ -> 1
@@ -656,6 +660,10 @@ struct
     | _, TypeInType _ -> 1
     | UIP _, _ -> -1
     | _, UIP _ -> 1
+    | IndicesNotMattering _, _ -> -1
+    | _, IndicesNotMattering _ -> 1
+    | ImpredicativeSet _, _ -> -1
+    | _, ImpredicativeSet _ -> 1
 
   let compare x y =
     match x , y with
@@ -685,6 +693,8 @@ let pr_assumptionset ?(flags=current_combined()) env sigma theory_info s =
   let dominated_by_env ax =
     match ax with
     | IndicesNotMattering _ -> not print_all && not (indices_matter env)
+    | ImpredicativeSet _ -> not print_all && not (is_impredicative_set env)
+    | RewriteRules _ -> not print_all && not (rewrite_rules_allowed env)
     | _ -> false
   in
   let s = ContextObjectMap.filter (fun k _v -> match k with
@@ -741,6 +751,10 @@ let pr_assumptionset ?(flags=current_combined()) env sigma theory_info s =
           hov 2 (safe_pr_inductive env mind ++ spc () ++ strbrk"relies on definitional UIP.")
       | IndicesNotMattering mind ->
           hov 2 (safe_pr_inductive env mind ++ spc () ++ strbrk"relies on indices not mattering.")
+      | ImpredicativeSet gr ->
+          hov 2 (safe_pr_global env gr ++ spc () ++ strbrk"was typed with Set being impredicative.")
+      | RewriteRules kn ->
+          hov 2 (safe_pr_constant env kn ++ spc () ++ strbrk"is a symbol for rewrite rules.")
     in
     let fold t typ accu =
       let (v, a, o, tr) = accu in

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -752,7 +752,7 @@ let pr_assumptionset ?(flags=current_combined()) env sigma theory_info s =
       | IndicesNotMattering mind ->
           hov 2 (safe_pr_inductive env mind ++ spc () ++ strbrk"relies on indices not mattering.")
       | ImpredicativeSet gr ->
-          hov 2 (safe_pr_global env gr ++ spc () ++ strbrk"was typed with Set being impredicative.")
+          hov 2 (safe_pr_global env gr ++ spc () ++ strbrk"relies on Set being impredicative.")
       | RewriteRules kn ->
           hov 2 (safe_pr_constant env kn ++ spc () ++ strbrk"is a symbol for rewrite rules.")
     in

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -236,6 +236,8 @@ type axiom =
   | TypeInType of GlobRef.t (* a constant which relies on type in type *)
   | UIP of MutInd.t (* An inductive using the special reduction rule. *)
   | IndicesNotMattering of MutInd.t (* An inductive relying on indices not mattering. *)
+  | ImpredicativeSet of GlobRef.t (* a definition typed with impredicative Set *)
+  | RewriteRules of Constant.t (* a symbol constant used with rewrite rules *)
 
 type context_object =
   | Variable of Id.t (* A section variable or a Let definition *)

--- a/test-suite/misc/impred_set_chk.sh
+++ b/test-suite/misc/impred_set_chk.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Check that rocq check validates the impredicative-Set usage bits
+# stored in vo files (cf Constr.const_uses_impredicative_set and the
+# opaque proof term bit).
+
+set -e
+
+export PATH=$BIN:$PATH
+
+cd misc/impred_set_chk
+rm -f *.vo
+rocq compile -impredicative-set -R . TestImpredChk impred_lib.v
+rocq check -impredicative-set -R . TestImpredChk TestImpredChk.impred_lib

--- a/test-suite/misc/impred_set_chk/impred_lib.v
+++ b/test-suite/misc/impred_set_chk/impred_lib.v
@@ -1,0 +1,11 @@
+(* Constants and inductives with and without actual reliance on
+   impredicative Set; the checker validates the stored usage bits. *)
+Definition impred_def : Set := forall X : Set, X -> X.
+Definition impred_unused : nat := 0.
+Definition fires_but_unused : Type := forall X : Set, X -> X.
+Inductive impred_ind : Set := mk_impred : (forall X : Set, X) -> impred_ind.
+Inductive param_ind (A : Prop) : Set := mk_param : A -> param_ind A.
+Lemma opaque_used : True.
+Proof. exact (let x : Set := forall X : Set, X -> X in I). Qed.
+Lemma opaque_unused : True.
+Proof. exact I. Qed.

--- a/test-suite/output/PrintAllAssumptions.out
+++ b/test-suite/output/PrintAllAssumptions.out
@@ -1,5 +1,34 @@
 Closed under the global context
 Axioms:
-impred_def was typed with Set being impredicative.
+impred_def relies on Set being impredicative.
+Theory:
+Set is impredicative
+Axioms:
+mk_impred relies on Set being impredicative.
+impred_ind relies on Set being impredicative.
+Theory:
+Set is impredicative
+Closed under the global context
+Closed under the global context
+Closed under the global context
+Axioms:
+impred_def_nested relies on Set being impredicative.
+Theory:
+Set is impredicative
+Axioms:
+mk_nested relies on Set being impredicative.
+impred_ind_nested relies on Set being impredicative.
+Theory:
+Set is impredicative
+Closed under the global context
+Axioms:
+impred_opaque_used relies on Set being impredicative.
+Theory:
+Set is impredicative
+Closed under the global context
+Closed under the global context
+Axioms:
+mk_param_impred relies on Set being impredicative.
+param_impred_ind relies on Set being impredicative.
 Theory:
 Set is impredicative

--- a/test-suite/output/PrintAllAssumptions.out
+++ b/test-suite/output/PrintAllAssumptions.out
@@ -1,3 +1,5 @@
 Closed under the global context
+Axioms:
+impred_def was typed with Set being impredicative.
 Theory:
 Set is impredicative

--- a/test-suite/output/PrintAllAssumptions.v
+++ b/test-suite/output/PrintAllAssumptions.v
@@ -8,3 +8,31 @@ Print Assumptions impred_def.
 (** With the flag, per-definition theory info is shown *)
 Set Printing All Assumptions.
 Print Assumptions impred_def.
+
+(** Inductive that uses impredicative Set should show it *)
+Print Assumptions impred_ind.
+
+(** Inductive that does not use impredicative Set should not show ImpredicativeSet axiom *)
+Print Assumptions normal_ind.
+
+(** Definitions merely typechecked with -impredicative-set but not
+    relying on it are not reported, even with the flag set *)
+Print Assumptions impred_unused.
+Print Assumptions IdSet.
+
+(** Reliance via a subterm that only typechecks with Set impredicative *)
+Print Assumptions impred_def_nested.
+Print Assumptions impred_ind_nested.
+
+(** The impredicative product rule fired during typechecking, but the
+    definition does not rely on it: cumulativity absorbs the sort
+    difference, and the re-typechecking pass exonerates it *)
+Print Assumptions impred_fires_but_unused.
+
+(** Reliance inside opaque proof bodies (tracked with the opaque proof) *)
+Print Assumptions impred_opaque_used.
+Print Assumptions impred_opaque_unused.
+
+(** Parameterized inductives: no false positive, and no false negative *)
+Print Assumptions param_ind.
+Print Assumptions param_impred_ind.

--- a/test-suite/prerequisite/impred_set_prereq.v
+++ b/test-suite/prerequisite/impred_set_prereq.v
@@ -1,2 +1,22 @@
 (* -*- coq-prog-args: ("-impredicative-set"); -*- *)
 Definition impred_def : Set := forall X : Set, X -> X.
+Inductive impred_ind : Set := mk_impred : (forall X : Set, X) -> impred_ind.
+Inductive normal_ind : Set := mk_normal : True -> normal_ind.
+Definition impred_unused : nat := 0.
+Definition IdSet (A : Set) : Set := A.
+Definition impred_def_nested := IdSet (forall X : Set, X -> X).
+Inductive impred_ind_nested : Set := mk_nested : IdSet (forall X : Set, X -> X) -> impred_ind_nested.
+(* The impredicative product rule fires here (the body is assigned sort
+   Set where predicative inference gives Type), but cumulativity absorbs
+   the difference: no actual reliance. *)
+Definition impred_fires_but_unused : Type := forall X : Set, X -> X.
+(* Reliance inside an opaque proof body. *)
+Lemma impred_opaque_used : True.
+Proof. exact (let x : Set := forall X : Set, X -> X in I). Qed.
+Lemma impred_opaque_unused : True.
+Proof. exact I. Qed.
+(* Parameterized inductives: binding of the block's inductives vs
+   parameters in the predicative recheck. *)
+Inductive param_ind (A : Prop) : Set := mk_param : A -> param_ind A.
+Inductive param_impred_ind (A : Prop) : Set :=
+  mk_param_impred : A -> (forall X : Set, X) -> param_impred_ind A.

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -407,6 +407,19 @@ let assumptions ?(add_opaque=false) ?(add_transparent=false) access st grs =
           let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
           ContextObjectMap.add (Axiom (TypeInType obj, l)) Constr.mkProp accu
       in
+      let accu =
+        if not cb.const_typing_flags.impredicative_set then accu
+        else
+          let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
+          ContextObjectMap.add (Axiom (ImpredicativeSet obj, l)) Constr.mkProp accu
+      in
+      let accu =
+        match cb.const_body with
+        | Symbol _ ->
+          let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
+          ContextObjectMap.add (Axiom (RewriteRules kn, l)) Constr.mkProp accu
+        | _ -> accu
+      in
     if not (Option.has_some contents) then
       let t = type_of_constant cb in
       let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
@@ -451,6 +464,12 @@ let assumptions ?(add_opaque=false) ?(add_transparent=false) access st grs =
         else
           let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
           ContextObjectMap.add (Axiom (IndicesNotMattering m, l)) Constr.mkProp accu
+      in
+      let accu =
+        if not mind.mind_typing_flags.impredicative_set then accu
+        else
+          let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
+          ContextObjectMap.add (Axiom (ImpredicativeSet obj, l)) Constr.mkProp accu
       in
       accu
   in

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -206,7 +206,7 @@ let get_constant_body access kn =
   | Def c -> Some c
   | OpaqueDef o ->
     match Global.force_proof access o with
-    | c, _ -> Some c
+    | c, _, _ -> Some c
     | exception e when CErrors.noncritical e -> None (* missing delayed body, e.g. in vok mode *)
 
 (* [constant_relies_on_impredicative_set access cb] tells whether a
@@ -215,6 +215,17 @@ let get_constant_body access kn =
    predicative environment. *)
 let constant_relies_on_impredicative_set access cb =
   cb.const_typing_flags.impredicative_set &&
+  (* fast path: the stored bits over-approximate usage, so [false]
+     soundly guarantees that the constant does not rely on
+     [-impredicative-set]; the re-typechecking below weeds out the
+     false alarms (cumulativity may absorb the sort difference) *)
+  (cb.const_uses_impredicative_set ||
+   (match cb.const_body with
+    | OpaqueDef o ->
+      (match Global.force_proof access o with
+       | (_, _, uses) -> uses
+       | exception e when CErrors.noncritical e -> false)
+    | Undef _ | Def _ | Primitive _ | Symbol _ -> false)) &&
   let env = Global.env () in
   let env = Environ.set_typing_flags cb.const_typing_flags env in
   let env = Environ.set_impredicative_set false env in
@@ -228,8 +239,8 @@ let constant_relies_on_impredicative_set access cb =
     | Def c -> Some (c, Univ.ContextSet.empty)
     | OpaqueDef o ->
       match Global.force_proof access o with
-      | c, Opaqueproof.PrivateMonomorphic () -> Some (c, Univ.ContextSet.empty)
-      | c, Opaqueproof.PrivatePolymorphic uctx -> Some (c, uctx)
+      | c, Opaqueproof.PrivateMonomorphic (), _ -> Some (c, Univ.ContextSet.empty)
+      | c, Opaqueproof.PrivatePolymorphic uctx, _ -> Some (c, uctx)
       | exception e when CErrors.noncritical e -> None (* missing delayed body, e.g. in vok mode *)
   in
   match

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -209,6 +209,43 @@ let get_constant_body access kn =
     | c, _ -> Some c
     | exception e when CErrors.noncritical e -> None (* missing delayed body, e.g. in vok mode *)
 
+(* [constant_relies_on_impredicative_set access cb] tells whether a
+   constant typechecked with [-impredicative-set] actually relies on the
+   impredicativity of [Set], by re-typechecking its type and body in a
+   predicative environment. *)
+let constant_relies_on_impredicative_set access cb =
+  cb.const_typing_flags.impredicative_set &&
+  let env = Global.env () in
+  let env = Environ.set_typing_flags cb.const_typing_flags env in
+  let env = Environ.set_impredicative_set false env in
+  let env = match cb.const_universes with
+    | Monomorphic -> env
+    | Polymorphic auctx ->
+      Environ.push_context ~strict:false (UVars.AbstractContext.repr auctx) env
+  in
+  let body = match cb.const_body with
+    | Undef _ | Primitive _ | Symbol _ -> None
+    | Def c -> Some (c, Univ.ContextSet.empty)
+    | OpaqueDef o ->
+      match Global.force_proof access o with
+      | c, Opaqueproof.PrivateMonomorphic () -> Some (c, Univ.ContextSet.empty)
+      | c, Opaqueproof.PrivatePolymorphic uctx -> Some (c, uctx)
+      | exception e when CErrors.noncritical e -> None (* missing delayed body, e.g. in vok mode *)
+  in
+  match
+    let _ = Typeops.infer_type env cb.const_type in
+    match body with
+    | None -> true
+    | Some (body, uctx) ->
+      let env = Environ.push_context_set ~strict:false uctx env in
+      let j = Typeops.infer env body in
+      (match Conversion.conv_leq env j.uj_type cb.const_type with
+       | Ok () -> true
+       | Error () -> false)
+  with
+  | ok -> not ok
+  | exception e when CErrors.noncritical e -> true
+
 let rec traverse access (current:GlobRef.t) ctx accu t =
   let open GlobRef in
   let open Constr in
@@ -377,9 +414,15 @@ let assumptions ?(add_opaque=false) ?(add_transparent=false) access st grs =
   let has_impredicative_set = ref false in
   let has_rewrite_rules = ref false in
   let has_type_in_type = ref false in
-  let collect_theory_flags (tf : Declarations.typing_flags) =
-    if tf.impredicative_set then has_impredicative_set := true;
-    if not tf.check_universes then has_type_in_type := true
+  let collect_const_theory_flags ~relies_on_impredicative_set (cb : Declarations.constant_body) =
+    if relies_on_impredicative_set then has_impredicative_set := true;
+    if not cb.const_typing_flags.check_universes then has_type_in_type := true;
+    match cb.const_body with Symbol _ -> has_rewrite_rules := true | _ -> ()
+  in
+  let collect_mind_theory_flags (mind : Declarations.mutual_inductive_body) =
+    if Array.exists (fun mip -> mip.Declarations.mind_uses_impredicative_set) mind.mind_packets then
+      has_impredicative_set := true;
+    if not mind.mind_typing_flags.check_universes then has_type_in_type := true
   in
   let fold obj contents accu = match obj with
   | VarRef id ->
@@ -390,11 +433,8 @@ let assumptions ?(add_opaque=false) ?(add_transparent=false) access st grs =
     else accu
   | ConstRef kn ->
       let cb = lookup_constant kn in
-      collect_theory_flags cb.const_typing_flags;
-      begin match cb.const_body with
-        | Symbol _ -> has_rewrite_rules := true
-        | _ -> ()
-      end;
+      let relies_on_impredicative_set = constant_relies_on_impredicative_set access cb in
+      collect_const_theory_flags ~relies_on_impredicative_set cb;
       let accu =
         if cb.const_typing_flags.check_guarded then accu
         else
@@ -408,7 +448,7 @@ let assumptions ?(add_opaque=false) ?(add_transparent=false) access st grs =
           ContextObjectMap.add (Axiom (TypeInType obj, l)) Constr.mkProp accu
       in
       let accu =
-        if not cb.const_typing_flags.impredicative_set then accu
+        if not relies_on_impredicative_set then accu
         else
           let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
           ContextObjectMap.add (Axiom (ImpredicativeSet obj, l)) Constr.mkProp accu
@@ -434,7 +474,7 @@ let assumptions ?(add_opaque=false) ?(add_transparent=false) access st grs =
       accu
   | IndRef (m,_) | ConstructRef ((m,_),_) ->
       let mind = lookup_mind m in
-      collect_theory_flags mind.mind_typing_flags;
+      collect_mind_theory_flags mind;
       let accu =
         if mind.mind_typing_flags.check_positive then accu
         else
@@ -466,7 +506,7 @@ let assumptions ?(add_opaque=false) ?(add_transparent=false) access st grs =
           ContextObjectMap.add (Axiom (IndicesNotMattering m, l)) Constr.mkProp accu
       in
       let accu =
-        if not mind.mind_typing_flags.impredicative_set then accu
+        if not (Array.exists (fun mip -> mip.mind_uses_impredicative_set) mind.mind_packets) then accu
         else
           let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
           ContextObjectMap.add (Axiom (ImpredicativeSet obj, l)) Constr.mkProp accu

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -214,10 +214,10 @@ let access_opaque_table o =
   in
   match ans with
   | None -> None
-  | Some (c, ctx) ->
-    let (c, ctx) = Discharge.cook_opaque_proofterm ci (c, ctx) in
+  | Some (c, ctx, uses) ->
+    let (c, ctx, uses) = Discharge.cook_opaque_proofterm ci (c, ctx, uses) in
     let c = Mod_subst.subst_mps_list sub c in
-    Some (c, ctx)
+    Some (c, ctx, uses)
 
 let indirect_accessor = {
   Global.access_proof = access_opaque_table;

--- a/vernac/opaques.ml
+++ b/vernac/opaques.ml
@@ -54,12 +54,12 @@ let get_opaque_disk i t =
   let () = assert (0 <= i && i < Array.length t) in
   t.(i)
 
-let set_opaque_disk i (c, priv) t =
+let set_opaque_disk i (c, priv, uses) t =
   let i = Opaqueproof.repr_handle i in
   let () = assert (0 <= i && i < Array.length t) in
   let () = assert (Option.is_empty t.(i)) in
   let _, c = Constr.hcons c in
-  t.(i) <- Some (c, priv)
+  t.(i) <- Some (c, priv, uses)
 
 let current_opaques = Summary.state
 
@@ -96,12 +96,12 @@ let get_current_opaque i =
     match pf with
     | OpaqueValue pf -> Some pf
     | OpaqueCertif cert ->
-      let c, ctx = Safe_typing.repr_certificate (Future.force cert) in
+      let c, ctx, uses = Safe_typing.repr_certificate_usage (Future.force cert) in
       let ctx = match ctx with
       | Opaqueproof.PrivateMonomorphic _ -> Opaqueproof.PrivateMonomorphic ()
       | Opaqueproof.PrivatePolymorphic _ as ctx -> ctx
       in
-      Some (c, ctx)
+      Some (c, ctx, uses)
   with Not_found -> None
 
 let get_current_constraints i =
@@ -144,12 +144,12 @@ let dump ?(except=Future.UUIDSet.empty) () =
     let c = match proof with
     | None -> None
     | Some cert ->
-      let (c, priv) = Safe_typing.repr_certificate cert in
+      let (c, priv, uses) = Safe_typing.repr_certificate_usage cert in
       let priv = match priv with
       | Opaqueproof.PrivateMonomorphic _ -> Opaqueproof.PrivateMonomorphic ()
       | Opaqueproof.PrivatePolymorphic _ as p -> p
       in
-      Some (c, priv)
+      Some (c, priv, uses)
     in
     let () = opaque_table.(i) <- c in
     f2t_map

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -615,7 +615,7 @@ let print_constant env ~with_values with_implicit cst udecl =
     | OpaqueDef o -> begin match with_values with
         | None -> false, typonly, None
         | Some access ->
-          let c, priv = Global.force_proof access o in
+          let c, priv, _uses = Global.force_proof access o in
           let priv = match priv with
             | PrivateMonomorphic () -> None
             | PrivatePolymorphic priv -> Some priv
@@ -797,7 +797,7 @@ let print_full_pure_atomic access env sigma mp lobj =
           str "Theorem " ++ print_basename con ++ cut () ++
           str " : " ++ pr_ltype_env env sigma typ ++ str "." ++ fnl () ++
           str "Proof " ++ pr_lconstr_env env sigma
-            (fst (Global.force_proof access lc))
+            (let (c, _, _) = Global.force_proof access lc in c)
         | Def c ->
           str "Definition " ++ print_basename con ++ cut () ++
           str "  : " ++ pr_ltype_env env sigma typ ++ cut () ++ str " := " ++


### PR DESCRIPTION
`Print Assumptions` now reports impredicative `Set` for a definition or inductive only when it relies on it to typecheck or for its elimination rules, rather than for everything compiled with `-impredicative-set`.

For inductives, `mind_uses_impredicative_set` records whether predicative typechecking would fail, including within arities or constructor types, or whether squashing/elimination analysis would differ. Detection compares the predicative and impredicative results following the `check_indices_matter` pattern.

For constants, the kernel records a sound over-approximation during original typechecking: `Typeops.sort_of_product` marks products assigned `Set` where predicative inference would produce a larger sort. The bit is stored in `constant_body` as `const_uses_impredicative_set` and, for Qed bodies, with the opaque proof term. `Print Assumptions` performs an exact predicative recheck only when this bit is set; false guarantees no reliance, while true may be rejected as a false alarm, as with `Definition d : Type := forall X : Set, X -> X`. Opaque bodies use the indirect accessor, polymorphic and private-polymorphic universe contexts are pushed, and other typing flags are preserved.

Definitions without a declared type re-infer the stored `j.uj_type` for the bit. Section discharge and trusted side-effect prefixes remain conservative over-approximations. Existing public functions retain their types as wrappers around new `*_usage` variants.

`rocq check` validates computed ⇒ stored usage bits for types, transparent bodies, and opaque bodies of constants carrying the `impredicative_set` typing flag; this gating accounts for coqchk applying `-impredicative-set` session-wide.

Tests cover reliance through body sorts, nested subterms, constructor arguments, parameterized inductives, and opaque proof bodies. `impred_unused`, `IdSet`, `param_ind`, and `impred_fires_but_unused` are not reported. `test-suite/misc/impred_set_chk.sh` checks stored bits in a library compiled with the flag. The full local test suite reports `NO FAILURES`; CI has not run.

Overlays:

- paramcoq: rocq-community/paramcoq#157 (draft; adapts to the 3-tuple `opaque_proofterm`, not master-compatible)
- metarocq: https://github.com/JasonGross/metacoq/tree/print-assumptions-fine-grained

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Wordsmithed by Codex.
