### PR TITLE
Add new canonical CDebug flag

### DIFF
--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -525,8 +525,17 @@ let nb_cs_proj_args env ise pc f u =
   let open ValuePattern in
   let na k =
     let open CanonicalSolution in
-    let _, { cvalue_arguments } = find env ise (GlobRef.ConstRef pc, k) in
-    List.length cvalue_arguments in
+    let _, { constant; body; cvalue_arguments } = find env ise (GlobRef.ConstRef pc, k) in
+    let n = List.length cvalue_arguments in
+    debug_canonical_structures (fun () ->
+      let field label pp = hov 2 (str label ++ str ":" ++ spc () ++ pp) in
+      v 0 (str "ssrmatching canonical projection arity" ++
+        fnl () ++ field "projection" (Nametab.pr_global_env Id.Set.empty (GlobRef.ConstRef pc)) ++
+        fnl () ++ field "key" (ValuePattern.print k) ++
+        fnl () ++ field "instance" (hov 1 (Termops.Internal.print_constr_env env ise constant)) ++
+        fnl () ++ field "registered body" (hov 1 (Termops.Internal.print_constr_env env ise body)) ++
+        fnl () ++ field "stored key arg count" (int n)));
+    n in
   let nargs_of_proj t = match EConstr.kind ise t with
       | App(_,args) -> Array.length args
       | Proj _ -> 0 (* if splay_app calls expand_projection, this has to be

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -527,14 +527,16 @@ let nb_cs_proj_args env ise pc f u =
     let open CanonicalSolution in
     let _, { constant; body; cvalue_arguments } = find env ise (GlobRef.ConstRef pc, k) in
     let n = List.length cvalue_arguments in
-    debug_canonical_structures (fun () ->
-      let field label pp = hov 2 (str label ++ str ":" ++ spc () ++ pp) in
-      v 0 (str "ssrmatching canonical projection arity" ++
-        fnl () ++ field "projection" (Nametab.pr_global_env Id.Set.empty (GlobRef.ConstRef pc)) ++
-        fnl () ++ field "key" (ValuePattern.print k) ++
-        fnl () ++ field "instance" (hov 1 (Termops.Internal.print_constr_env env ise constant)) ++
-        fnl () ++ field "registered body" (hov 1 (Termops.Internal.print_constr_env env ise body)) ++
-        fnl () ++ field "stored key arg count" (int n)));
+    let () =
+      debug_canonical_structures (fun () ->
+        let field label pp = hov 2 (str label ++ str ":" ++ spc () ++ pp) in
+        v 0 (str "ssrmatching canonical projection arity" ++
+          fnl () ++ field "projection" (Nametab.pr_global_env Id.Set.empty (GlobRef.ConstRef pc)) ++
+          fnl () ++ field "key" (ValuePattern.print k) ++
+          fnl () ++ field "instance" (hov 1 (Termops.Internal.print_constr_env env ise constant)) ++
+          fnl () ++ field "registered body" (hov 1 (Termops.Internal.print_constr_env env ise body)) ++
+          fnl () ++ field "stored key arg count" (int n)))
+    in
     n in
   let nargs_of_proj t = match EConstr.kind ise t with
       | App(_,args) -> Array.length args

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -297,6 +297,18 @@ let apply_hooks env sigma proj pat =
     try CString.Map.get name !all_hooks env sigma proj pat
     with e when CErrors.noncritical e -> anomaly Pp.(str "CS hook " ++ str name ++ str " exploded")) !active_hooks
 
+let pr_cs_constr env sigma c = Pp.hov 1 (Termops.Internal.print_constr_env env sigma c)
+
+let pr_cs_constr_list env sigma l =
+  Pp.(hov 1 (str "[" ++ prlist_with_sep (fun () -> str ";" ++ spc ()) (pr_cs_constr env sigma) l ++ str "]"))
+
+let pr_cs_stack env sigma sk = Pp.hov 1 (Stack.pr (pr_cs_constr env sigma) sk)
+
+let pr_cs_field label pp = Pp.(hov 2 (str label ++ str ":" ++ spc () ++ pp))
+
+let debug_canonical_unification pp =
+  Structures.debug_canonical_structures (fun () -> Pp.(str "unification: " ++ pp ()))
+
 let decompose_proj ?metas env sigma (t1, sk1) =
    (* I only recognize ConstRef projections since these are the only ones for which
       I know how to obtain the number of parameters. *)
@@ -353,33 +365,97 @@ let decompose_proj ?metas env sigma (t1, sk1) =
    projection would have been reduced) *)
 
 let check_conv_record env sigma ((proji, u), (params1, c1, extra_args1)) (t2,sk2) =
+  debug_canonical_unification Pp.(fun () ->
+    v 0 (str "try canonical projection" ++
+      fnl () ++ pr_cs_field "projection" (Nametab.pr_global_env Id.Set.empty (Names.GlobRef.ConstRef proji)) ++
+      fnl () ++ pr_cs_field "record argument" (pr_cs_constr env sigma c1) ++
+      fnl () ++ pr_cs_field "rhs head" (pr_cs_constr env sigma t2) ++
+      fnl () ++ pr_cs_field "rhs stack" (pr_cs_stack env sigma sk2)));
   let h2, sk2' = decompose_app sigma (shrink_eta sigma t2) in
   let sk2 = Stack.append_app sk2' sk2 in
   let k = Reductionops.Stack.args_size sk2 - Reductionops.Stack.args_size extra_args1 in
   (* Knowing the shape of extra_args1, I can cut sk2 into pieces, extracting extra_args2 from it. *)
   let args2, extra_args2 =
     if k = 0 then [], sk2
-    else if k < 0 then raise Not_found
+    else if k < 0 then begin
+      debug_canonical_unification Pp.(fun () ->
+        str "reject canonical projection: rhs has fewer arguments than projection context");
+      raise Not_found
+    end
     else match Reductionops.Stack.strip_n_app (k-1) sk2 with
-    | None -> raise Not_found
+    | None ->
+      debug_canonical_unification Pp.(fun () ->
+        str "reject canonical projection: cannot split rhs application stack");
+      raise Not_found
     | Some (l',el,s') -> ((Option.get @@ Reductionops.Stack.list_of_app_stack l') @ [el], s') in
   let (pat, _, args2') = try ValuePattern.of_constr sigma h2 with | DestKO -> (Default_cs, None, []) in
+  let observed = k + List.length args2' in
+  debug_canonical_unification Pp.(fun () ->
+    v 0 (str "canonical projection rhs key" ++
+      fnl () ++ pr_cs_field "key" (ValuePattern.print pat) ++
+      fnl () ++ pr_cs_field "key args" (pr_cs_constr_list env sigma args2') ++
+      fnl () ++ pr_cs_field "available rhs args" (int observed)));
+  let find_solution pat =
+    match CanonicalSolution.find env sigma (Names.GlobRef.ConstRef proji, pat) with
+    | exception Not_found ->
+      debug_canonical_unification Pp.(fun () ->
+        str "no canonical entry for key " ++ ValuePattern.print pat);
+      None
+    | sigma, solution -> Some (sigma, solution)
+  in
+  let accept_solution ~default pat ((sigma, (solution : CanonicalSolution.t)) as r) effective_args =
+    let expected = List.length solution.cvalue_arguments in
+    if (default && expected = 0) || ((not default) && expected = observed) then begin
+      debug_canonical_unification Pp.(fun () ->
+        v 0 (str "selected canonical entry" ++
+          fnl () ++ pr_cs_field "key" (ValuePattern.print pat) ++
+          fnl () ++ pr_cs_field "instance" (pr_cs_constr env sigma solution.constant) ++
+          fnl () ++ pr_cs_field "registered body" (pr_cs_constr env sigma solution.body) ++
+          fnl () ++ pr_cs_field "stored key args" (pr_cs_constr_list env sigma solution.cvalue_arguments) ++
+          fnl () ++ pr_cs_field "matched rhs args" (pr_cs_constr_list env sigma effective_args)));
+      Some (r, effective_args)
+    end
+    else begin
+      debug_canonical_unification Pp.(fun () ->
+        v 0 (str "reject canonical entry" ++
+          fnl () ++ pr_cs_field "key" (ValuePattern.print pat) ++
+          fnl () ++ pr_cs_field "instance" (pr_cs_constr env sigma solution.constant) ++
+          fnl () ++ pr_cs_field "expected stored key args" (int expected) ++
+          fnl () ++ pr_cs_field "observed rhs args" (int observed)));
+      None
+    end
+  in
+  let try_hooks () =
+    debug_canonical_unification Pp.(fun () ->
+      str "no canonical entry selected; trying hooks");
+    match (apply_hooks env sigma ((proji, u), params1, c1) (t2, args2)) with
+    | Some r ->
+      debug_canonical_unification Pp.(fun () ->
+        str "canonical hook selected an entry");
+      r, args2' @ args2
+    | None ->
+      debug_canonical_unification Pp.(fun () ->
+        str "no canonical hook selected an entry");
+      raise Not_found
+  in
   let (sigma, solution), sk2_effective =
      (* N.B. In the `Proj` case, the subject needs to be added in args2. *)
-    try begin
-      try
-         let () = if pat = Default_cs then raise Not_found else () in
-         let (sigma, solution) = CanonicalSolution.find env sigma (Names.GlobRef.ConstRef proji, pat) in
-         if List.length solution.cvalue_arguments = k + (List.length args2') then (sigma, solution), args2' @ args2 else raise Not_found
-       with | Not_found ->
-         let (sigma, solution) = CanonicalSolution.find env sigma (Names.GlobRef.ConstRef proji, Default_cs) in
-         (* We have to drop the arguments args2 because the default solution does not have them. *)
-         if List.length solution.cvalue_arguments = 0 then (sigma, solution), [] else raise Not_found
+    match
+      if pat = Default_cs then None
+      else Option.bind (find_solution pat)
+        (fun solution -> accept_solution ~default:false pat solution (args2' @ args2))
+    with
+    | Some r -> r
+    | None ->
+      begin match find_solution Default_cs with
+      | Some solution ->
+        (* We have to drop the arguments args2 because the default solution does not have them. *)
+        begin match accept_solution ~default:true Default_cs solution [] with
+        | Some r -> r
+        | None -> try_hooks ()
+        end
+      | None -> try_hooks ()
       end
-    with | Not_found -> (* If we find no solution, we ask the hook if it has any. *)
-      match (apply_hooks env sigma ((proji, u), params1, c1) (t2, args2)) with
-      | Some r -> r, args2' @ args2
-      | None -> raise Not_found
   in
   let t2 = Stack.zip sigma (h2, (Stack.append_app_list args2 Stack.empty)) in
   let h, _ = decompose_app sigma solution.body in
@@ -1423,7 +1499,17 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) flags env evd pbty
         | LetIn _, _ -> assert false
       end
 
-and conv_record flags env (evd,(h,h2),c,bs,(params,params1),(us,us2),(sk1,sk2),c1,(n,t2)) =
+and conv_record flags env (evd,(h1,h2),c,bs,(params,params1),(us,us2),(sk1,sk2),c1,(n,t2)) =
+  debug_canonical_unification Pp.(fun () ->
+    v 0 (str "solve canonical projection" ++
+      fnl () ++ pr_cs_field "instance" (pr_cs_constr env evd c) ++
+      fnl () ++ pr_cs_field "registered head" (pr_cs_constr env evd h1) ++
+      fnl () ++ pr_cs_field "rhs head" (pr_cs_constr env evd h2) ++
+      fnl () ++ pr_cs_field "stored key args" (pr_cs_constr_list env evd us) ++
+      fnl () ++ pr_cs_field "matched rhs args" (pr_cs_constr_list env evd us2) ++
+      fnl () ++ pr_cs_field "projection stack" (pr_cs_stack env evd sk1) ++
+      fnl () ++ pr_cs_field "rhs stack" (pr_cs_stack env evd sk2)));
+  let result =
   (* Tries to unify the states
 
         (proji params1 c1 | sk1)   =   (proji params2 (c (?xs:bs)) | sk2)
@@ -1481,8 +1567,14 @@ and conv_record flags env (evd,(h,h2),c,bs,(params,params1),(us,us2),(sk1,sk2),c
        (fun i -> exact_ise_stack2 env i (evar_conv_x flags) sk1 sk2);
        test;
        (fun i -> evar_conv_x flags env i CONV h2
-         (fst (decompose_app i (substl ks h))))])
+         (fst (decompose_app i (substl ks h1))))])
   else UnifFailure(evd,(*dummy*)NotSameHead)
+  in
+  debug_canonical_unification Pp.(fun () ->
+    match result with
+    | Success _ -> str "canonical projection solved"
+    | UnifFailure _ -> str "canonical projection failed");
+  result
 
 and eta_constructor flags env evd ((ind, i), u) sk1 (term2,sk2) =
   (* reduces an equation <Construct(ind,i)|sk1> == <term2|sk2> to the

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -365,12 +365,14 @@ let decompose_proj ?metas env sigma (t1, sk1) =
    projection would have been reduced) *)
 
 let check_conv_record env sigma ((proji, u), (params1, c1, extra_args1)) (t2,sk2) =
-  debug_canonical_unification Pp.(fun () ->
-    v 0 (str "try canonical projection" ++
-      fnl () ++ pr_cs_field "projection" (Nametab.pr_global_env Id.Set.empty (Names.GlobRef.ConstRef proji)) ++
-      fnl () ++ pr_cs_field "record argument" (pr_cs_constr env sigma c1) ++
-      fnl () ++ pr_cs_field "rhs head" (pr_cs_constr env sigma t2) ++
-      fnl () ++ pr_cs_field "rhs stack" (pr_cs_stack env sigma sk2)));
+  let () =
+    debug_canonical_unification Pp.(fun () ->
+      v 0 (str "try canonical projection" ++
+        fnl () ++ pr_cs_field "projection" (Nametab.pr_global_env Id.Set.empty (Names.GlobRef.ConstRef proji)) ++
+        fnl () ++ pr_cs_field "record argument" (pr_cs_constr env sigma c1) ++
+        fnl () ++ pr_cs_field "rhs head" (pr_cs_constr env sigma t2) ++
+        fnl () ++ pr_cs_field "rhs stack" (pr_cs_stack env sigma sk2)))
+  in
   let h2, sk2' = decompose_app sigma (shrink_eta sigma t2) in
   let sk2 = Stack.append_app sk2' sk2 in
   let k = Reductionops.Stack.args_size sk2 - Reductionops.Stack.args_size extra_args1 in
@@ -378,64 +380,80 @@ let check_conv_record env sigma ((proji, u), (params1, c1, extra_args1)) (t2,sk2
   let args2, extra_args2 =
     if k = 0 then [], sk2
     else if k < 0 then begin
-      debug_canonical_unification Pp.(fun () ->
-        str "reject canonical projection: rhs has fewer arguments than projection context");
+      let () =
+        debug_canonical_unification Pp.(fun () ->
+          str "reject canonical projection: rhs has fewer arguments than projection context")
+      in
       raise Not_found
     end
     else match Reductionops.Stack.strip_n_app (k-1) sk2 with
     | None ->
-      debug_canonical_unification Pp.(fun () ->
-        str "reject canonical projection: cannot split rhs application stack");
+      let () =
+        debug_canonical_unification Pp.(fun () ->
+          str "reject canonical projection: cannot split rhs application stack")
+      in
       raise Not_found
     | Some (l',el,s') -> ((Option.get @@ Reductionops.Stack.list_of_app_stack l') @ [el], s') in
   let (pat, _, args2') = try ValuePattern.of_constr sigma h2 with | DestKO -> (Default_cs, None, []) in
   let observed = k + List.length args2' in
-  debug_canonical_unification Pp.(fun () ->
-    v 0 (str "canonical projection rhs key" ++
-      fnl () ++ pr_cs_field "key" (ValuePattern.print pat) ++
-      fnl () ++ pr_cs_field "key args" (pr_cs_constr_list env sigma args2') ++
-      fnl () ++ pr_cs_field "available rhs args" (int observed)));
+  let () =
+    debug_canonical_unification Pp.(fun () ->
+      v 0 (str "canonical projection rhs key" ++
+        fnl () ++ pr_cs_field "key" (ValuePattern.print pat) ++
+        fnl () ++ pr_cs_field "key args" (pr_cs_constr_list env sigma args2') ++
+        fnl () ++ pr_cs_field "available rhs args" (int observed)))
+  in
   let find_solution pat =
     match CanonicalSolution.find env sigma (Names.GlobRef.ConstRef proji, pat) with
     | exception Not_found ->
-      debug_canonical_unification Pp.(fun () ->
-        str "no canonical entry for key " ++ ValuePattern.print pat);
+      let () =
+        debug_canonical_unification Pp.(fun () ->
+          str "no canonical entry for key " ++ ValuePattern.print pat)
+      in
       None
     | sigma, solution -> Some (sigma, solution)
   in
   let accept_solution ~default pat ((sigma, (solution : CanonicalSolution.t)) as r) effective_args =
     let expected = List.length solution.cvalue_arguments in
-    if (default && expected = 0) || ((not default) && expected = observed) then begin
-      debug_canonical_unification Pp.(fun () ->
-        v 0 (str "selected canonical entry" ++
-          fnl () ++ pr_cs_field "key" (ValuePattern.print pat) ++
-          fnl () ++ pr_cs_field "instance" (pr_cs_constr env sigma solution.constant) ++
-          fnl () ++ pr_cs_field "registered body" (pr_cs_constr env sigma solution.body) ++
-          fnl () ++ pr_cs_field "stored key args" (pr_cs_constr_list env sigma solution.cvalue_arguments) ++
-          fnl () ++ pr_cs_field "matched rhs args" (pr_cs_constr_list env sigma effective_args)));
+    if (default && expected = 0) || ((not default) && expected = observed) then
+      let () =
+        debug_canonical_unification Pp.(fun () ->
+          v 0 (str "selected canonical entry" ++
+            fnl () ++ pr_cs_field "key" (ValuePattern.print pat) ++
+            fnl () ++ pr_cs_field "instance" (pr_cs_constr env sigma solution.constant) ++
+            fnl () ++ pr_cs_field "registered body" (pr_cs_constr env sigma solution.body) ++
+            fnl () ++ pr_cs_field "stored key args" (pr_cs_constr_list env sigma solution.cvalue_arguments) ++
+            fnl () ++ pr_cs_field "matched rhs args" (pr_cs_constr_list env sigma effective_args)))
+      in
       Some (r, effective_args)
-    end
-    else begin
-      debug_canonical_unification Pp.(fun () ->
-        v 0 (str "reject canonical entry" ++
-          fnl () ++ pr_cs_field "key" (ValuePattern.print pat) ++
-          fnl () ++ pr_cs_field "instance" (pr_cs_constr env sigma solution.constant) ++
-          fnl () ++ pr_cs_field "expected stored key args" (int expected) ++
-          fnl () ++ pr_cs_field "observed rhs args" (int observed)));
+    else
+      let () =
+        debug_canonical_unification Pp.(fun () ->
+          v 0 (str "reject canonical entry" ++
+            fnl () ++ pr_cs_field "key" (ValuePattern.print pat) ++
+            fnl () ++ pr_cs_field "instance" (pr_cs_constr env sigma solution.constant) ++
+            fnl () ++ pr_cs_field "expected stored key args" (int expected) ++
+            fnl () ++ pr_cs_field "observed rhs args" (int observed)))
+      in
       None
-    end
   in
   let try_hooks () =
-    debug_canonical_unification Pp.(fun () ->
-      str "no canonical entry selected; trying hooks");
+    let () =
+      debug_canonical_unification Pp.(fun () ->
+        str "no canonical entry selected; trying hooks")
+    in
     match (apply_hooks env sigma ((proji, u), params1, c1) (t2, args2)) with
     | Some r ->
-      debug_canonical_unification Pp.(fun () ->
-        str "canonical hook selected an entry");
+      let () =
+        debug_canonical_unification Pp.(fun () ->
+          str "canonical hook selected an entry")
+      in
       r, args2' @ args2
     | None ->
-      debug_canonical_unification Pp.(fun () ->
-        str "no canonical hook selected an entry");
+      let () =
+        debug_canonical_unification Pp.(fun () ->
+          str "no canonical hook selected an entry")
+      in
       raise Not_found
   in
   let (sigma, solution), sk2_effective =
@@ -1500,15 +1518,17 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) flags env evd pbty
       end
 
 and conv_record flags env (evd,(h1,h2),c,bs,(params,params1),(us,us2),(sk1,sk2),c1,(n,t2)) =
-  debug_canonical_unification Pp.(fun () ->
-    v 0 (str "solve canonical projection" ++
-      fnl () ++ pr_cs_field "instance" (pr_cs_constr env evd c) ++
-      fnl () ++ pr_cs_field "registered head" (pr_cs_constr env evd h1) ++
-      fnl () ++ pr_cs_field "rhs head" (pr_cs_constr env evd h2) ++
-      fnl () ++ pr_cs_field "stored key args" (pr_cs_constr_list env evd us) ++
-      fnl () ++ pr_cs_field "matched rhs args" (pr_cs_constr_list env evd us2) ++
-      fnl () ++ pr_cs_field "projection stack" (pr_cs_stack env evd sk1) ++
-      fnl () ++ pr_cs_field "rhs stack" (pr_cs_stack env evd sk2)));
+  let () =
+    debug_canonical_unification Pp.(fun () ->
+      v 0 (str "solve canonical projection" ++
+        fnl () ++ pr_cs_field "instance" (pr_cs_constr env evd c) ++
+        fnl () ++ pr_cs_field "registered head" (pr_cs_constr env evd h1) ++
+        fnl () ++ pr_cs_field "rhs head" (pr_cs_constr env evd h2) ++
+        fnl () ++ pr_cs_field "stored key args" (pr_cs_constr_list env evd us) ++
+        fnl () ++ pr_cs_field "matched rhs args" (pr_cs_constr_list env evd us2) ++
+        fnl () ++ pr_cs_field "projection stack" (pr_cs_stack env evd sk1) ++
+        fnl () ++ pr_cs_field "rhs stack" (pr_cs_stack env evd sk2)))
+  in
   let result =
   (* Tries to unify the states
 
@@ -1570,10 +1590,12 @@ and conv_record flags env (evd,(h1,h2),c,bs,(params,params1),(us,us2),(sk1,sk2),
          (fst (decompose_app i (substl ks h1))))])
   else UnifFailure(evd,(*dummy*)NotSameHead)
   in
-  debug_canonical_unification Pp.(fun () ->
-    match result with
-    | Success _ -> str "canonical projection solved"
-    | UnifFailure _ -> str "canonical projection failed");
+  let () =
+    debug_canonical_unification Pp.(fun () ->
+      match result with
+      | Success _ -> str "canonical projection solved"
+      | UnifFailure _ -> str "canonical projection failed")
+  in
   result
 
 and eta_constructor flags env evd ((ind, i), u) sk1 (term2,sk2) =

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -307,7 +307,7 @@ let pr_cs_stack env sigma sk = Pp.hov 1 (Stack.pr (pr_cs_constr env sigma) sk)
 let pr_cs_field label pp = Pp.(hov 2 (str label ++ str ":" ++ spc () ++ pp))
 
 let debug_canonical_unification pp =
-  Structures.debug_canonical_structures (fun () -> Pp.(str "unification: " ++ pp ()))
+  Structures.debug_canonical_structures (fun () -> Pp.(v 0 (str "unification:" ++ fnl () ++ pp ())))
 
 let decompose_proj ?metas env sigma (t1, sk1) =
    (* I only recognize ConstRef projections since these are the only ones for which

--- a/pretyping/structures.ml
+++ b/pretyping/structures.ml
@@ -150,6 +150,8 @@ type obj_typ = {
   o_NPARAMS : int;
   o_TCOMPS : constr list } (* ordered *)
 
+let debug_canonical_structures = CDebug.create ~name:"canonical" ()
+
 module ValuePattern = struct
 
 type t =
@@ -201,6 +203,15 @@ let print = function
 
 end
 
+let pr_debug_field label pp = hov 2 (str label ++ str ":" ++ spc () ++ pp)
+
+let pr_debug_fields fields =
+  v 0 (prlist_with_sep (fun () -> fnl ()) (fun x -> x) fields)
+
+let pr_econstr_list env sigma l =
+  hov 1 (str "[" ++ prlist_with_sep (fun () -> str ";" ++ spc ())
+    (fun c -> hov 1 (Termops.Internal.print_constr_env env sigma c)) l ++ str "]")
+
 module PatMap = Environ.QMap(Map.Make(ValuePattern))(ValuePattern)
 
 module GlobRefMap = Environ.QGlobRef.Map
@@ -244,17 +255,37 @@ let compute_canonical_projections env sigma ~warn (gref,ind) =
   let o_TPARAMS, projs = List.chop p args in
   let o_NPARAMS = List.length o_TPARAMS in
   let lpj = keep_true_projections lpj in
-  List.fold_left2 (fun acc (spopt, canonical) t ->
-      let t = EConstr.Unsafe.to_constr (shrink_eta sigma (EConstr.of_constr t)) in
+  List.fold_left2 (fun acc (spopt, canonical) raw_t ->
+      let t = EConstr.Unsafe.to_constr (shrink_eta sigma (EConstr.of_constr raw_t)) in
       if canonical
       then
         Option.cata (fun proji_sp ->
             match ValuePattern.of_constr sigma (EConstr.of_constr t) with
             | patt, o_INJ, o_TCOMPS ->
+              debug_canonical_structures (fun () ->
+                let env = Environ.push_rel_context sign env in
+                let sigma = Evd.from_env env in
+                pr_debug_fields [
+                  str "register canonical projection";
+                  pr_debug_field "projection" (Nametab.pr_global_env Id.Set.empty (GlobRef.ConstRef proji_sp));
+                  pr_debug_field "instance" (Nametab.pr_global_env Id.Set.empty gref);
+                  pr_debug_field "raw field" (Termops.Internal.print_constr_env env sigma (EConstr.of_constr raw_t));
+                  pr_debug_field "stored field" (Termops.Internal.print_constr_env env sigma (EConstr.of_constr t));
+                  pr_debug_field "eta-shrunk" (str (if Constr.equal raw_t t then "no" else "yes"));
+                  pr_debug_field "key" (ValuePattern.print patt);
+                  pr_debug_field "stored key args" (pr_econstr_list env sigma o_TCOMPS)]);
               ((GlobRef.ConstRef proji_sp, (patt, t)),
                { o_ORIGIN = gref ; o_DEF ; o_CTX ; o_INJ ; o_TABS ; o_TPARAMS ; o_NPARAMS ; o_TCOMPS = List.map EConstr.Unsafe.to_constr o_TCOMPS })
               :: acc
             | exception DestKO ->
+              debug_canonical_structures (fun () ->
+                let env = Environ.push_rel_context sign env in
+                let sigma = Evd.from_env env in
+                pr_debug_fields [
+                  str "ignore canonical projection with no head constant";
+                  pr_debug_field "projection" (Nametab.pr_global_env Id.Set.empty (GlobRef.ConstRef proji_sp));
+                  pr_debug_field "instance" (Nametab.pr_global_env Id.Set.empty gref);
+                  pr_debug_field "field" (Termops.Internal.print_constr_env env sigma (EConstr.of_constr t))]);
               if warn then warn_projection_no_head_constant (sign, env, t, gref, proji_sp);
               acc
           ) acc spopt

--- a/pretyping/structures.ml
+++ b/pretyping/structures.ml
@@ -263,30 +263,34 @@ let compute_canonical_projections env sigma ~warn (gref,ind) =
         Option.cata (fun proji_sp ->
             match ValuePattern.of_constr sigma (EConstr.of_constr t) with
             | patt, o_INJ, o_TCOMPS ->
-              debug_canonical_structures (fun () ->
-                let env = Environ.push_rel_context sign env in
-                let sigma = Evd.from_env env in
-                pr_debug_fields [
-                  str "register canonical projection";
-                  pr_debug_field "projection" (Nametab.pr_global_env Id.Set.empty (GlobRef.ConstRef proji_sp));
-                  pr_debug_field "instance" (Nametab.pr_global_env Id.Set.empty gref);
-                  pr_debug_field "raw field" (Termops.Internal.print_constr_env env sigma (EConstr.of_constr raw_t));
-                  pr_debug_field "stored field" (Termops.Internal.print_constr_env env sigma (EConstr.of_constr t));
-                  pr_debug_field "eta-shrunk" (str (if Constr.equal raw_t t then "no" else "yes"));
-                  pr_debug_field "key" (ValuePattern.print patt);
-                  pr_debug_field "stored key args" (pr_econstr_list env sigma o_TCOMPS)]);
+              let () =
+                debug_canonical_structures (fun () ->
+                  let env = Environ.push_rel_context sign env in
+                  let sigma = Evd.from_env env in
+                  pr_debug_fields [
+                    str "register canonical projection";
+                    pr_debug_field "projection" (Nametab.pr_global_env Id.Set.empty (GlobRef.ConstRef proji_sp));
+                    pr_debug_field "instance" (Nametab.pr_global_env Id.Set.empty gref);
+                    pr_debug_field "raw field" (Termops.Internal.print_constr_env env sigma (EConstr.of_constr raw_t));
+                    pr_debug_field "stored field" (Termops.Internal.print_constr_env env sigma (EConstr.of_constr t));
+                    pr_debug_field "eta-shrunk" (str (if Constr.equal raw_t t then "no" else "yes"));
+                    pr_debug_field "key" (ValuePattern.print patt);
+                    pr_debug_field "stored key args" (pr_econstr_list env sigma o_TCOMPS)])
+              in
               ((GlobRef.ConstRef proji_sp, (patt, t)),
                { o_ORIGIN = gref ; o_DEF ; o_CTX ; o_INJ ; o_TABS ; o_TPARAMS ; o_NPARAMS ; o_TCOMPS = List.map EConstr.Unsafe.to_constr o_TCOMPS })
               :: acc
             | exception DestKO ->
-              debug_canonical_structures (fun () ->
-                let env = Environ.push_rel_context sign env in
-                let sigma = Evd.from_env env in
-                pr_debug_fields [
-                  str "ignore canonical projection with no head constant";
-                  pr_debug_field "projection" (Nametab.pr_global_env Id.Set.empty (GlobRef.ConstRef proji_sp));
-                  pr_debug_field "instance" (Nametab.pr_global_env Id.Set.empty gref);
-                  pr_debug_field "field" (Termops.Internal.print_constr_env env sigma (EConstr.of_constr t))]);
+              let () =
+                debug_canonical_structures (fun () ->
+                  let env = Environ.push_rel_context sign env in
+                  let sigma = Evd.from_env env in
+                  pr_debug_fields [
+                    str "ignore canonical projection with no head constant";
+                    pr_debug_field "projection" (Nametab.pr_global_env Id.Set.empty (GlobRef.ConstRef proji_sp));
+                    pr_debug_field "instance" (Nametab.pr_global_env Id.Set.empty gref);
+                    pr_debug_field "field" (Termops.Internal.print_constr_env env sigma (EConstr.of_constr t))])
+              in
               if warn then warn_projection_no_head_constant (sign, env, t, gref, proji_sp);
               acc
           ) acc spopt

--- a/pretyping/structures.ml
+++ b/pretyping/structures.ml
@@ -151,10 +151,7 @@ type obj_typ = {
   o_TCOMPS : constr list } (* ordered *)
 
 let debug_canonical_structures =
-  let flag, _ = CDebug.create_full ~name:"canonical" () in
-  fun pp ->
-    if CDebug.get_flag flag then
-      Feedback.msg_debug Pp.(hov 2 (str "[canonical]" ++ fnl () ++ pp ()))
+  CDebug.create ~name:"canonical" ()
 
 module ValuePattern = struct
 

--- a/pretyping/structures.ml
+++ b/pretyping/structures.ml
@@ -150,7 +150,11 @@ type obj_typ = {
   o_NPARAMS : int;
   o_TCOMPS : constr list } (* ordered *)
 
-let debug_canonical_structures = CDebug.create ~name:"canonical" ()
+let debug_canonical_structures =
+  let flag, _ = CDebug.create_full ~name:"canonical" () in
+  fun pp ->
+    if CDebug.get_flag flag then
+      Feedback.msg_debug Pp.(hov 2 (str "[canonical]" ++ fnl () ++ pp ()))
 
 module ValuePattern = struct
 

--- a/pretyping/structures.mli
+++ b/pretyping/structures.mli
@@ -82,6 +82,8 @@ val repr : t -> Names.GlobRef.t
 end
 
 
+val debug_canonical_structures : CDebug.t
+
 (** A ValuePattern.t characterizes the form of a component of canonical
     instance and is used to query the data base of canonical instances *)
 module ValuePattern : sig

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1560,10 +1560,12 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env pb flags m n
     let env = fst curenvnb in
     let sigma = substn.subst_sigma in
     let metas = substn.subst_metam in
-    debug_canonical_tactic_unification (fun () ->
-      v 0 (str "try canonical projection" ++ fnl () ++
-        pr_cs_field "projection side" (pr_cs_constr env sigma cM) ++ fnl () ++
-        pr_cs_field "rhs side" (pr_cs_constr env sigma cN)));
+    let () =
+      debug_canonical_tactic_unification (fun () ->
+        v 0 (str "try canonical projection" ++ fnl () ++
+          pr_cs_field "projection side" (pr_cs_constr env sigma cM) ++ fnl () ++
+          pr_cs_field "rhs side" (pr_cs_constr env sigma cN)))
+    in
     let f1l1 = whd_nored_state ~metas:(Meta.meta_handler metas) env sigma (cM,Stack.empty) in
     let f2l2 = whd_nored_state ~metas:(Meta.meta_handler metas) env sigma (cN,Stack.empty) in
     let metasfn substn mv = match Metamap.find mv substn.subst_metam with
@@ -1575,7 +1577,7 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env pb flags m n
     let (sigma,t,c,bs,(params,params1),(us,us2),(ts,ts1),c1,(n,t2)) =
       try Evarconv.check_conv_record env sigma (Evarconv.decompose_proj ~metas:(metasfn substn) env sigma f1l1) f2l2
       with Not_found ->
-        debug_canonical_tactic_unification (fun () -> str "no canonical entry selected");
+        let () = debug_canonical_tactic_unification (fun () -> str "no canonical entry selected") in
         error_cannot_unify env sigma (cM,cN)
     in
     if Reductionops.Stack.compare_shape ts ts1 then
@@ -1609,20 +1611,19 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env pb flags m n
       let substn = test substn in
       unirec_rec curenvnb pb opt' substn (snd t) (fst (decompose_app substn.subst_sigma (substl ks (fst t))))
       with Reductionops.Stack.IncompatibleFold2 ->
-        debug_canonical_tactic_unification (fun () -> str "reject canonical projection: incompatible stacks");
+        let () = debug_canonical_tactic_unification (fun () -> str "reject canonical projection: incompatible stacks") in
         error_cannot_unify env sigma (cM,cN)
-    else begin
-      debug_canonical_tactic_unification (fun () -> str "reject canonical projection: different stack shapes");
+    else
+      let () = debug_canonical_tactic_unification (fun () -> str "reject canonical projection: different stack shapes") in
       error_cannot_unify env sigma (cM,cN)
-    end
     in
     try
       let substn = solve () in
-      debug_canonical_tactic_unification (fun () -> str "canonical projection solved");
+      let () = debug_canonical_tactic_unification (fun () -> str "canonical projection solved") in
       substn
     with e when precatchable_exception e ->
       let e = Exninfo.capture e in
-      debug_canonical_tactic_unification (fun () -> str "canonical projection failed");
+      let () = debug_canonical_tactic_unification (fun () -> str "canonical projection failed") in
       Exninfo.iraise e
   in
 

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -344,6 +344,13 @@ let { Goptions.get = is_keyed_unification } =
 
 let debug_tactic_unification = CDebug.create ~name:"tactic-unification" ()
 
+let debug_canonical_tactic_unification pp =
+  Structures.debug_canonical_structures (fun () -> str "tactic-unification: " ++ pp ())
+
+let pr_cs_constr env sigma c = hov 1 (Termops.Internal.print_constr_env env sigma c)
+
+let pr_cs_field label pp = hov 2 (str label ++ str ":" ++ spc () ++ pp)
+
 let occur_meta_or_undefined_evar evd c =
   (* This is performance-critical. Using the evar-insensitive API changes the
      resulting heuristic. *)
@@ -1550,18 +1557,26 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env pb flags m n
           else error_cannot_unify (fst curenvnb) sigma (cM,cN)
 
   and solve_canonical_projection curenvnb pb opt cM cN substn =
+    let env = fst curenvnb in
     let sigma = substn.subst_sigma in
     let metas = substn.subst_metam in
-    let f1l1 = whd_nored_state ~metas:(Meta.meta_handler metas) (fst curenvnb) sigma (cM,Stack.empty) in
-    let f2l2 = whd_nored_state ~metas:(Meta.meta_handler metas) (fst curenvnb) sigma (cN,Stack.empty) in
+    debug_canonical_tactic_unification (fun () ->
+      v 0 (str "try canonical projection" ++ fnl () ++
+        pr_cs_field "projection side" (pr_cs_constr env sigma cM) ++ fnl () ++
+        pr_cs_field "rhs side" (pr_cs_constr env sigma cN)));
+    let f1l1 = whd_nored_state ~metas:(Meta.meta_handler metas) env sigma (cM,Stack.empty) in
+    let f2l2 = whd_nored_state ~metas:(Meta.meta_handler metas) env sigma (cN,Stack.empty) in
     let metasfn substn mv = match Metamap.find mv substn.subst_metam with
       | Cltyp (_, b) -> Some b.rebus
       | Clval (_, _, b) -> Some b.rebus
       | exception Not_found -> None
     in
+    let solve () =
     let (sigma,t,c,bs,(params,params1),(us,us2),(ts,ts1),c1,(n,t2)) =
-      try Evarconv.check_conv_record (fst curenvnb) sigma (Evarconv.decompose_proj ~metas:(metasfn substn) (fst curenvnb) sigma f1l1) f2l2
-      with Not_found -> error_cannot_unify (fst curenvnb) sigma (cM,cN)
+      try Evarconv.check_conv_record env sigma (Evarconv.decompose_proj ~metas:(metasfn substn) env sigma f1l1) f2l2
+      with Not_found ->
+        debug_canonical_tactic_unification (fun () -> str "no canonical entry selected");
+        error_cannot_unify env sigma (cM,cN)
     in
     if Reductionops.Stack.compare_shape ts ts1 then
       let substn = push_sigma sigma substn in
@@ -1594,8 +1609,21 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env pb flags m n
       let substn = test substn in
       unirec_rec curenvnb pb opt' substn (snd t) (fst (decompose_app substn.subst_sigma (substl ks (fst t))))
       with Reductionops.Stack.IncompatibleFold2 ->
-        error_cannot_unify (fst curenvnb) sigma (cM,cN)
-    else error_cannot_unify (fst curenvnb) sigma (cM,cN)
+        debug_canonical_tactic_unification (fun () -> str "reject canonical projection: incompatible stacks");
+        error_cannot_unify env sigma (cM,cN)
+    else begin
+      debug_canonical_tactic_unification (fun () -> str "reject canonical projection: different stack shapes");
+      error_cannot_unify env sigma (cM,cN)
+    end
+    in
+    try
+      let substn = solve () in
+      debug_canonical_tactic_unification (fun () -> str "canonical projection solved");
+      substn
+    with e when precatchable_exception e ->
+      let e = Exninfo.capture e in
+      debug_canonical_tactic_unification (fun () -> str "canonical projection failed");
+      Exninfo.iraise e
   in
 
   let sigma = subst.subst_sigma in

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -345,7 +345,7 @@ let { Goptions.get = is_keyed_unification } =
 let debug_tactic_unification = CDebug.create ~name:"tactic-unification" ()
 
 let debug_canonical_tactic_unification pp =
-  Structures.debug_canonical_structures (fun () -> str "tactic-unification: " ++ pp ())
+  Structures.debug_canonical_structures (fun () -> v 0 (str "tactic-unification:" ++ fnl () ++ pp ()))
 
 let pr_cs_constr env sigma c = hov 1 (Termops.Internal.print_constr_env env sigma c)
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This output is helpful in debugging canonical structure resolution failure.

I am not quite sure about the messages in unification.ml and evarconv.ml. They are currently emitted as soon as the `canonical` flag  is turned on. Should we instead guard them by the intersection of the new flag and the corresponding existing flag?

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
