### PR TITLE
Add Ltac2 Constr.Unsafe.fold(_with_binders) and Constr.has_of_is/has_var/has_fix_or_cofix

### DIFF
--- a/doc/changelog/06-Ltac2-language/22266-ltac2-constr-fold-Added.rst
+++ b/doc/changelog/06-Ltac2-language/22266-ltac2-constr-fold-Added.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Ltac2 functions ``Constr.Unsafe.fold``, ``Constr.Unsafe.fold_with_binders``, ``Constr.has_of_is``, ``Constr.has_var``, ``Constr.is_fix_or_cofix`` and ``Constr.has_fix_or_cofix``
+  (`#22266 <https://github.com/rocq-prover/rocq/pull/22266>`_,
+  by Jason Gross).

--- a/test-suite/ltac2/constr_fold.v
+++ b/test-suite/ltac2/constr_fold.v
@@ -1,0 +1,29 @@
+Require Import Ltac2.Ltac2.
+
+Ltac2 Type exn ::= [ Regression_Test_Failure ].
+Ltac2 check (b : bool) := if b then () else Control.throw Regression_Test_Failure.
+
+(* immediate subterms of [S 0] are [S] and [0] *)
+Ltac2 Eval check (Int.equal (Constr.Unsafe.fold (fun n _ => Int.add n 1) 0 constr:(S 0)) 2).
+(* immediate subterms of [fun x : nat => x] are [nat] and [Rel 1] *)
+Ltac2 Eval check (Int.equal (Constr.Unsafe.fold (fun n _ => Int.add n 1) 0 constr:(fun x : nat => x)) 2).
+Ltac2 Eval check (Int.equal (Constr.Unsafe.fold (fun n _ => Int.add n 1) 0 constr:(0)) 0).
+(* fold_with_binders: sum the binder depths at which subterms occur *)
+Ltac2 Eval check (Int.equal
+  (Constr.Unsafe.fold_with_binders (fun n _ => Int.add n 1)
+     (fun n acc _ => Int.add acc n) 0 0 constr:(fun x : nat => S x))
+  1). (* [nat] at depth 0, [S x] at depth 1 *)
+
+Goal forall x : nat, x = x -> True.
+Proof.
+  intros x h.
+  let t := Constr.type (Control.hyp @h) in check (Constr.has_var t).
+  check (Bool.neg (Constr.has_var constr:(S 0))).
+  exact I.
+Qed.
+
+Ltac2 Eval check (Constr.has_fix_or_cofix constr:(fix f (n : nat) : nat := 0)).
+Ltac2 Eval check (Constr.has_fix_or_cofix constr:(S ((fix f (n : nat) : nat := 0) 0))).
+Ltac2 Eval check (Bool.neg (Constr.has_fix_or_cofix constr:(S 0))).
+Ltac2 Eval check (Constr.is_fix_or_cofix constr:(fix f (n : nat) : nat := 0)).
+Ltac2 Eval check (Constr.has_of_is Constr.is_ind constr:(S 0 = 1)).

--- a/theories/Ltac2/Constr.v
+++ b/theories/Ltac2/Constr.v
@@ -430,6 +430,22 @@ Ltac2 map_with_binders (lift : 'a -> binder -> 'a) (f : 'a -> constr -> constr) 
       make (Array u t def ty)
   end.
 
+(** [fold f acc c] folds [f] over the immediate subterms of [c],
+    mirroring [iter].  Cf the OCaml [Constr.fold]. *)
+Ltac2 fold (f : 'a -> constr -> 'a) (acc : 'a) (c : constr) : 'a :=
+  let cell := { contents := acc } in
+  iter (fun c => cell.(contents) := f (cell.(contents)) c) c;
+  cell.(contents).
+
+(** [fold_with_binders g f n acc c] folds [f n] over the immediate
+    subterms of [c], updating [n] with [g] at each binder traversal,
+    mirroring [iter_with_binders].  Cf the OCaml
+    [Constr.fold_constr_with_binders]. *)
+Ltac2 fold_with_binders (g : 'b -> binder -> 'b) (f : 'b -> 'a -> constr -> 'a) (n : 'b) (acc : 'a) (c : constr) : 'a :=
+  let cell := { contents := acc } in
+  iter_with_binders g (fun n c => cell.(contents) := f n (cell.(contents)) c) n c;
+  cell.(contents).
+
 End Unsafe.
 
 Module Cast.
@@ -648,3 +664,23 @@ Ltac2 is_case(c: constr) :=
   | Unsafe.Case _ _ _ _ _ => true
   | _ => false
   end.
+
+(** [has_of_is is_x c] returns [true] iff [is_x] returns [true] on [c]
+    or on any of its (deep) subterms. *)
+Ltac2 has_of_is (is_x : constr -> bool) (c : constr) : bool :=
+  let rec aux c :=
+    if is_x c then true
+    else Unsafe.fold (fun acc c => if acc then true else aux c) false c
+  in aux c.
+
+(** [has_var c] returns [true] iff [c] contains a named variable. *)
+Ltac2 has_var (c : constr) : bool := has_of_is is_var c.
+
+(** [is_fix_or_cofix c] returns [true] iff [c] is a [Fix] or a
+    [CoFix]. *)
+Ltac2 is_fix_or_cofix (c : constr) : bool :=
+  if is_fix c then true else is_cofix c.
+
+(** [has_fix_or_cofix c] returns [true] iff [c] contains a [Fix] or a
+    [CoFix] as a (deep) subterm. *)
+Ltac2 has_fix_or_cofix (c : constr) : bool := has_of_is is_fix_or_cofix c.


### PR DESCRIPTION
Adds `Constr.Unsafe.fold`/`fold_with_binders` and implements `Constr.has_of_is`, `has_var`, and `has_fix_or_cofix`.

The folds traverse immediate subterms, matching OCaml `Constr.fold`/`fold_constr_with_binders` and Ltac2 `iter`/`iter_with_binders`; deep folds are recursive. They use a local mutable record over `iter`, avoiding duplicate kind dispatch. `has_of_is` checks the term and its deep subterms.

*[Note from Claude (Fable 5), who implemented this on my behalf.]*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Wordsmithed by Codex.
