### PR TITLE
Add Ltac2 List.map_opt

### DIFF
--- a/doc/changelog/06-Ltac2-language/22237-ltac2-list-map-opt-Added.rst
+++ b/doc/changelog/06-Ltac2-language/22237-ltac2-list-map-opt-Added.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Ltac2 function ``List.map_opt``
+  (`#22237 <https://github.com/rocq-prover/rocq/pull/22237>`_,
+  by Jason Gross).

--- a/test-suite/ltac2/list_map_opt.v
+++ b/test-suite/ltac2/list_map_opt.v
@@ -1,0 +1,14 @@
+Require Import Ltac2.Ltac2.
+
+Ltac2 Type exn ::= [ Regression_Test_Failure ].
+Ltac2 check (b : bool) := if b then () else Control.throw Regression_Test_Failure.
+
+Ltac2 Eval check (Option.equal (List.equal Int.equal)
+  (List.map_opt (fun x => if Int.gt x 0 then Some (Int.add x 1) else None) [1; 2; 3])
+  (Some [2; 3; 4])).
+Ltac2 Eval check (Option.equal (List.equal Int.equal)
+  (List.map_opt (fun x => if Int.gt x 1 then Some x else None) [1; 2; 3])
+  None).
+Ltac2 Eval check (Option.equal (List.equal Int.equal)
+  (List.map_opt (fun (x : int) => (None : int option)) [])
+  (Some [])).

--- a/theories/Ltac2/List.v
+++ b/theories/Ltac2/List.v
@@ -790,3 +790,21 @@ Ltac2 rec map_filter (f : 'a -> 'b option) (l : 'a list) : 'b list :=
     | None => map_filter f l
     end
   end.
+
+(** [map_opt f xs] maps [f] over [xs], returning [Some] of the mapped
+    list if [f] returns [Some] on every element, and [None] otherwise.
+    Cf [map_filter], which instead drops the elements on which [f]
+    returns [None]. *)
+Ltac2 rec map_opt (f : 'a -> 'b option) (xs : 'a list) : 'b list option :=
+  match xs with
+  | [] => Some []
+  | x :: xs
+    => match f x with
+       | Some fx
+         => match map_opt f xs with
+            | Some fxs => Some (fx :: fxs)
+            | None => None
+            end
+       | None => None
+       end
+  end.


### PR DESCRIPTION
*[Written by Claude (Fable 5) via Claude Code, on behalf of @JasonGross; extracted from a larger Ltac2 utility library. One of a series of small independent Ltac2 stdlib additions.]*

Adds `List.map_opt (f : 'a -> 'b option) : 'a list -> 'b list option`, which maps `f` over a list and returns `Some` of the results only if every application succeeds. It returns `None` at the first failure.

The naming is the open design question: `map_opt` may be confused with the existing `map_filter`, which drops `None`s; alternatives include `traverse_opt` or `map_all_opt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Wordsmithed by Codex.
