### PR TITLE
Add Ltac2 String.starts_with, String.ends_with and the String.index family

### DIFF
--- a/doc/changelog/06-Ltac2-language/22238-ltac2-string-search-Added.rst
+++ b/doc/changelog/06-Ltac2-language/22238-ltac2-string-search-Added.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Ltac2 functions ``String.starts_with``, ``String.ends_with``, ``String.index``, ``String.index_opt``, ``String.index_from`` and ``String.index_from_opt``
+  (`#22238 <https://github.com/rocq-prover/rocq/pull/22238>`_,
+  by Jason Gross).

--- a/test-suite/ltac2/string_search.v
+++ b/test-suite/ltac2/string_search.v
@@ -1,0 +1,21 @@
+Require Import Ltac2.Ltac2.
+
+Ltac2 Type exn ::= [ Regression_Test_Failure ].
+Ltac2 check (b : bool) := if b then () else Control.throw Regression_Test_Failure.
+Ltac2 c (s : string) : char := String.get s 0.
+
+Ltac2 Eval check (String.starts_with "He" "Hello").
+Ltac2 Eval check (String.starts_with "" "Hello").
+Ltac2 Eval check (String.starts_with "" "").
+Ltac2 Eval check (Bool.neg (String.starts_with "hello" "He")).
+Ltac2 Eval check (Bool.neg (String.starts_with "eH" "Hello")).
+Ltac2 Eval check (String.ends_with "lo" "Hello").
+Ltac2 Eval check (String.ends_with "" "Hello").
+Ltac2 Eval check (Bool.neg (String.ends_with "Hello!" "lo")).
+Ltac2 Eval check (Int.equal (String.index "banana" (c "a")) 1).
+Ltac2 Eval check (Int.equal (String.index_from "banana" 2 (c "a")) 3).
+Ltac2 Eval check (Option.equal Int.equal (String.index_opt "banana" (c "z")) None).
+Ltac2 Eval check (Option.equal Int.equal (String.index_from_opt "banana" 6 (c "a")) None).
+Fail Ltac2 Eval String.index "banana" (c "z").
+Fail Ltac2 Eval String.index_from_opt "banana" 7 (c "a").
+Fail Ltac2 Eval String.index_from_opt "banana" (Int.neg 1) (c "a").

--- a/theories/Ltac2/String.v
+++ b/theories/Ltac2/String.v
@@ -9,6 +9,10 @@
 (************************************************************************)
 
 Require Import Ltac2.Init.
+Require Ltac2.Int.
+Require Ltac2.Char.
+Require Ltac2.Bool.
+Require Ltac2.Control.
 
 Ltac2 Type t := string.
 
@@ -23,3 +27,56 @@ Ltac2 @external equal : string -> string -> bool := "rocq-runtime.plugins.ltac2"
 Ltac2 @external compare : string -> string -> int := "rocq-runtime.plugins.ltac2" "string_compare".
 
 Ltac2 is_empty s := match s with "" => true | _ => false end.
+
+(** [starts_with prefix s] tests whether [s] begins with [prefix]. *)
+Ltac2 starts_with (prefix : string) (s : string) : bool :=
+  let len_pre := length prefix in
+  if Int.lt (length s) len_pre then false
+  else
+    let rec aux i :=
+      if Int.equal i len_pre then true
+      else if Char.equal (get s i) (get prefix i) then aux (Int.add i 1)
+      else false
+    in aux 0.
+
+(** [ends_with suffix s] tests whether [s] ends with [suffix]. *)
+Ltac2 ends_with (suffix : string) (s : string) : bool :=
+  let len_suf := length suffix in
+  let diff := Int.sub (length s) len_suf in
+  if Int.lt diff 0 then false
+  else
+    let rec aux i :=
+      if Int.equal i len_suf then true
+      else if Char.equal (get s (Int.add diff i)) (get suffix i) then aux (Int.add i 1)
+      else false
+    in aux 0.
+
+(** [index_from_opt s i c] returns the position of the first occurrence
+    of [c] in [s] at or after position [i], if any.  Throws an
+    exception if [i] is not a valid position in [s] (i.e. not between
+    [0] and [length s]). *)
+Ltac2 index_from_opt (s : string) (i : int) (c : char) : int option :=
+  let l := length s in
+  Control.assert_valid_argument "String.index_from_opt"
+    (Bool.and (Int.ge i 0) (Int.le i l));
+  let rec aux i :=
+    if Int.ge i l then None
+    else if Char.equal (get s i) c then Some i
+    else aux (Int.add i 1)
+  in aux i.
+
+(** [index_from s i c] is like [index_from_opt s i c], but throws
+    [Not_found] if [c] does not occur in [s] at or after position [i]. *)
+Ltac2 index_from (s : string) (i : int) (c : char) : int :=
+  match index_from_opt s i c with
+  | Some n => n
+  | None => Control.throw Not_found
+  end.
+
+(** [index_opt s c] returns the position of the first occurrence of
+    [c] in [s], if any. *)
+Ltac2 index_opt (s : string) (c : char) : int option := index_from_opt s 0 c.
+
+(** [index s c] returns the position of the first occurrence of [c] in
+    [s]; throws [Not_found] if there is none. *)
+Ltac2 index (s : string) (c : char) : int := index_from s 0 c.


### PR DESCRIPTION
Adds `starts_with`/`ends_with` to `Ltac2.String`, with the prefix first as in OCaml's `String.starts_with ~prefix`, plus the `index`/`index_opt`/`index_from`/`index_from_opt` family. Following OCaml's `String.index`, throwing variants raise `Not_found` and an out-of-bounds start raises `Invalid_argument`.

The design choice is adopting OCaml's `String.index` conventions wholesale.

Written by Claude (Fable 5) via Claude Code for @JasonGross; extracted from a larger Ltac2 utility library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Wordsmithed by Codex.
