### PR TITLE
Add Ltac2 List.take_while, List.drop_while and List.take_drop_while

### DIFF
--- a/doc/changelog/06-Ltac2-language/22234-ltac2-list-take-drop-while-Added.rst
+++ b/doc/changelog/06-Ltac2-language/22234-ltac2-list-take-drop-while-Added.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Ltac2 functions ``List.take_while``, ``List.drop_while`` and ``List.take_drop_while``
+  (`#22234 <https://github.com/rocq-prover/rocq/pull/22234>`_,
+  by Jason Gross).

--- a/test-suite/ltac2/list_take_drop_while.v
+++ b/test-suite/ltac2/list_take_drop_while.v
@@ -1,0 +1,18 @@
+Require Import Ltac2.Ltac2.
+
+Ltac2 Type exn ::= [ Regression_Test_Failure ].
+Ltac2 check (b : bool) := if b then () else Control.throw Regression_Test_Failure.
+Ltac2 check_eq_l (a : int list) (b : int list) := check (List.equal Int.equal a b).
+
+Ltac2 Eval check_eq_l (List.take_while (Int.gt 3) [1; 2; 3; 1]) [1; 2].
+Ltac2 Eval check_eq_l (List.drop_while (Int.gt 3) [1; 2; 3; 1]) [3; 1].
+Ltac2 Eval check_eq_l (List.take_while (Int.gt 3) []) [].
+Ltac2 Eval check_eq_l (List.drop_while (Int.gt 3) []) [].
+Ltac2 Eval check_eq_l (List.take_while (Int.gt 9) [1; 2]) [1; 2].
+Ltac2 Eval check_eq_l (List.drop_while (Int.gt 9) [1; 2]) [].
+Ltac2 Eval
+  let (pre, rest) := List.take_drop_while (Int.gt 3) [1; 2; 3; 1] in
+  check_eq_l pre [1; 2]; check_eq_l rest [3; 1].
+Ltac2 Eval
+  let (pre, rest) := List.take_drop_while (Int.gt 3) [] in
+  check_eq_l pre []; check_eq_l rest [].

--- a/theories/Ltac2/List.v
+++ b/theories/Ltac2/List.v
@@ -790,3 +790,41 @@ Ltac2 rec map_filter (f : 'a -> 'b option) (l : 'a list) : 'b list :=
     | None => map_filter f l
     end
   end.
+
+(** [take_while f xs] returns the longest prefix of [xs] all of whose
+    elements satisfy [f]. *)
+Ltac2 rec take_while (f : 'a -> bool) (xs : 'a list) : 'a list :=
+  match xs with
+  | [] => []
+  | x :: xs
+    => match f x with
+       | true => x :: take_while f xs
+       | false => []
+       end
+  end.
+
+(** [drop_while f xs] removes the longest prefix of [xs] all of whose
+    elements satisfy [f]. *)
+Ltac2 rec drop_while (f : 'a -> bool) (xs : 'a list) : 'a list :=
+  match xs with
+  | [] => []
+  | x :: tl
+    => match f x with
+       | true => drop_while f tl
+       | false => x :: tl
+       end
+  end.
+
+(** [take_drop_while f xs] returns
+    [(take_while f xs, drop_while f xs)], computed in a single pass. *)
+Ltac2 take_drop_while (f : 'a -> bool) (xs : 'a list) : 'a list * 'a list :=
+  let rec aux acc xs :=
+    match xs with
+    | [] => (rev acc, [])
+    | x :: tl
+      => match f x with
+         | true => aux (x :: acc) tl
+         | false => (rev acc, x :: tl)
+         end
+    end in
+  aux [] xs.


### PR DESCRIPTION
Add `take_while`, `drop_while`, and single-pass `take_drop_while`, returning `(take_while f xs, drop_while f xs)` with the first failing element in the latter. This uses a pair and `_while` naming rather than `span`.

*Written by Claude (Fable 5) via Claude Code on behalf of @JasonGross.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Wordsmithed by Codex.
