### PR TITLE
Add Ltac2 String.common_prefix, String.strip_prefix and String.replace_char

### DIFF
--- a/doc/changelog/06-Ltac2-language/22240-ltac2-string-affix-Added.rst
+++ b/doc/changelog/06-Ltac2-language/22240-ltac2-string-affix-Added.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Ltac2 functions ``String.length_common_prefix``, ``String.common_prefix``, ``String.strip_prefix`` and ``String.replace_char``
+  (`#22240 <https://github.com/rocq-prover/rocq/pull/22240>`_,
+  by Jason Gross).

--- a/test-suite/ltac2/string_affix.v
+++ b/test-suite/ltac2/string_affix.v
@@ -1,0 +1,16 @@
+Require Import Ltac2.Ltac2.
+
+Ltac2 Type exn ::= [ Regression_Test_Failure ].
+Ltac2 check (b : bool) := if b then () else Control.throw Regression_Test_Failure.
+
+Ltac2 Eval check (Int.equal (String.length_common_prefix "abcd" "abef") 2).
+Ltac2 Eval check (Int.equal (String.length_common_prefix "xyz" "abc") 0).
+Ltac2 Eval check (String.equal (String.common_prefix "abcd" "abef") "ab").
+Ltac2 Eval check (String.equal (String.common_prefix "abc" "abcdef") "abc").
+Ltac2 Eval check (Option.equal String.equal (String.strip_prefix "ab" "abcd") (Some "cd")).
+Ltac2 Eval check (Option.equal String.equal (String.strip_prefix "abcd" "abcd") (Some "")).
+Ltac2 Eval check (Option.equal String.equal (String.strip_prefix "b" "abcd") None).
+Ltac2 Eval check (Option.equal String.equal (String.strip_prefix "abcde" "abcd") None).
+Ltac2 Eval check (String.equal (String.replace_char (String.get "," 0) "; " "a,b,c") "a; b; c").
+Ltac2 Eval check (String.equal (String.replace_char (String.get "," 0) "" ",a,") "a").
+Ltac2 Eval check (String.equal (String.replace_char (String.get "," 0) "x" "abc") "abc").

--- a/theories/Ltac2/String.v
+++ b/theories/Ltac2/String.v
@@ -9,6 +9,8 @@
 (************************************************************************)
 
 Require Import Ltac2.Init.
+Require Ltac2.Int.
+Require Ltac2.Char.
 
 Ltac2 Type t := string.
 
@@ -23,3 +25,40 @@ Ltac2 @external equal : string -> string -> bool := "rocq-runtime.plugins.ltac2"
 Ltac2 @external compare : string -> string -> int := "rocq-runtime.plugins.ltac2" "string_compare".
 
 Ltac2 is_empty s := match s with "" => true | _ => false end.
+
+(** [length_common_prefix s1 s2] returns the length of the longest
+    common prefix of [s1] and [s2]. *)
+Ltac2 length_common_prefix (s1 : string) (s2 : string) : int :=
+  let l1 := length s1 in
+  let l2 := length s2 in
+  let rec aux i :=
+    if Int.lt i l1
+    then if Int.lt i l2
+         then (if Char.equal (get s1 i) (get s2 i) then aux (Int.add i 1) else i)
+         else i
+    else i
+  in aux 0.
+
+(** [common_prefix s1 s2] returns the longest common prefix of [s1]
+    and [s2]. *)
+Ltac2 common_prefix (s1 : string) (s2 : string) : string :=
+  sub s1 0 (length_common_prefix s1 s2).
+
+(** [strip_prefix prefix s] removes [prefix] from the beginning of
+    [s], or returns [None] if [s] does not start with [prefix]. *)
+Ltac2 strip_prefix (prefix : string) (s : string) : string option :=
+  let lp := length prefix in
+  if Int.equal (length_common_prefix prefix s) lp
+  then Some (sub s lp (Int.sub (length s) lp))
+  else None.
+
+(** [replace_char c rep s] replaces every occurrence of the character
+    [c] in [s] with the string [rep]. *)
+Ltac2 replace_char (c : char) (rep : string) (s : string) : string :=
+  let l := length s in
+  let rec aux from i :=
+    if Int.ge i l then [sub s from (Int.sub i from)]
+    else if Char.equal (get s i) c
+    then sub s from (Int.sub i from) :: rep :: aux (Int.add i 1) (Int.add i 1)
+    else aux from (Int.add i 1)
+  in concat "" (aux 0 0).


### PR DESCRIPTION
Adds `length_common_prefix`/`common_prefix`, option-returning `strip_prefix` (`None` on mismatch), and `replace_char c rep s`, which replaces every `c` with `rep`, to `Ltac2.String`. The alternative `strip_prefix` design returns the unchanged string on mismatch.

*[Written by Claude (Fable 5) via Claude Code, on behalf of @JasonGross.]*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Wordsmithed by Codex.
