### PR TITLE
Add Ltac2 List.find_index(_opt) and List.find_rev_index(_opt)

### DIFF
--- a/doc/changelog/06-Ltac2-language/22233-ltac2-list-find-index-Added.rst
+++ b/doc/changelog/06-Ltac2-language/22233-ltac2-list-find-index-Added.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Ltac2 functions ``List.find_index``, ``List.find_index_opt``, ``List.find_rev_index`` and ``List.find_rev_index_opt``
+  (`#22233 <https://github.com/rocq-prover/rocq/pull/22233>`_,
+  by Jason Gross).

--- a/test-suite/ltac2/list_find_index.v
+++ b/test-suite/ltac2/list_find_index.v
@@ -1,0 +1,15 @@
+Require Import Ltac2.Ltac2.
+
+Ltac2 Type exn ::= [ Regression_Test_Failure ].
+Ltac2 check (b : bool) := if b then () else Control.throw Regression_Test_Failure.
+Ltac2 check_eq_int_opt (a : int option) (b : int option) := check (Option.equal Int.equal a b).
+
+Ltac2 Eval check_eq_int_opt (List.find_index_opt (Int.equal 2) [1; 2; 3; 2]) (Some 1).
+Ltac2 Eval check_eq_int_opt (List.find_rev_index_opt (Int.equal 2) [1; 2; 3; 2]) (Some 3).
+Ltac2 Eval check_eq_int_opt (List.find_index_opt (Int.equal 9) [1; 2; 3]) None.
+Ltac2 Eval check_eq_int_opt (List.find_rev_index_opt (Int.equal 9) [1; 2; 3]) None.
+Ltac2 Eval check_eq_int_opt (List.find_index_opt (fun _ => true) []) None.
+Ltac2 Eval check (Int.equal (List.find_index (Int.equal 3) [1; 2; 3; 2]) 2).
+Ltac2 Eval check (Int.equal (List.find_rev_index (Int.equal 1) [1; 2; 3; 2]) 0).
+Fail Ltac2 Eval List.find_index (Int.equal 9) [1; 2; 3].
+Fail Ltac2 Eval List.find_rev_index (Int.equal 9) ([] : int list).

--- a/theories/Ltac2/List.v
+++ b/theories/Ltac2/List.v
@@ -790,3 +790,42 @@ Ltac2 rec map_filter (f : 'a -> 'b option) (l : 'a list) : 'b list :=
     | None => map_filter f l
     end
   end.
+
+(** [find_index_opt f xs] returns the index of the _first_ element of
+    the list [xs] satisfying [f].  Returns [None] if no element is
+    found. *)
+Ltac2 find_index_opt (f : 'a -> bool) (xs : 'a list) : int option :=
+  let rec aux i xs :=
+    match xs with
+    | [] => None
+    | x :: xs
+      => match f x with
+         | true => Some i
+         | false => aux (Int.add i 1) xs
+         end
+    end in
+  aux 0 xs.
+
+(** [find_index f xs] returns the index of the _first_ element of the
+    list [xs] satisfying [f].  Throws an exception if no element is
+    found. *)
+Ltac2 find_index (f : 'a -> bool) (xs : 'a list) : int :=
+  match find_index_opt f xs with
+  | Some i => i
+  | None => Control.throw Not_found
+  end.
+
+(** [find_rev_index_opt f xs] returns the index of the _last_ element
+    of the list [xs] satisfying [f].  Returns [None] if no element is
+    found. *)
+Ltac2 find_rev_index_opt (f : 'a -> bool) (xs : 'a list) : int option :=
+  fold_lefti (fun i acc x => match f x with true => Some i | false => acc end) None xs.
+
+(** [find_rev_index f xs] returns the index of the _last_ element of
+    the list [xs] satisfying [f].  Throws an exception if no element
+    is found. *)
+Ltac2 find_rev_index (f : 'a -> bool) (xs : 'a list) : int :=
+  match find_rev_index_opt f xs with
+  | Some i => i
+  | None => Control.throw Not_found
+  end.


### PR DESCRIPTION
Adds `_index` counterparts to `List.find`/`List.find_opt`/`List.find_rev`/`List.find_rev_opt`, preserving their naming and `Not_found` conventions.

Written by Claude (Fable 5) via Claude Code for @JasonGross; extracted from a larger Ltac2 utility library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Wordsmithed by Codex.
