### PR TITLE
Fix notations and scopes for (hexa)decimal values

### DIFF
--- a/doc/changelog/11-corelib/22270-fix-number-scopes-Fixed.rst
+++ b/doc/changelog/11-corelib/22270-fix-number-scopes-Fixed.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  notations for `Number.uint` and `Number.int` that were broken
+  since the introduction of hexadecimal variants.
+  The notations are now accessible in the `%uint` and `%int`
+  scopes, binded in functions like `Nat.of_num_uint`
+  (`#22270 <https://github.com/rocq-prover/rocq/pull/22270>`_,
+  by Pierre Roux).

--- a/test-suite/output/Arguments.out
+++ b/test-suite/output/Arguments.out
@@ -5,7 +5,7 @@ Arguments Nat.sub (n m)%_nat_scope : simpl nomatch
 The reduction tactics unfold Nat.sub but avoid exposing match constructs
 Nat.sub is transparent
 Expands to: Constant Corelib.Init.Nat.sub
-Declared in library Corelib.Init.Nat, line 71, characters 9-12
+Declared in library Corelib.Init.Nat, line 73, characters 9-12
 Nat.sub : nat -> nat -> nat
 
 Nat.sub is not universe polymorphic
@@ -14,7 +14,7 @@ The reduction tactics unfold Nat.sub when applied to 1 argument
   but avoid exposing match constructs
 Nat.sub is transparent
 Expands to: Constant Corelib.Init.Nat.sub
-Declared in library Corelib.Init.Nat, line 71, characters 9-12
+Declared in library Corelib.Init.Nat, line 73, characters 9-12
 Nat.sub : nat -> nat -> nat
 
 Nat.sub is not universe polymorphic
@@ -24,7 +24,7 @@ The reduction tactics unfold Nat.sub
   when applied to 1 argument but avoid exposing match constructs
 Nat.sub is transparent
 Expands to: Constant Corelib.Init.Nat.sub
-Declared in library Corelib.Init.Nat, line 71, characters 9-12
+Declared in library Corelib.Init.Nat, line 73, characters 9-12
 Nat.sub : nat -> nat -> nat
 
 Nat.sub is not universe polymorphic
@@ -33,7 +33,7 @@ The reduction tactics unfold Nat.sub when the 1st and
   2nd arguments evaluate to a constructor and when applied to 2 arguments
 Nat.sub is transparent
 Expands to: Constant Corelib.Init.Nat.sub
-Declared in library Corelib.Init.Nat, line 71, characters 9-12
+Declared in library Corelib.Init.Nat, line 73, characters 9-12
 Nat.sub : nat -> nat -> nat
 
 Nat.sub is not universe polymorphic
@@ -42,7 +42,7 @@ The reduction tactics unfold Nat.sub when the 1st and
   2nd arguments evaluate to a constructor
 Nat.sub is transparent
 Expands to: Constant Corelib.Init.Nat.sub
-Declared in library Corelib.Init.Nat, line 71, characters 9-12
+Declared in library Corelib.Init.Nat, line 73, characters 9-12
 pf :
 forall {D1 C1 : Type},
 (D1 -> C1) -> forall [D2 C2 : Type], (D2 -> C2) -> D1 * D2 -> C1 * C2

--- a/test-suite/output/NumberNotations.out
+++ b/test-suite/output/NumberNotations.out
@@ -38,7 +38,7 @@ applications of pto_punits. [abstract-large-number,numbers,default]
 File "./output/NumberNotations.v", line 91, characters 32-33:
 The command has indeed failed with message:
 In environment
-v := pto_punits (Number.UIntDecimal (Decimal.D1 Decimal.Nil)) : punit
+v := pto_punits 1 : punit
 The term "v" has type "punit@{Set}" while it is expected to have type
  "punit@{u}"
 (universe inconsistency: Cannot enforce Set = u).
@@ -69,7 +69,7 @@ The command has indeed failed with message:
 In environment
 v := 0 : nat
 The term "v" has type "nat" while it is expected to have type "wuint".
-     = {| unwrap := Number.UIntDecimal (Decimal.D0 Decimal.Nil) |}
+     = {| unwrap := 0 |}
      : wuint
 let v := 0%wuint8' in v : wuint
      : wuint
@@ -93,7 +93,7 @@ The command has indeed failed with message:
 The 'abstract after' directive has no effect when the parsing function
 (of_uint) targets an option type.
 [abstract-large-number-no-op,numbers,default]
-let v := of_uint (Number.UIntDecimal (Decimal.D1 Decimal.Nil)) in v : unit
+let v := of_uint 1 in v : unit
      : unit
 let v := 0%test13 in v : unit
      : unit
@@ -578,3 +578,27 @@ NUnit 0
      : nunit 0
 NUnit (1 + 1)
      : nunit (1 + 1)
+Decimal.D1 (Decimal.D2 Decimal.Nil)
+     : Decimal.uint
+Hexadecimal.D1 (Hexadecimal.Da Hexadecimal.Nil)
+     : Hexadecimal.uint
+Number.UIntDecimal (Decimal.D1 (Decimal.D2 Decimal.Nil))
+     : Number.uint
+Number.UIntHexadecimal (Hexadecimal.D1 (Hexadecimal.Da Hexadecimal.Nil))
+     : Number.uint
+12%duint
+     : Decimal.uint
+0x1a%huint
+     : Hexadecimal.uint
+12%uint
+     : Number.uint
+0x1a%uint
+     : Number.uint
+Nat.of_uint 12
+     : nat
+Nat.of_hex_uint 0x1a
+     : nat
+Nat.of_num_uint 12
+     : nat
+Nat.of_num_uint 0x1a
+     : nat

--- a/test-suite/output/NumberNotations.v
+++ b/test-suite/output/NumberNotations.v
@@ -1056,3 +1056,20 @@ Arguments option {_}.
 Number Notation positive Zto_pos_opt Zpos : mypos_scope2. (* was failing *)
 
 End Bug10878.
+
+(* Test Corelib parser/printer for (hexa)decimal values *)
+Set Printing All.
+Check 12%duint.
+Check 0x1a%huint.
+Check 12%uint.
+Check 0x1a%uint.
+Unset Printing All.
+Check 12%duint.
+Check 0x1a%huint.
+Check 12%uint.
+Check 0x1a%uint.
+(* and check that scopes are correctly binded to types *)
+Check Nat.of_uint 12.
+Check Nat.of_hex_uint 0x1a.
+Check Nat.of_num_uint 12.
+Check Nat.of_num_uint 0x1a.

--- a/test-suite/output/PrintInfos.out
+++ b/test-suite/output/PrintInfos.out
@@ -43,7 +43,7 @@ Nat.add is not universe polymorphic
 Arguments Nat.add (n m)%_nat_scope
 Nat.add is transparent
 Expands to: Constant Corelib.Init.Nat.add
-Declared in library Corelib.Init.Nat, line 47, characters 9-12
+Declared in library Corelib.Init.Nat, line 49, characters 9-12
 Nat.add : nat -> nat -> nat
 
 plus_n_O : forall n : nat, n = n + 0

--- a/test-suite/output/Qf_stdlib.out
+++ b/test-suite/output/Qf_stdlib.out
@@ -9,7 +9,7 @@ Nat.add is not universe polymorphic
 Arguments Nat.add (n m)%_nat_scope
 Nat.add is transparent
 Expands to: Constant Corelib.Init.Nat.add
-Declared in library Corelib.Init.Nat, line 47, characters 9-12
+Declared in library Corelib.Init.Nat, line 49, characters 9-12
 File "./output/Qf_stdlib.v", line 13, characters 6-22:
 Warning: Coq.Init.Nat.add has been replaced by Corelib.Init.Nat.add.
 [deprecated-dirpath-Coq,deprecated-since-9.0,deprecated,default]

--- a/test-suite/output/wish_18097.out
+++ b/test-suite/output/wish_18097.out
@@ -19,4 +19,4 @@ Nat.pow is not universe polymorphic
 Arguments Nat.pow (n m)%_nat_scope
 Nat.pow is transparent
 Expands to: Constant Corelib.Init.Nat.pow
-Declared in library Corelib.Init.Nat, line 143, characters 9-12
+Declared in library Corelib.Init.Nat, line 145, characters 9-12

--- a/theories/Corelib/Init/Decimal.v
+++ b/theories/Corelib/Init/Decimal.v
@@ -64,13 +64,15 @@ Abbreviation int_beq := signed_int_beq.
 Abbreviation internal_int_dec_lb := internal_signed_int_dec_lb.
 Abbreviation internal_int_dec_bl := internal_signed_int_dec_bl.
 
+Module Import NumberNotations.
 Declare Scope dec_uint_scope.
-Delimit Scope dec_uint_scope with uint.
+Delimit Scope dec_uint_scope with duint.
 Bind Scope dec_uint_scope with uint.
 
 Declare Scope dec_int_scope.
-Delimit Scope dec_int_scope with int.
+Delimit Scope dec_int_scope with dint.
 Bind Scope dec_int_scope with int.
+End NumberNotations.
 
 Register uint as num.uint.type.
 Register int as num.int.type.
@@ -256,9 +258,3 @@ with succ_double d :=
   end.
 
 End Little.
-
-(** Pseudo-conversion functions used when declaring
-    Number Notations on [uint] and [int]. *)
-
-Definition uint_of_uint (i:uint) := i.
-Definition int_of_int (i:int) := i.

--- a/theories/Corelib/Init/Hexadecimal.v
+++ b/theories/Corelib/Init/Hexadecimal.v
@@ -68,6 +68,7 @@ Abbreviation int_beq := signed_int_beq.
 Abbreviation internal_int_dec_lb := internal_signed_int_dec_lb.
 Abbreviation internal_int_dec_bl := internal_signed_int_dec_bl.
 
+Module Import NumberNotations.
 Declare Scope hex_uint_scope.
 Delimit Scope hex_uint_scope with huint.
 Bind Scope hex_uint_scope with uint.
@@ -75,6 +76,7 @@ Bind Scope hex_uint_scope with uint.
 Declare Scope hex_int_scope.
 Delimit Scope hex_int_scope with hint.
 Bind Scope hex_int_scope with int.
+End NumberNotations.
 
 Register uint as num.hexadecimal_uint.type.
 Register int as num.hexadecimal_int.type.

--- a/theories/Corelib/Init/Nat.v
+++ b/theories/Corelib/Init/Nat.v
@@ -12,6 +12,8 @@ Require Import Notations Logic Datatypes.
 Require Decimal Hexadecimal Number.
 Local Open Scope nat_scope.
 
+Import Number.NumberNotations.
+
 (**********************************************************************)
 (** * Peano natural numbers, definitions of operations *)
 (**********************************************************************)
@@ -425,11 +427,6 @@ Definition land a b := bitwise andb a a b.
 Definition lor a b := bitwise orb (max a b) a b.
 Definition ldiff a b := bitwise (fun b b' => andb b (negb b')) a a b.
 Definition lxor a b := bitwise xorb (max a b) a b.
-
-Arguments of_hex_uint d%_hex_uint_scope.
-Arguments of_hex_int d%_hex_int_scope.
-Arguments of_uint d%_dec_uint_scope.
-Arguments of_int d%_dec_int_scope.
 
 Module Export NumberNotations.
   Number Notation nat of_num_uint to_num_hex_uint (abstract after 5000) : hex_nat_scope.

--- a/theories/Corelib/Init/Number.v
+++ b/theories/Corelib/Init/Number.v
@@ -10,7 +10,7 @@
 
 (** * Decimal or Hexadecimal numbers *)
 
-Require Import Decimal Hexadecimal.
+Require Import Datatypes Decimal Hexadecimal.
 
 Variant uint := UIntDecimal (u:Decimal.uint) | UIntHexadecimal (u:Hexadecimal.uint).
 
@@ -37,14 +37,28 @@ Register number as num.number.type.
 Definition uint_of_uint (i:uint) := i.
 Definition int_of_int (i:int) := i.
 
-Module NumberNotations.
-  Number Notation Number.uint Number.uint_of_uint Number.uint_of_uint
-    : hex_uint_scope.
-  Number Notation Number.int Number.int_of_int Number.int_of_int
-    : hex_int_scope.
+Definition to_dec_uint (i:uint) := if i is UIntDecimal u then Some u else None.
+Definition to_hex_uint (i:uint) :=
+  if i is UIntHexadecimal u then Some u else None.
 
-  Number Notation Number.uint Number.uint_of_uint Number.uint_of_uint
-    : dec_uint_scope.
-  Number Notation Number.int Number.int_of_int Number.int_of_int
-    : dec_int_scope.
+Definition to_dec_int (i:int) := if i is IntDecimal u then Some u else None.
+Definition to_hex_int (i:int) := if i is IntHexadecimal u then Some u else None.
+
+Module NumberNotations.
+  Export Hexadecimal.NumberNotations.
+  Number Notation Hexadecimal.uint to_hex_uint UIntHexadecimal : hex_uint_scope.
+  Number Notation Hexadecimal.int to_hex_int IntHexadecimal : hex_int_scope.
+
+  Export Decimal.NumberNotations.
+  Number Notation Decimal.uint to_dec_uint UIntDecimal : dec_uint_scope.
+  Number Notation Decimal.int to_dec_int IntDecimal : dec_int_scope.
+
+  Declare Scope num_uint_scope.
+  Delimit Scope num_uint_scope with uint.
+  Bind Scope num_uint_scope with uint.
+  Number Notation uint uint_of_uint uint_of_uint : num_uint_scope.
+  Declare Scope num_int_scope.
+  Delimit Scope num_int_scope with int.
+  Bind Scope num_int_scope with int.
+  Number Notation int int_of_int int_of_int : num_int_scope.
 End NumberNotations.


### PR DESCRIPTION
The trivial parser/printer for these values (used as interface for the `Number Notation` command) were essentially unusable.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
<!-- Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] ~Added **changelog**.~
- [ ] ~Added / updated **documentation**.~
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
<!-- - [ ] Opened **overlay** pull requests. -->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
