### PR TITLE
Add Ltac2 Char.is_space, String.split_on_char and String.trim

### DIFF
--- a/doc/changelog/06-Ltac2-language/22239-ltac2-string-split-trim-Added.rst
+++ b/doc/changelog/06-Ltac2-language/22239-ltac2-string-split-trim-Added.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Ltac2 functions ``Char.is_space``, ``String.split_on_char`` and ``String.trim``
+  (`#22239 <https://github.com/rocq-prover/rocq/pull/22239>`_,
+  by Jason Gross).

--- a/test-suite/ltac2/string_split_trim.v
+++ b/test-suite/ltac2/string_split_trim.v
@@ -1,0 +1,18 @@
+Require Import Ltac2.Ltac2.
+
+Ltac2 Type exn ::= [ Regression_Test_Failure ].
+Ltac2 check (b : bool) := if b then () else Control.throw Regression_Test_Failure.
+Ltac2 check_eq_sl (a : string list) (b : string list) := check (List.equal String.equal a b).
+Ltac2 comma () : char := String.get "," 0.
+
+Ltac2 Eval check (Char.is_space (String.get " " 0)).
+Ltac2 Eval check (Bool.neg (Char.is_space (String.get "a" 0))).
+Ltac2 Eval check_eq_sl (String.split_on_char (comma ()) "a,b,c") ["a"; "b"; "c"].
+Ltac2 Eval check_eq_sl (String.split_on_char (comma ()) "a,,c,") ["a"; ""; "c"; ""].
+Ltac2 Eval check_eq_sl (String.split_on_char (comma ()) "") [""].
+Ltac2 Eval check_eq_sl (String.split_on_char (comma ()) ",") [""; ""].
+Ltac2 Eval check (String.equal (String.concat (String.make 1 (comma ())) (String.split_on_char (comma ()) "x,y,")) "x,y,").
+Ltac2 Eval check (String.equal (String.trim "  a b  ") "a b").
+Ltac2 Eval check (String.equal (String.trim "a") "a").
+Ltac2 Eval check (String.equal (String.trim "   ") "").
+Ltac2 Eval check (String.equal (String.trim "") "").

--- a/theories/Ltac2/Char.v
+++ b/theories/Ltac2/Char.v
@@ -18,3 +18,13 @@ Ltac2 @external to_int : char -> int := "rocq-runtime.plugins.ltac2" "char_to_in
 
 Ltac2 equal (x : char) (y : char) : bool := Int.equal (to_int x) (to_int y).
 Ltac2 compare (x : char) (y : char) : int := Int.compare (to_int x) (to_int y).
+
+(** [is_space c] tests whether [c] is a whitespace character: space,
+    horizontal tab, newline, carriage return, or form feed. *)
+Ltac2 is_space (c : char) : bool :=
+  let c := to_int c in
+  if Int.equal c 32 then true
+  else if Int.equal c 9 then true
+  else if Int.equal c 10 then true
+  else if Int.equal c 13 then true
+  else Int.equal c 12.

--- a/theories/Ltac2/String.v
+++ b/theories/Ltac2/String.v
@@ -9,6 +9,8 @@
 (************************************************************************)
 
 Require Import Ltac2.Init.
+Require Ltac2.Int.
+Require Ltac2.Char.
 
 Ltac2 Type t := string.
 
@@ -23,3 +25,30 @@ Ltac2 @external equal : string -> string -> bool := "rocq-runtime.plugins.ltac2"
 Ltac2 @external compare : string -> string -> int := "rocq-runtime.plugins.ltac2" "string_compare".
 
 Ltac2 is_empty s := match s with "" => true | _ => false end.
+
+(** [split_on_char sep s] splits [s] into the (possibly empty)
+    substrings delimited by occurrences of [sep], following the
+    conventions of OCaml's [String.split_on_char]: the result is never
+    empty, and [concat (make 1 sep) (split_on_char sep s)] is equal to
+    [s]. *)
+Ltac2 split_on_char (sep : char) (s : string) : string list :=
+  let l := length s in
+  let rec aux from i :=
+    if Int.ge i l then [sub s from (Int.sub i from)]
+    else if Char.equal (get s i) sep
+    then sub s from (Int.sub i from) :: aux (Int.add i 1) (Int.add i 1)
+    else aux from (Int.add i 1)
+  in aux 0 0.
+
+(** [trim s] removes leading and trailing whitespace
+    (cf [Char.is_space]) from [s]. *)
+Ltac2 trim (s : string) : string :=
+  let l := length s in
+  let rec up i :=
+    if Int.lt i l then (if Char.is_space (get s i) then up (Int.add i 1) else i) else i in
+  let rec down i :=
+    let i' := Int.sub i 1 in
+    if Int.ge i' 0 then (if Char.is_space (get s i') then down i' else i) else i in
+  let start := up 0 in
+  let stop := down l in
+  if Int.le stop start then "" else sub s start (Int.sub stop start).


### PR DESCRIPTION
Add `Char.is_space`, `String.split_on_char`, and `String.trim` to Ltac2. Whitespace is space, tab, newline, carriage return, and form feed, matching OCaml's `String.trim`. Split results are never empty and preserve empty segments.

`String.split_on_char` satisfies `String.concat (String.make 1 sep) (split_on_char sep s) = s`. The design choices are the whitespace set and empty-segment behavior.

*[Written by Claude (Fable 5) via Claude Code, on behalf of @JasonGross; extracted from a larger Ltac2 utility library. One of a series of small independent Ltac2 stdlib additions.]*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Wordsmithed by Codex.
