### PR TITLE
Add Ltac2 Constr.Unsafe.mk* constructor wrappers

### DIFF
--- a/doc/changelog/06-Ltac2-language/22263-ltac2-constr-mk-Added.rst
+++ b/doc/changelog/06-Ltac2-language/22263-ltac2-constr-mk-Added.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Ltac2 constructor wrappers ``Constr.Unsafe.mkRel``, ``mkVar``, ``mkMeta``, ``mkEvar``, ``mkSort``, ``mkCast``, ``mkProd``, ``mkLambda``, ``mkLetIn``, ``mkApp``, ``mkApp_list``, ``mkConstant``, ``mkInd``, ``mkConstructor``, ``mkCase``, ``mkFix``, ``mkCoFix``, ``mkProj``, ``mkUint63``, ``mkFloat``, ``mkString``, ``mkArray`` and ``mkArrow``
+  (`#22263 <https://github.com/rocq-prover/rocq/pull/22263>`_,
+  by Jason Gross).

--- a/test-suite/ltac2/constr_mk.v
+++ b/test-suite/ltac2/constr_mk.v
@@ -1,0 +1,57 @@
+Require Import Ltac2.Ltac2.
+
+Ltac2 Type exn ::= [ Regression_Test_Failure ].
+Ltac2 check (b : bool) := if b then () else Control.throw Regression_Test_Failure.
+
+Ltac2 Eval check (Constr.equal (Constr.Unsafe.mkApp constr:(S) [| constr:(0) |]) constr:(S 0)).
+Ltac2 Eval check (Constr.equal (Constr.Unsafe.mkApp_list constr:(Nat.add) [constr:(1); constr:(2)]) constr:(Nat.add 1 2)).
+Ltac2 Eval
+  (* rebuild constrs from their own kinds via the wrappers *)
+  match Constr.Unsafe.kind constr:(nat -> bool) with
+  | Constr.Unsafe.Prod b body => check (Constr.equal (Constr.Unsafe.mkProd b body) constr:(nat -> bool))
+  | _ => Control.throw Regression_Test_Failure
+  end.
+Ltac2 Eval
+  match Constr.Unsafe.kind constr:(fun n : nat => n) with
+  | Constr.Unsafe.Lambda b body => check (Constr.equal (Constr.Unsafe.mkLambda b body) constr:(fun n : nat => n))
+  | _ => Control.throw Regression_Test_Failure
+  end.
+Ltac2 Eval
+  match Constr.Unsafe.kind constr:(let x := 5 in x) with
+  | Constr.Unsafe.LetIn b v body => check (Constr.equal (Constr.Unsafe.mkLetIn b v body) constr:(let x := 5 in x))
+  | _ => Control.throw Regression_Test_Failure
+  end.
+Ltac2 Eval
+  match Constr.Unsafe.kind constr:(nat) with
+  | Constr.Unsafe.Ind ind inst => check (Constr.equal (Constr.Unsafe.mkInd ind inst) constr:(nat))
+  | _ => Control.throw Regression_Test_Failure
+  end.
+Ltac2 Eval
+  match Constr.Unsafe.kind constr:(S) with
+  | Constr.Unsafe.Constructor cstr inst => check (Constr.equal (Constr.Unsafe.mkConstructor cstr inst) constr:(S))
+  | _ => Control.throw Regression_Test_Failure
+  end.
+Ltac2 Eval
+  match Constr.Unsafe.kind constr:(Nat.add) with
+  | Constr.Unsafe.Constant cst inst => check (Constr.equal (Constr.Unsafe.mkConstant cst inst) constr:(Nat.add))
+  | _ => Control.throw Regression_Test_Failure
+  end.
+Ltac2 Eval
+  match Constr.Unsafe.kind constr:(match 0 with 0 => 1 | S n => n end) with
+  | Constr.Unsafe.Case ci p iv scrut branches =>
+      check (Constr.equal (Constr.Unsafe.mkCase ci p iv scrut branches)
+                          constr:(match 0 with 0 => 1 | S n => n end))
+  | _ => Control.throw Regression_Test_Failure
+  end.
+Ltac2 Eval
+  match Constr.Unsafe.kind constr:(Prop) with
+  | Constr.Unsafe.Sort s => check (Constr.equal (Constr.Unsafe.mkSort s) constr:(Prop))
+  | _ => Control.throw Regression_Test_Failure
+  end.
+Ltac2 Eval check (match Constr.Unsafe.kind (Constr.Unsafe.mkRel 1) with
+                  | Constr.Unsafe.Rel n => Int.equal n 1
+                  | _ => false
+                  end).
+Ltac2 Eval check (Constr.equal
+  (Constr.Unsafe.mkArrow (Some Constr.Binder.Relevant) constr:(nat) constr:(bool))
+  constr:(nat -> bool)).

--- a/theories/Ltac2/Constr.v
+++ b/theories/Ltac2/Constr.v
@@ -430,6 +430,69 @@ Ltac2 map_with_binders (lift : 'a -> binder -> 'a) (f : 'a -> constr -> constr) 
       make (Array u t def ty)
   end.
 
+(** Convenience wrappers around [make], one per constructor of [kind],
+    plus [mkApp_list] and [mkArrow]. *)
+
+Ltac2 mkRel (n : int) : constr := make (Rel n).
+
+Ltac2 mkVar (id : ident) : constr := make (Var id).
+
+Ltac2 mkMeta (m : meta) : constr := make (Meta m).
+
+Ltac2 mkEvar (ev : evar) (args : constr array) : constr := make (Evar ev args).
+
+Ltac2 mkSort (s : sort) : constr := make (Sort s).
+
+Ltac2 mkCast (v : constr) (k : cast) (ty : constr) : constr := make (Cast v k ty).
+
+Ltac2 mkProd (b : binder) (body : constr) : constr := make (Prod b body).
+
+Ltac2 mkLambda (b : binder) (body : constr) : constr := make (Lambda b body).
+
+Ltac2 mkLetIn (b : binder) (v : constr) (body : constr) : constr := make (LetIn b v body).
+
+Ltac2 mkApp (f : constr) (args : constr array) : constr := make (App f args).
+
+Ltac2 mkApp_list (f : constr) (args : constr list) : constr := mkApp f (Array.of_list args).
+
+Ltac2 mkConstant (cst : constant) (inst : instance) : constr := make (Constant cst inst).
+
+Ltac2 mkInd (ind : inductive) (inst : instance) : constr := make (Ind ind inst).
+
+Ltac2 mkConstructor (cstr : constructor) (inst : instance) : constr := make (Constructor cstr inst).
+
+Ltac2 mkCase (ci : case) (p : constr * Relevance.t) (iv : case_invert) (scrut : constr) (branches : constr array) : constr :=
+  make (Case ci p iv scrut branches).
+
+Ltac2 mkFix (structs : int array) (which : int) (tl : binder array) (bl : constr array) : constr :=
+  make (Fix structs which tl bl).
+
+Ltac2 mkCoFix (which : int) (tl : binder array) (bl : constr array) : constr :=
+  make (CoFix which tl bl).
+
+Ltac2 mkProj (p : projection) (r : Relevance.t) (c : constr) : constr := make (Proj p r c).
+
+Ltac2 mkUint63 (n : uint63) : constr := make (Uint63 n).
+
+Ltac2 mkFloat (f : float) : constr := make (Float f).
+
+Ltac2 mkString (s : pstring) : constr := make (String s).
+
+Ltac2 mkArray (inst : instance) (vals : constr array) (def : constr) (ty : constr) : constr :=
+  make (Array inst vals def ty).
+
+(** [mkArrow r a b] builds the non-dependent product [a -> b];
+    [b] is lifted.  The binder is built with [Binder.unsafe_make] when
+    the relevance [r] is given, and with [Binder.make] (which infers
+    the relevance, and requires a focused goal) otherwise. *)
+Ltac2 mkArrow (r : Binder.relevance option) (a : constr) (b : constr) : constr :=
+  let bnd :=
+    match r with
+    | Some r => Binder.unsafe_make None r a
+    | None => Binder.make None a
+    end in
+  mkProd bnd (liftn 1 0 b).
+
 End Unsafe.
 
 Module Cast.


### PR DESCRIPTION
Should these convenience constructors live in a separately importable namespace?

Beyond raw wrappers, this adds `mkApp_list` and `mkArrow`. `mkArrow` takes a `Binder.relevance option`: `Some r` uses `Binder.unsafe_make`; `None` uses `Binder.make`, which infers relevance but requires a focused goal.

Implemented by Claude (Fable 5) on my behalf; these design decisions remain for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Wordsmithed by Codex.
