### PR TITLE
Fix #22227: retry failed typeclass resolutions with closed goals ordered last

### DIFF
--- a/doc/changelog/02-specification-language/22228-fix-tc-noapplicablehint-defer-Fixed.rst
+++ b/doc/changelog/02-specification-language/22228-fix-tc-noapplicablehint-defer-Fixed.rst
@@ -1,5 +1,9 @@
 - **Fixed:**
-  Typeclass resolution failed eagerly when a goal had no applicable hint, without attempting the remaining goals, whose resolution may instantiate the failed goal's evars by unification; such goals are now deferred and retried after progress (regression in 9.3 from the goal-tactic association fix)
+  Typeclass resolution failed eagerly when a goal had no applicable hint,
+  even when resolving the remaining goals would have instantiated the failed
+  goal's evar by unification; failed final resolutions are now retried once
+  with such goals ordered last (regression in 9.3 from the goal-tactic
+  association fix)
   (`#22228 <https://github.com/rocq-prover/rocq/pull/22228>`_,
   fixes `#22227 <https://github.com/rocq-prover/rocq/issues/22227>`_,
   by Jason Gross).

--- a/doc/changelog/02-specification-language/22228-fix-tc-noapplicablehint-defer-Fixed.rst
+++ b/doc/changelog/02-specification-language/22228-fix-tc-noapplicablehint-defer-Fixed.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Typeclass resolution failed eagerly when a goal had no applicable hint, without attempting the remaining goals, whose resolution may instantiate the failed goal's evars by unification; such goals are now deferred and retried after progress (regression in 9.3 from the goal-tactic association fix)
+  (`#22228 <https://github.com/rocq-prover/rocq/pull/22228>`_,
+  fixes `#22227 <https://github.com/rocq-prover/rocq/issues/22227>`_,
+  by Jason Gross).

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -636,39 +636,7 @@ module Search = struct
             str "considering goal " ++ int glid ++
             str " of status " ++ pr_goal_status status)
         in
-        let rec kont ~first = function
-          | Fail (NoApplicableHint, info)
-            when first && best_effort && allow_out_of_order
-                 && not (List.is_empty tacs) ->
-            tclEVARMAP >>= fun sigma ->
-            let closed =
-              match Evd.find_undefined sigma ev with
-              | evi ->
-                Evar.Set.is_empty
-                  (Evarutil.undefined_evars_of_term sigma (Evd.evar_concl evi))
-              | exception Not_found -> false
-            in
-            if not closed then fk (NoApplicableHint, info) else
-            (* The goal is closed (no undefined evar in its conclusion) and
-               has no applicable hint, so running the search again can never
-               help; but the goal evar itself may still be instantiated as a
-               side effect of resolving the remaining goals, by unification
-               against the type of another instance. Defer it like a
-               non-stuck failure instead of failing the whole resolution
-               eagerly; when it is retried (after further progress, see the
-               generation counter), only check whether its evar was
-               instantiated. The deferral is restricted to closed goals
-               under best-effort mode (the final resolution of the remaining
-               evars of a term) and to the first failure of the goal:
-               deferring open goals, or re-running the search on retries,
-               exhibits exponential behavior under backtracking (e.g. stack
-               overflows in coq-ext-lib and math-classes). *)
-            let () = ppdebug 1 (fun () ->
-                str "Goal " ++ int glid ++
-                str" has no applicable hint, deferring it after the remaining goals.")
-            in
-            let check_solved = focus_goal ev (tclZERO ~info NonStuckFailure) in
-            fixpoint generation tacs ((glid, ev, IsNonStuckFailure, check_solved, generation) :: stuck) fk
+        let rec kont = function
           | Fail ((NonStuckFailure | StuckGoal as exn), info) when allow_out_of_order ->
             let () = ppdebug 1 (fun () ->
                 str "Goal " ++ int glid ++
@@ -709,12 +677,12 @@ module Search = struct
                   let ie = merge_exceptions e ie in
                   begin match fst ie with
                   | NoProgress -> fk ie
-                  | _ -> kont ~first:false (Fail ie)
+                  | _ -> kont (Fail ie)
                   end
-                | _ -> kont ~first:false fail
+                | _ -> kont fail
                 end
-              | next -> kont ~first:false next)
-        in tclCASE tac >>= kont ~first:true
+              | next -> kont next)
+        in tclCASE tac >>= kont
       in
       tclEVARMAP >>= fun sigma ->
       let () = ppdebug 1 (fun () ->
@@ -784,7 +752,47 @@ module Search = struct
          (succ i, ev, IsInitial, focus_goal ev tac, 0))
       0 gls tacs
     in
-    fixpoint 0 tacs [] (fun (e, info) -> tclZERO ~info e) <*>
+    let run tacs = fixpoint 0 tacs [] (fun (e, info) -> tclZERO ~info e) in
+    let run tacs =
+      if not best_effort then run tacs
+      else
+        (* Second-chance pass for failed best-effort resolutions: a goal
+           whose conclusion has no undefined evars (a "closed" goal) cannot
+           be affected by the resolution of the other goals except through
+           the instantiation of its own evar, by unification against the
+           type of another instance (see e.g. #22227, where an instance is
+           reachable only that way, its own hint being unusable). When such
+           a goal fails, letting the remaining goals run first can thus
+           recover a solution. We do this in a separate pass, keeping the
+           failing pass untouched, because changing the failure behavior
+           inside a resolution perturbs the backtracking of resolutions
+           that currently succeed (leading e.g. to exponential blowups);
+           a resolution that fails in the first pass has by definition no
+           behavior to preserve. *)
+        tclORELSE (run tacs)
+          (fun (e, ie) ->
+            tclEVARMAP >>= fun sigma ->
+            let closed (_, ev, _, _, _) =
+              match Evd.find_undefined sigma ev with
+              | evi ->
+                Evar.Set.is_empty
+                  (Evarutil.undefined_evars_of_term sigma (Evd.evar_concl evi))
+              | exception Not_found -> false
+            in
+            let opens, closeds = List.partition (fun g -> not (closed g)) tacs in
+            let reordered = opens @ closeds in
+            let order gs = List.map (fun (glid, _, _, _, _) -> glid) gs in
+            if List.is_empty closeds || List.is_empty opens
+               || List.equal Int.equal (order reordered) (order tacs)
+            then tclZERO ~info:ie e
+            else
+              let () = ppdebug 1 (fun () ->
+                  str "Best-effort resolution failed; retrying with closed goals last: " ++
+                  prlist_with_sep spc int (order reordered))
+              in
+              run reordered)
+    in
+    run tacs <*>
     pr_goals (str "Result goals after fixpoint: ")
 
 

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -636,7 +636,24 @@ module Search = struct
             str "considering goal " ++ int glid ++
             str " of status " ++ pr_goal_status status)
         in
-        let rec kont = function
+        let rec kont ~first = function
+          | Fail (NoApplicableHint, _)
+            when first && allow_out_of_order && not (List.is_empty tacs) ->
+            (* The goal has no applicable hint at this point, but it may
+               still become solvable as a side effect of resolving the
+               remaining goals, by having its evars (possibly including the
+               goal evar itself) instantiated by later unifications. Defer
+               it like a non-stuck failure instead of failing the whole
+               resolution eagerly; it is retried after further progress (see
+               the generation counter) and fails for good only once no other
+               goal can advance. Only the first failure is deferred: once
+               the goal has been successfully run, exhaustion of its
+               solutions keeps triggering backtracking as usual. *)
+            let () = ppdebug 1 (fun () ->
+                str "Goal " ++ int glid ++
+                str" has no applicable hint, deferring it after the remaining goals.")
+            in
+            fixpoint generation tacs ((glid, ev, IsNonStuckFailure, tac, generation) :: stuck) fk
           | Fail ((NonStuckFailure | StuckGoal as exn), info) when allow_out_of_order ->
             let () = ppdebug 1 (fun () ->
                 str "Goal " ++ int glid ++
@@ -677,12 +694,12 @@ module Search = struct
                   let ie = merge_exceptions e ie in
                   begin match fst ie with
                   | NoProgress -> fk ie
-                  | _ -> kont (Fail ie)
+                  | _ -> kont ~first:false (Fail ie)
                   end
-                | _ -> kont fail
+                | _ -> kont ~first:false fail
                 end
-              | next -> kont next)
-        in tclCASE tac >>= kont
+              | next -> kont ~first:false next)
+        in tclCASE tac >>= kont ~first:true
       in
       tclEVARMAP >>= fun sigma ->
       let () = ppdebug 1 (fun () ->

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -637,23 +637,38 @@ module Search = struct
             str " of status " ++ pr_goal_status status)
         in
         let rec kont ~first = function
-          | Fail (NoApplicableHint, _)
-            when first && allow_out_of_order && not (List.is_empty tacs) ->
-            (* The goal has no applicable hint at this point, but it may
-               still become solvable as a side effect of resolving the
-               remaining goals, by having its evars (possibly including the
-               goal evar itself) instantiated by later unifications. Defer
-               it like a non-stuck failure instead of failing the whole
-               resolution eagerly; it is retried after further progress (see
-               the generation counter) and fails for good only once no other
-               goal can advance. Only the first failure is deferred: once
-               the goal has been successfully run, exhaustion of its
-               solutions keeps triggering backtracking as usual. *)
+          | Fail (NoApplicableHint, info)
+            when first && best_effort && allow_out_of_order
+                 && not (List.is_empty tacs) ->
+            tclEVARMAP >>= fun sigma ->
+            let closed =
+              match Evd.find_undefined sigma ev with
+              | evi ->
+                Evar.Set.is_empty
+                  (Evarutil.undefined_evars_of_term sigma (Evd.evar_concl evi))
+              | exception Not_found -> false
+            in
+            if not closed then fk (NoApplicableHint, info) else
+            (* The goal is closed (no undefined evar in its conclusion) and
+               has no applicable hint, so running the search again can never
+               help; but the goal evar itself may still be instantiated as a
+               side effect of resolving the remaining goals, by unification
+               against the type of another instance. Defer it like a
+               non-stuck failure instead of failing the whole resolution
+               eagerly; when it is retried (after further progress, see the
+               generation counter), only check whether its evar was
+               instantiated. The deferral is restricted to closed goals
+               under best-effort mode (the final resolution of the remaining
+               evars of a term) and to the first failure of the goal:
+               deferring open goals, or re-running the search on retries,
+               exhibits exponential behavior under backtracking (e.g. stack
+               overflows in coq-ext-lib and math-classes). *)
             let () = ppdebug 1 (fun () ->
                 str "Goal " ++ int glid ++
                 str" has no applicable hint, deferring it after the remaining goals.")
             in
-            fixpoint generation tacs ((glid, ev, IsNonStuckFailure, tac, generation) :: stuck) fk
+            let check_solved = focus_goal ev (tclZERO ~info NonStuckFailure) in
+            fixpoint generation tacs ((glid, ev, IsNonStuckFailure, check_solved, generation) :: stuck) fk
           | Fail ((NonStuckFailure | StuckGoal as exn), info) when allow_out_of_order ->
             let () = ppdebug 1 (fun () ->
                 str "Goal " ++ int glid ++

--- a/test-suite/success/eauto.v
+++ b/test-suite/success/eauto.v
@@ -231,10 +231,13 @@ Module StrictlyUnique.
 
     Class DynamicType := { dyn_type : Type }.
 
-    (* [WhatIsThis ls] cannot be resolved despite having a clear answer. The
-       fact that the [DynamicType] instance cannot be found makes Coq abandon
-       the search for [WhatIsThis] entirely. *)
-    Fail Example test := Eval lazy in (fun (ls : list dyn_type) => what_is ls _) _.
+    (* [WhatIsThis ls] used to be unresolvable despite having a clear
+       answer: the fact that the [DynamicType] instance cannot be found made
+       Coq abandon the search for [WhatIsThis] entirely. The failed
+       [DynamicType] goal is now deferred behind the remaining goals
+       (rocq-prover/rocq#22228), so [WhatIsThis] resolves; the unresolved
+       [DynamicType] evar is erased by the reduction. *)
+    Example test := Eval lazy in (fun (ls : list dyn_type) => what_is ls _) _.
   End Problem.
 
   Module Solution.

--- a/test-suite/success/eauto.v
+++ b/test-suite/success/eauto.v
@@ -231,13 +231,10 @@ Module StrictlyUnique.
 
     Class DynamicType := { dyn_type : Type }.
 
-    (* [WhatIsThis ls] used to be unresolvable despite having a clear
-       answer: the fact that the [DynamicType] instance cannot be found made
-       Coq abandon the search for [WhatIsThis] entirely. The failed
-       [DynamicType] goal is now deferred behind the remaining goals
-       (rocq-prover/rocq#22228), so [WhatIsThis] resolves; the unresolved
-       [DynamicType] evar is erased by the reduction. *)
-    Example test := Eval lazy in (fun (ls : list dyn_type) => what_is ls _) _.
+    (* [WhatIsThis ls] cannot be resolved despite having a clear answer. The
+       fact that the [DynamicType] instance cannot be found makes Coq abandon
+       the search for [WhatIsThis] entirely. *)
+    Fail Example test := Eval lazy in (fun (ls : list dyn_type) => what_is ls _) _.
   End Problem.
 
   Module Solution.

--- a/test-suite/success/typeclass_defer_no_hint.v
+++ b/test-suite/success/typeclass_defer_no_hint.v
@@ -1,0 +1,21 @@
+(* A typeclass goal with no applicable hint may still be solved as a side
+   effect of resolving the remaining goals: below, [?a : A] has no instance,
+   but resolving [?b : B ?a] with [b0 : B a0] instantiates [?a := a0].
+   The resolution fixpoint must defer the failed goal and retry it after
+   progress instead of failing eagerly (regression in the fix for #21044,
+   which broke fiat-crypto's Bedrock/End2End/X25519/MontgomeryLadder.v:
+   the [FieldParameters] instance is only reachable through unification
+   against the [FieldRepresentation] instance). *)
+Class A : Type := {}.
+Class B (a : A) : Type := {}.
+Axiom a0 : A.
+Axiom b0 : B a0.
+#[local] Existing Instance b0.
+Definition body {a : A} {b : @B a} : nat := 0.
+Definition foo := body.
+
+(* Same, with a successfully resolvable goal in front. *)
+Class W : Type := {}.
+#[global] Instance w0 : W := {}.
+Definition body' {w : W} {a : A} {b : @B a} : nat := 0.
+Definition foo' := body'.


### PR DESCRIPTION
*[Written by Claude (Fable 5) via Claude Code, on behalf of @JasonGross.]*

Fixes #22227, a typeclass-resolution regression from #22037 that breaks fiat-crypto on `rocq/rocq-prover:dev`; see [mit-plv/fiat-crypto#2356](https://github.com/mit-plv/fiat-crypto/issues/2356).

## Problem

After #22037 corrected `search_fixpoint`'s goal-tactic association, `NoApplicableHint` fails before remaining goals run, losing solutions when a later goal could instantiate evars. `NonStuckFailure` does not defer classes without declared `Hint Mode`s because their `all_mode_match` is `false`.

In `Bedrock/End2End/X25519/MontgomeryLadder.v`, stale secvars leave `?field_parameters : FieldParameters` without a direct hint. A later goal solves it by unifying with `frep25519 : FieldRepresentation`.

## Fix

After best-effort resolution fails, retry once with closed goals—those without an undefined evar in their conclusion—last, unless ordering is unchanged. The master fixpoint stays unchanged.

The extra pass costs one bounded search only after failure. It preserves #22037's fix and anti-quadratic behavior: `output/bug_21044.v` and the `success/Typeclasses.v` additions pass. Neither pre-#22037 behavior nor master solved the new test's plain two-goal variant.

## Testing

- Added `test-suite/success/typeclass_defer_no_hint.v`.
- Full local test suite: no failures.
- `MontgomeryLadder.v`, failing on master since b53550ee44, compiles with the fix on both `2274c5dc56` and current master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Wordsmithed by Codex.
