### PR TITLE
Add Ltac2 List.shared_prefix and List.shared_prefix_full

### DIFF
--- a/doc/changelog/06-Ltac2-language/22235-ltac2-list-shared-prefix-Added.rst
+++ b/doc/changelog/06-Ltac2-language/22235-ltac2-list-shared-prefix-Added.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Ltac2 functions ``List.shared_prefix`` and ``List.shared_prefix_full``
+  (`#22235 <https://github.com/rocq-prover/rocq/pull/22235>`_,
+  by Jason Gross).

--- a/test-suite/ltac2/list_shared_prefix.v
+++ b/test-suite/ltac2/list_shared_prefix.v
@@ -1,0 +1,21 @@
+Require Import Ltac2.Ltac2.
+
+Ltac2 Type exn ::= [ Regression_Test_Failure ].
+Ltac2 check (b : bool) := if b then () else Control.throw Regression_Test_Failure.
+Ltac2 check_eq_l (a : int list) (b : int list) := check (List.equal Int.equal a b).
+
+Ltac2 Eval
+  let (pre, rest) := List.shared_prefix Int.equal [1; 2; 3] [1; 2; 4; 5] in
+  let (r1, r2) := rest in
+  check_eq_l pre [1; 2]; check_eq_l r1 [3]; check_eq_l r2 [4; 5].
+Ltac2 Eval
+  let (pre, rest) := List.shared_prefix Int.equal [1; 2] [1; 2] in
+  let (r1, r2) := rest in
+  check_eq_l pre [1; 2]; check_eq_l r1 []; check_eq_l r2 [].
+Ltac2 Eval
+  let (pre, rest) := List.shared_prefix Int.equal [] [1] in
+  let (r1, r2) := rest in
+  check_eq_l pre []; check_eq_l r1 []; check_eq_l r2 [1].
+Ltac2 Eval
+  let (pre, _) := List.shared_prefix_full Int.equal [1; 2; 3] [1; 9] in
+  check (Int.equal (List.length pre) 1).

--- a/theories/Ltac2/List.v
+++ b/theories/Ltac2/List.v
@@ -790,3 +790,27 @@ Ltac2 rec map_filter (f : 'a -> 'b option) (l : 'a list) : 'b list :=
     | None => map_filter f l
     end
   end.
+
+(** [shared_prefix_full eq xs ys] splits [xs] and [ys] into their
+    longest common prefix (according to [eq]) and the two remaining
+    suffixes.  The prefix is returned as a list of pairs of the (equal
+    according to [eq], but possibly not identical) elements. *)
+Ltac2 rec shared_prefix_full (eq : 'a -> 'a -> bool) (xs : 'a list) (ys : 'a list)
+  : ('a * 'a) list * ('a list * 'a list) :=
+  match xs, ys with
+  | x :: xs', y :: ys'
+    => match eq x y with
+       | true
+         => let (prefix, rest) := shared_prefix_full eq xs' ys' in
+            ((x, y) :: prefix, rest)
+       | false => ([], (xs, ys))
+       end
+  | _, _ => ([], (xs, ys))
+  end.
+
+(** [shared_prefix eq xs ys] is like [shared_prefix_full], with the
+    common prefix taken from the first list. *)
+Ltac2 shared_prefix (eq : 'a -> 'a -> bool) (xs : 'a list) (ys : 'a list)
+  : 'a list * ('a list * 'a list) :=
+  let (prefix, rest) := shared_prefix_full eq xs ys in
+  (map (fun (x, _) => x) prefix, rest).


### PR DESCRIPTION
Adds longest-common-prefix computation with the remaining suffixes. `shared_prefix_full eq xs ys : ('a * 'a) list * ('a list * 'a list)` keeps both prefix elements, which may differ despite satisfying `eq`; `shared_prefix` keeps those from the first list.

The design choice is `shared_prefix_full`'s pairs-plus-remainders return type.

Written by Claude (Fable 5) via Claude Code for @JasonGross; extracted from a larger Ltac2 utility library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Wordsmithed by Codex.
