### PR TITLE
Add Ltac2 List.firstn_relaxed and List.skipn_relaxed

### DIFF
--- a/doc/changelog/06-Ltac2-language/22236-ltac2-list-firstn-relaxed-Added.rst
+++ b/doc/changelog/06-Ltac2-language/22236-ltac2-list-firstn-relaxed-Added.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Ltac2 functions ``List.firstn_relaxed`` and ``List.skipn_relaxed``
+  (`#22236 <https://github.com/rocq-prover/rocq/pull/22236>`_,
+  by Jason Gross).

--- a/test-suite/ltac2/list_firstn_relaxed.v
+++ b/test-suite/ltac2/list_firstn_relaxed.v
@@ -1,0 +1,14 @@
+Require Import Ltac2.Ltac2.
+
+Ltac2 Type exn ::= [ Regression_Test_Failure ].
+Ltac2 check (b : bool) := if b then () else Control.throw Regression_Test_Failure.
+Ltac2 check_eq_l (a : int list) (b : int list) := check (List.equal Int.equal a b).
+
+Ltac2 Eval check_eq_l (List.firstn_relaxed 2 [1; 2; 3]) [1; 2].
+Ltac2 Eval check_eq_l (List.firstn_relaxed 5 [1; 2; 3]) [1; 2; 3].
+Ltac2 Eval check_eq_l (List.firstn_relaxed 0 [1; 2; 3]) [].
+Ltac2 Eval check_eq_l (List.skipn_relaxed 2 [1; 2; 3]) [3].
+Ltac2 Eval check_eq_l (List.skipn_relaxed 5 [1; 2; 3]) [].
+Ltac2 Eval check_eq_l (List.skipn_relaxed 0 [1; 2; 3]) [1; 2; 3].
+Fail Ltac2 Eval List.firstn_relaxed (Int.neg 1) [1; 2; 3].
+Fail Ltac2 Eval List.skipn_relaxed (Int.neg 1) [1; 2; 3].

--- a/theories/Ltac2/List.v
+++ b/theories/Ltac2/List.v
@@ -790,3 +790,33 @@ Ltac2 rec map_filter (f : 'a -> 'b option) (l : 'a list) : 'b list :=
     | None => map_filter f l
     end
   end.
+
+(** [firstn_relaxed n ls] returns the first [n] elements of [ls], or
+    all of [ls] if [n > length ls].  Throws an exception if [n < 0].
+    Cf [firstn], which throws when [n > length ls]. *)
+Ltac2 rec firstn_relaxed (n : int) (ls : 'a list) : 'a list :=
+  Control.assert_valid_argument "List.firstn_relaxed" (Int.ge n 0);
+  match Int.equal n 0 with
+  | true => []
+  | false
+    => match ls with
+       | [] => []
+       | x :: xs
+         => x :: firstn_relaxed (Int.sub n 1) xs
+       end
+  end.
+
+(** [skipn_relaxed n ls] removes the first [n] elements of [ls],
+    returning the empty list if [n > length ls].  Throws an exception
+    if [n < 0].  Cf [skipn], which throws when [n > length ls]. *)
+Ltac2 rec skipn_relaxed (n : int) (ls : 'a list) : 'a list :=
+  Control.assert_valid_argument "List.skipn_relaxed" (Int.ge n 0);
+  match Int.equal n 0 with
+  | true => ls
+  | false
+    => match ls with
+       | [] => []
+       | _ :: xs
+         => skipn_relaxed (Int.sub n 1) xs
+       end
+  end.


### PR DESCRIPTION
Adds `List.firstn`/`List.skipn` variants that return the whole or empty list when `n > length ls`, like OCaml Base's `List.take`/`List.drop`. `n < 0` remains an `Invalid_argument`.

Naming remains to review: `_relaxed`, `take`/`drop`, or a breaking relaxation of existing `firstn`/`skipn`.

Written by Claude (Fable 5) via Claude Code for @JasonGross; extracted from a larger Ltac2 library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Wordsmithed by Codex.
