### PR TITLE
Fix #22229 (Extraction use "Rocq" prefix instead of "Coq")

### DIFF
--- a/dev/ci/user-overlays/22271-proux01-extraction_rocq_prefix.sh
+++ b/dev/ci/user-overlays/22271-proux01-extraction_rocq_prefix.sh
@@ -1,0 +1,3 @@
+overlay compcert https://github.com/proux01/CompCert rocq22271 22271
+overlay metarocq https://github.com/proux01/metarocq rocq22271 22271
+overlay stdlib https://github.com/proux01/stdlib rocq22271 22271

--- a/dev/ci/user-overlays/22271-proux01-extraction_rocq_prefix.sh
+++ b/dev/ci/user-overlays/22271-proux01-extraction_rocq_prefix.sh
@@ -1,3 +1,2 @@
-overlay compcert https://github.com/proux01/CompCert rocq22271 22271
 overlay metarocq https://github.com/proux01/metarocq rocq22271 22271
 overlay stdlib https://github.com/proux01/stdlib rocq22271 22271

--- a/doc/changelog/13-extraction/22271-extraction_rocq_prefix-Changed.rst
+++ b/doc/changelog/13-extraction/22271-extraction_rocq_prefix-Changed.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  extraction prefix default value from ``Coq`` to ``Rocq``,
+  use the new option :opt:`Extraction Prefix` to customize it
+  (`#22271 <https://github.com/rocq-prover/rocq/pull/22271>`_,
+  fixes `#22229 <https://github.com/rocq-prover/rocq/issues/22229>`_,
+  by Pierre Roux).

--- a/doc/sphinx/addendum/extraction.rst
+++ b/doc/sphinx/addendum/extraction.rst
@@ -75,8 +75,8 @@ the command :cmd:`Cd`.
    :cmd:`Recursive Extraction Library`, except that only the needed
    parts of Rocq libraries are extracted instead of the whole.
    The naming convention in case of name clash is the same one as
-   :cmd:`Extraction Library`: identifiers are here renamed using prefixes
-   ``coq_``  or ``Coq_``.
+   :cmd:`Extraction Library`: identifiers are here renamed using
+   :opt:`Extraction Prefix`.
 
 The following command is meant to help automatic testing of
 the extraction, see for instance the ``test-suite`` directory
@@ -623,6 +623,10 @@ Additional settings
    files will be written to the directory specified by the command line
    option :n:`-output-directory`, if set (see :ref:`command-line-options`) and
    otherwise, the current directory.  Use :cmd:`Pwd` to display the current directory.
+
+.. opt:: Extraction Prefix @string
+
+   Prefix to use in resulting code, defaults to ``Rocq``.
 
 Differences between Rocq and ML type systems
 ----------------------------------------------

--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -115,11 +115,14 @@ let pseudo_qualify = qualify "__"
 let is_upper s = match s.[0] with 'A' .. 'Z' -> true | _ -> false
 let is_lower s = match s.[0] with 'a' .. 'z' | '_' -> true | _ -> false
 
+let lowercase_prefix () = String.uncapitalize_ascii (Table.prefix ())
+let uppercase_prefix () = Table.prefix ()
+
 let lowercase_id id = Id.of_string (String.uncapitalize_ascii (ascii_of_id id))
 let uppercase_id id =
   let s = ascii_of_id id in
   assert (not (String.is_empty s));
-  if s.[0] == '_' then Id.of_string ("Coq_"^s)
+  if s.[0] == '_' then Id.of_string (uppercase_prefix ()^"_"^s)
   else Id.of_string (String.capitalize_ascii s)
 
 type kind = Term | Type | Cons | Mod
@@ -366,7 +369,7 @@ let clear_mpfiles s =
 let add_duplicate s mp l =
   let state = s.state.contents in
   let (index, dups) = state.duplicates in
-  let ren = "Coq__" ^ string_of_int (index + 1) in
+  let ren = uppercase_prefix () ^ "__" ^ string_of_int (index + 1) in
   let dups = DupMap.add (mp, l) ren dups in
   s.state := { state with duplicates = (index + 1, dups) }
 
@@ -409,13 +412,15 @@ let get_mpfiles_content s mp =
 (*S Renaming functions *)
 
 (* This function creates from [id] a correct uppercase/lowercase identifier.
-   This is done by adding a [Coq_] or [coq_] prefix. To avoid potential clashes
-   with previous [Coq_id] variable, these prefixes are duplicated if already
+   This is done by adding a [Rocq_] or [rocq_] prefix. To avoid potential clashes
+   with previous [Rocq_id] variable, these prefixes are duplicated if already
    existing. *)
 
 let modular_rename table k id =
   let s = ascii_of_id id in
-  let prefix,is_ok = if upperkind k then "Coq_",is_upper else "coq_",is_lower
+  let prefix,is_ok =
+    if upperkind k then uppercase_prefix () ^ "_",is_upper
+    else lowercase_prefix () ^ "_",is_lower
   in
   if not (is_ok s) || Id.Set.mem id (State.get_keywords table) || begins_with s prefix
   then prefix ^ s
@@ -429,12 +434,12 @@ let modfstlev_rename table id =
     let n = State.get_mod_index table id in
     let () = State.add_mod_index table id (n+1) in
     let s = if n == 0 then "" else string_of_int (n-1) in
-    "Coq"^s^"_"^(ascii_of_id id)
+    uppercase_prefix ()^s^"_"^(ascii_of_id id)
   with Not_found ->
     let s = ascii_of_id id in
     if is_lower s || begins_with_CoqXX s then
       let () = State.add_mod_index table id 1 in
-      "Coq_" ^ s
+      uppercase_prefix () ^ "_" ^ s
     else
       let () = State.add_mod_index table id 0 in
       s

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -594,7 +594,13 @@ let keep_singleton = my_bool_option "KeepSingleton" false
 (*s Extraction Prefix *)
 
 let { Goptions.get = prefix } =
-  declare_string_option_and_ref
+  declare_interpreted_string_option_and_ref
+    (fun s ->
+      let () = if not (Unicode.is_basic_ascii s && Id.is_valid s) then
+        user_err Pp.(str "Extraction prefix must be a valid ASCII identifier.")
+      in
+      String.capitalize_ascii s)
+    Fun.id
     ~key:["Extraction"; "Prefix"]
     ~value:"Rocq"
     ()

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -591,6 +591,14 @@ let type_expand = my_bool_option "TypeExpand" true
 
 let keep_singleton = my_bool_option "KeepSingleton" false
 
+(*s Extraction Prefix *)
+
+let { Goptions.get = prefix } =
+  declare_string_option_and_ref
+    ~key:["Extraction"; "Prefix"]
+    ~value:"Rocq"
+    ()
+
 (*s Extraction Optimize *)
 
 type opt_flag =

--- a/plugins/extraction/table.mli
+++ b/plugins/extraction/table.mli
@@ -127,6 +127,10 @@ val type_expand : unit -> bool
 
 val keep_singleton : unit -> bool
 
+(*s Prefix parameter *)
+
+val prefix : unit -> string
+
 (*s Optimize parameter *)
 
 type opt_flag =

--- a/test-suite/output/Qf_extraction.out
+++ b/test-suite/output/Qf_extraction.out
@@ -7,7 +7,7 @@ Quickfix:
 Replace File "./output/Qf_extraction.v", line 5, characters 11-14 with Qf_extraction.nat
 Replace File "./output/Qf_extraction.v", line 5, characters 11-14 with Corelib.Init.Datatypes.nat
 
-module Coq_nat =
+module Rocq_nat =
  struct
  end
 

--- a/test-suite/output/bug7348.out
+++ b/test-suite/output/bug7348.out
@@ -11,14 +11,14 @@ type bool =
 
 module Case1 =
  struct
-  type coq_rec = { f : bool }
+  type rocq_rec = { f : bool }
 
-  (** val f : bool -> coq_rec -> bool **)
+  (** val f : bool -> rocq_rec -> bool **)
 
   let f _ r =
     r.f
 
-  (** val silly : bool -> coq_rec -> __ **)
+  (** val silly : bool -> rocq_rec -> __ **)
 
   let silly x b =
     match x with
@@ -28,14 +28,14 @@ module Case1 =
 
 module Case2 =
  struct
-  type coq_rec = { f : (bool -> bool) }
+  type rocq_rec = { f : (bool -> bool) }
 
-  (** val f : bool -> coq_rec -> bool -> bool **)
+  (** val f : bool -> rocq_rec -> bool -> bool **)
 
   let f _ r =
     r.f
 
-  (** val silly : bool -> coq_rec -> __ **)
+  (** val silly : bool -> rocq_rec -> __ **)
 
   let silly x b =
     match x with


### PR DESCRIPTION
Fixes https://github.com/rocq-prover/rocq/issues/22229

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

#### Overlays (to be merged before the PR)

* https://github.com/AbsInt/CompCert/pull/589

#### Overlays (to be merged in sync with the PR)

* https://github.com/MetaRocq/metarocq/pull/1291
* https://github.com/rocq-prover/stdlib/pull/292

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
