### PR TITLE
Add Printing Reversible flags: check printed terms reparse to equal terms, escalating printing options when not

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/22283-reversible-printing-Added.rst
+++ b/doc/changelog/08-vernac-commands-and-options/22283-reversible-printing-Added.rst
@@ -1,0 +1,11 @@
+- **Added:**
+  flags ``Printing Reversible Up To Unification``,
+  ``Printing Reversible Up To Conversion Modulo Sorts And Universes``,
+  ``Printing Reversible Up To Conversion Modulo Universes``,
+  ``Printing Reversible Up To Conversion Modulo Universe Unification`` and
+  ``Printing Reversible Up To Conversion``, which check, each time a term
+  is printed, that the printed form can be parsed and elaborated back to
+  a term equal to the original one up to the selected equivalence, and
+  progressively turn more printing options on until this is the case
+  (`#22283 <https://github.com/rocq-prover/rocq/pull/22283>`_,
+  written by Claude (Anthropic), for Jason Gross).

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -1164,6 +1164,101 @@ Printing constructions in full
 
    This flag is off by default.
 
+.. _reversible-printing:
+
+Checking that printed terms can be parsed back (reversible printing)
+--------------------------------------------------------------------
+
+Because notations, hidden implicit arguments, hidden coercions or hidden
+universe instances can make different terms print alike, the printed form
+of a term cannot always be parsed and elaborated back to the term it
+stands for. Rather than unconditionally making printing fully explicit as
+:flag:`Printing All` does, the following flags keep the current printing
+options, but check, each time a term is printed, that its printed form
+can be parsed and elaborated back to a term equal to the original one, up
+to the equivalence selected by the flag; when the check fails, printing
+options are progressively turned on — first :flag:`Printing Coercions`,
+then :flag:`Printing Implicit`, then unsetting :flag:`Printing Notations`,
+then :flag:`Printing Universes` (first with, then without notations),
+then :flag:`Printing Parentheses` and finally all the options implied by
+:flag:`Printing All` — until the printed form passes the check.
+
+These five flags are mutually exclusive: setting one of them unsets the
+others, and unsetting the currently set one turns the checks off
+entirely. All are off by default. Since every displayed term is re-parsed
+and re-elaborated (possibly several times), printing can become
+noticeably more expensive when one of these flags is set.
+
+.. flag:: Printing Reversible Up To Unification
+
+   The re-parsed form must unify with the original term: holes standing
+   for arguments that are not printed and universes introduced by the
+   re-elaboration may be instantiated by unifying against the original
+   term. This is the most permissive of the five checks; it accepts any
+   printed form that can denote the original term, even if only in a
+   context where the expected type is known.
+
+   .. warn:: The printed form of this term could not be re-parsed and re-elaborated to an equal term (up to ...), even with all printing options turned on.
+
+      If no printed form, however explicit, passes the check, the most
+      explicit one is printed anyway and this warning is emitted. This
+      happens for instance for terms mentioning universes that cannot be
+      referred to by name, such as the sort of ``Check Type``.
+
+.. flag:: Printing Reversible Up To Conversion Modulo Sorts And Universes
+
+   The printed form must re-elaborate on its own (without help from the
+   original term) to a term with no unresolved holes, and that term must
+   be convertible to the original one when sorts and universes are
+   ignored entirely: sort qualities (``SProp``, ``Prop``, ``Type``),
+   universe levels and universe instances may all differ. This is the
+   laxest of the conversion-based checks; in particular, unlike
+   :flag:`Printing Reversible Up To Conversion Modulo Universes` below,
+   it accepts a printed form whose re-elaboration lives at a different
+   sort quality than the original term.
+
+.. flag:: Printing Reversible Up To Conversion Modulo Universes
+
+   The printed form must re-elaborate on its own (without help from the
+   original term) to a term with no unresolved holes, and that term must
+   be convertible to the original one when universe levels (and the level
+   components of universe instances) are ignored, but *sort qualities
+   must agree*: ``Set`` and ``Type@{u}`` are accepted, but ``Prop``,
+   ``SProp`` and ``Type`` are pairwise distinguished. With this flag,
+   implicit arguments that can only be inferred from the type of the
+   original term get printed, and the universe levels of sorts (such as
+   the sort of ``Check Type``) generally do not, but the *sort quality*
+   part of a polymorphic instance is kept when it would otherwise
+   re-elaborate to a different quality.
+
+.. flag:: Printing Reversible Up To Conversion Modulo Universe Unification
+
+   Like :flag:`Printing Reversible Up To Conversion Modulo Universes`,
+   but instead of ignoring universe levels it lets the universes (and
+   sort qualities) introduced by the re-elaboration be unified against
+   the original ones, enforcing new universe (in)equalities as needed.
+   This is stricter than
+   :flag:`Printing Reversible Up To Conversion Modulo Universes` on
+   universe levels — a universe level cannot be unified with an
+   algebraic universe, so the sort of ``Check Type`` is printed
+   explicitly — but laxer on sort qualities, which get unified rather
+   than required to match syntactically.
+
+.. flag:: Printing Reversible Up To Conversion
+
+   Like :flag:`Printing Reversible Up To Conversion Modulo Universe
+   Unification`, but no new universe constraints are enforced: the
+   universe (in)equalities needed for convertibility must already be
+   valid in the current universe graph. With this flag, universe
+   instances of polymorphic constants generally need to be printed
+   (turning on :flag:`Printing Universes` for the terms where they
+   matter).
+
+For all five flags, when the printed expression stands for a term (as
+opposed to a type), the types of the original and re-elaborated terms
+are compared as well, so that, e.g., a printed form whose re-elaboration
+lives at a different universe instance is not considered reversible.
+
 .. _controlling-typing-flags:
 
 Controlling Typing Flags

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -45,15 +45,32 @@ let current_extern = PrintingFlags.Extern.current
    and only names of goal/section variables and rel names that do
    _not_ occur in the scope of the binder to be printed are avoided. *)
 
+(* When a [Printing Reversible] flag is set, the externalization is
+   checked for reparsability and the printing flags are possibly made
+   more explicit accordingly, hence rendering uses the flags returned
+   by [ReversiblePrinting.checked_extern]. *)
+let checked_extern_constr ?inctx ?scope ~flags env sigma t =
+  ReversiblePrinting.checked_extern ~flags
+    ~extern:(fun ~flags -> extern_constr ?inctx ?scope ~flags env sigma t)
+    ~kind:ReversiblePrinting.Term env sigma t
+
+let checked_extern_type ?goal_concl_style ?impargs ~flags env sigma t =
+  ReversiblePrinting.checked_extern ~flags
+    ~extern:(fun ~flags -> extern_type ?goal_concl_style ~flags env sigma ?impargs t)
+    ~kind:ReversiblePrinting.Type env sigma t
+
 let pr_econstr_n_env ?inctx ?scope ?(flags=current_combined()) env sigma n t =
+  let flags, c = checked_extern_constr ?inctx ?scope ~flags env sigma t in
   let ppflags = Ppconstr.of_printing_flags flags in
-  pr_constr_expr_n ~flags:ppflags env sigma n (extern_constr ?inctx ?scope ~flags env sigma t)
+  pr_constr_expr_n ~flags:ppflags env sigma n c
 let pr_econstr_env ?inctx ?scope ?(flags=current_combined()) env sigma t =
+  let flags, c = checked_extern_constr ?inctx ?scope ~flags env sigma t in
   let ppflags = Ppconstr.of_printing_flags flags in
-  pr_constr_expr ~flags:ppflags env sigma (extern_constr ?inctx ?scope ~flags env sigma t)
+  pr_constr_expr ~flags:ppflags env sigma c
 let pr_leconstr_env ?inctx ?scope ?(flags=current_combined()) env sigma t =
+  let flags, c = checked_extern_constr ?inctx ?scope ~flags env sigma t in
   let ppflags = Ppconstr.of_printing_flags flags in
-  Ppconstr.pr_lconstr_expr ~flags:ppflags env sigma (extern_constr ?inctx ?scope ~flags env sigma t)
+  Ppconstr.pr_lconstr_expr ~flags:ppflags env sigma c
 
 let pr_constr_n_env ?inctx ?scope ?flags env sigma n c =
   pr_econstr_n_env ?inctx ?scope ?flags env sigma n (EConstr.of_constr c)
@@ -73,11 +90,13 @@ let pr_constr_under_binders_env = pr_constr_under_binders_env_gen pr_econstr_env
 let pr_lconstr_under_binders_env = pr_constr_under_binders_env_gen pr_leconstr_env
 
 let pr_etype_env ?goal_concl_style ?(flags=current_combined()) env sigma t =
+  let flags, c = checked_extern_type ?goal_concl_style ~flags env sigma t in
   let ppflags = Ppconstr.of_printing_flags flags in
-  pr_constr_expr ~flags:ppflags env sigma (extern_type ?goal_concl_style ~flags env sigma t)
+  pr_constr_expr ~flags:ppflags env sigma c
 let pr_letype_env ?goal_concl_style ?(flags=current_combined()) env sigma ?impargs t =
+  let flags, c = checked_extern_type ?goal_concl_style ?impargs ~flags env sigma t in
   let ppflags = Ppconstr.of_printing_flags flags in
-  pr_lconstr_expr ~flags:ppflags env sigma (extern_type ?goal_concl_style ~flags env sigma ?impargs t)
+  pr_lconstr_expr ~flags:ppflags env sigma c
 
 let pr_type_env ?goal_concl_style ?flags env sigma c =
   pr_etype_env ?goal_concl_style ?flags env sigma (EConstr.of_constr c)

--- a/printing/reversiblePrinting.ml
+++ b/printing/reversiblePrinting.ml
@@ -1,0 +1,286 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+type kind = Term | Type
+
+type mode =
+  | UpToUnification
+  (** The reparsed term, with its holes, must unify with the original
+      term (holes and universes get instantiated by unification). *)
+  | UpToConversionModuloSortsAndUniverses
+  (** The reparsed term must elaborate on its own (no hole may need the
+      original term to be resolved) to a term convertible with the
+      original one when sorts and universes are ignored entirely: sort
+      qualities, universe levels and universe instances may all differ.
+      The laxest of the conversion-based checks. *)
+  | UpToConversionModuloUniverses
+  (** The reparsed term must elaborate on its own (no hole may need the
+      original term to be resolved) to a term convertible with the
+      original one when universe levels (and the level components of
+      universe instances) are ignored but sort qualities must agree.
+      Thus [Set] and [Type@{u}] are accepted, but [Prop], [SProp] and
+      [Type] are pairwise distinguished. *)
+  | UpToConversionModuloUniverseUnification
+  (** The reparsed term must elaborate on its own to a term convertible
+      with the original one, allowing new universe (in)equations to be
+      enforced on the universes introduced by the reparsing (universe
+      unification through the evar map). Stricter than
+      [UpToConversionModuloUniverses] (a universe level cannot be set
+      equal to an algebraic universe), laxer than [UpToConversion]. *)
+  | UpToConversion
+  (** The reparsed term must elaborate on its own to a term convertible
+      with the original one, with universe (in)equations valid in the
+      current graph. *)
+
+let mode_eq m1 m2 = match m1, m2 with
+  | UpToUnification, UpToUnification
+  | UpToConversionModuloSortsAndUniverses, UpToConversionModuloSortsAndUniverses
+  | UpToConversionModuloUniverses, UpToConversionModuloUniverses
+  | UpToConversionModuloUniverseUnification, UpToConversionModuloUniverseUnification
+  | UpToConversion, UpToConversion -> true
+  | (UpToUnification | UpToConversionModuloSortsAndUniverses
+    | UpToConversionModuloUniverses
+    | UpToConversionModuloUniverseUnification | UpToConversion), _ -> false
+
+let current_mode : mode option ref = ref None
+
+(* These flags behave like a radio button: setting one unsets the
+   others; unsetting the one currently set disables the check. *)
+let declare_mode_option key mode =
+  let open Goptions in
+  declare_bool_option {
+    optstage = Summary.Stage.Interp;
+    optdepr  = None;
+    optkey   = key;
+    optread  = (fun () -> match !current_mode with
+        | Some m -> mode_eq m mode
+        | None -> false);
+    optwrite = (fun b ->
+        if b then current_mode := Some mode
+        else match !current_mode with
+          | Some m when mode_eq m mode -> current_mode := None
+          | _ -> ());
+  }
+
+let () = declare_mode_option
+    ["Printing";"Reversible";"Up";"To";"Unification"] UpToUnification
+let () = declare_mode_option
+    ["Printing";"Reversible";"Up";"To";"Conversion";"Modulo";"Sorts";"And";"Universes"]
+    UpToConversionModuloSortsAndUniverses
+let () = declare_mode_option
+    ["Printing";"Reversible";"Up";"To";"Conversion";"Modulo";"Universes"]
+    UpToConversionModuloUniverses
+let () = declare_mode_option
+    ["Printing";"Reversible";"Up";"To";"Conversion";"Modulo";"Universe";"Unification"]
+    UpToConversionModuloUniverseUnification
+let () = declare_mode_option
+    ["Printing";"Reversible";"Up";"To";"Conversion"] UpToConversion
+
+let pr_mode = function
+  | UpToUnification -> Pp.str "unification"
+  | UpToConversionModuloSortsAndUniverses ->
+    Pp.str "conversion modulo sorts and universes"
+  | UpToConversionModuloUniverses -> Pp.str "conversion modulo universes"
+  | UpToConversionModuloUniverseUnification ->
+    Pp.str "conversion modulo universe unification"
+  | UpToConversion -> Pp.str "conversion"
+
+let warn_not_reversible =
+  CWarnings.create ~name:"reversible-printing"
+    (fun mode ->
+       Pp.(strbrk "The printed form of this term could not be re-parsed \
+                   and re-elaborated to an equal term (up to " ++ pr_mode mode ++
+           strbrk "), even with all printing options turned on."))
+
+let lconstr_eoi = Procq.eoi_entry Procq.Constr.lconstr
+
+(* Successively more explicit printing flags: coercions, implicit
+   arguments, no notations, universes (first with, then without
+   notations), parentheses, ending with the equivalent of
+   [Printing All] plus [Printing Universes] and [Printing
+   Parentheses]. Unsetting notations is tried after implicit arguments
+   and before universes, but is not kept when escalating to universes:
+   configurations are ordered by explicitness, not included in each
+   other. Only extern/detype-level flags and the [parentheses] flag may
+   vary along the ladder: the rendering of the returned [constr_expr]
+   must be fully determined by the returned flags (see
+   [Ppconstr.of_printing_flags]). *)
+let ladder flags =
+  let open PrintingFlags in
+  let e0 = flags.extern in
+  let e1 = { e0 with Extern.coercions = true } in
+  let e2 = { e1 with Extern.implicits = true; Extern.implicits_defensive = true } in
+  let e3 = { e2 with Extern.notations = false } in
+  let d4 = { flags.detype with Detype.universes = true } in
+  let e5 = { e3 with Extern.parentheses = true } in
+  let raw = make_raw flags in
+  let raw = { detype = { raw.detype with Detype.universes = true };
+              extern = { raw.extern with Extern.parentheses = true } } in
+  [ flags;
+    { flags with extern = e1 };
+    { flags with extern = e2 };
+    { flags with extern = e3 };
+    { detype = d4; extern = e2 };
+    { detype = d4; extern = e3 };
+    { detype = d4; extern = e5 };
+    raw ]
+
+(* Reparsing a term can spuriously emit warnings (e.g. deprecation
+   warnings for notations it reuses); silence them during the check. *)
+let no_warnings f =
+  let saved = CWarnings.get_flags () in
+  CWarnings.set_flags "-all";
+  try let v = f () in CWarnings.set_flags saved; v
+  with e ->
+    let e = Exninfo.capture e in
+    CWarnings.set_flags saved;
+    Exninfo.iraise e
+
+(* Conversion for the [UpToConversionModuloUniverses] mode: universe
+   levels (and the level components of universe instances) are ignored,
+   but sort qualities must agree. So [Set] and [Type@{u}] (both of
+   [QType] quality) are accepted, and [Type@{u}] vs [Type@{v}] is
+   accepted, but [Prop], [SProp] and [Type] are pairwise rejected; the
+   quality components of instances (for sort-polymorphic constants) must
+   also agree. This lets [Check Type] print plain [Type] while still
+   catching a reparse whose sort quality differs from the original. *)
+let modulo_universes_compare =
+  let open Conversion in
+  let compare_sorts _pb s1 s2 () =
+    if Sorts.Quality.equal (Sorts.quality s1) (Sorts.quality s2)
+    then Result.Ok () else Result.Error None
+  in
+  let compare_instances ~flex:_ i1 i2 () =
+    let (q1, _), (q2, _) = UVars.Instance.to_array i1, UVars.Instance.to_array i2 in
+    if CArray.equal Sorts.Quality.equal q1 q2
+    then Result.Ok () else Result.Error None
+  in
+  let compare_cumul_instances _pb _variance i1 i2 () =
+    compare_instances ~flex:false i1 i2 ()
+  in
+  { compare_sorts; compare_instances; compare_cumul_instances }
+
+(* No [eq_constr_nounivs] fast-path here: it would treat sorts of
+   different qualities as equal, defeating the sort-sensitivity we want. *)
+let is_conv_modulo_universes env sigma t1 t2 =
+  let evars = Evd.evar_handler sigma in
+  let t1 = EConstr.Unsafe.to_constr t1 in
+  let t2 = EConstr.Unsafe.to_constr t2 in
+  let env = Environ.set_universes (Evd.universes sigma) env in
+  match Conversion.generic_conv ~l2r:false Conversion.CONV ~evars
+          TransparentState.full env ((), modulo_universes_compare) t1 t2 with
+  | Result.Ok () -> true
+  | Result.Error None -> false
+  | Result.Error (Some e) -> Util.Empty.abort e
+
+let reparses ~mode ~kind ~flags env sigma t expr =
+  try
+    no_warnings begin fun () ->
+      let ppflags = Ppconstr.of_printing_flags flags in
+      let str = Pp.string_of_ppcmds (Ppconstr.pr_lconstr_expr ~flags:ppflags env sigma expr) in
+      let expr = Procq.parse_string lconstr_eoi str in
+      let expected_type = match kind with
+        | Type -> Pretyping.IsType
+        | Term -> Pretyping.WithoutTypeConstraint
+      in
+      let sigma', t' = Constrintern.interp_open_constr ~expected_type env sigma expr in
+      let no_new_undefined () =
+        Evar.Set.for_all (fun ev -> Evd.mem sigma ev)
+          (Evarutil.undefined_evars_of_term sigma' t')
+      in
+      (* Conversion (and unification) of terms does not imply that they
+         have convertible types (e.g. binder types of lambdas are not
+         compared), so for terms we compare the types too. For [Type]
+         kind we do not compare the (algebraic) sorts the types live
+         in, as elaboration is anyway allowed to pick different such
+         sorts for the very same expression. *)
+      let pairs = match kind with
+        | Type -> [t', t]
+        | Term ->
+          let ty' = Retyping.get_type_of env sigma' t' in
+          let ty = Retyping.get_type_of env sigma' t in
+          [ty', ty; t', t]
+      in
+      match mode with
+      | UpToUnification ->
+        let sigma' = List.fold_left (fun sigma' (t', t) ->
+            Evarconv.unify_delay env sigma' t' t) sigma' pairs in
+        let (_ : Evd.evar_map) = Evarconv.solve_unif_constraints_with_heuristics env sigma' in
+        true
+      | UpToConversionModuloSortsAndUniverses ->
+        (* Convertibility ignoring sorts and universes entirely
+           ([Reductionops.is_conv_nounivs]): unlike modulo universes
+           below, even sort qualities need not agree, so e.g. dropping a
+           sort-polymorphic instance whose omission changes the
+           elaborated quality is accepted. *)
+        no_new_undefined () &&
+        List.for_all (fun (t', t) -> Reductionops.is_conv_nounivs env sigma' t' t) pairs
+      | UpToConversionModuloUniverses ->
+        (* Convertibility ignoring universe levels (and the level
+           components of instances) but requiring sort qualities to
+           agree. Unlike a conversion enforcing universe equalities,
+           this accepts e.g. a freshly elaborated [Type@{v}] against the
+           original [Type@{u+1}], where [v] is a plain level that cannot
+           be set equal to the algebraic [u+1]; but it still rejects a
+           reparse whose sort quality differs (e.g. [Prop] vs [Type]). *)
+        no_new_undefined () &&
+        List.for_all (fun (t', t) -> is_conv_modulo_universes env sigma' t' t) pairs
+      | UpToConversionModuloUniverseUnification ->
+        (* Convertibility enforcing universe unification: the universes
+           introduced by the reparsing may be unified against the
+           original ones through the evar map, but a universe level
+           cannot be set equal to an algebraic universe, so e.g. [Check
+           Type] does not check under this mode. *)
+        no_new_undefined () &&
+        (let rec conv sigma' = function
+           | [] -> true
+           | (t', t) :: pairs ->
+             match Reductionops.infer_conv ~pb:Conversion.CONV env sigma' t' t with
+             | Some sigma' -> conv sigma' pairs
+             | None -> false
+         in
+         conv sigma' pairs)
+      | UpToConversion ->
+        no_new_undefined () &&
+        List.for_all (fun (t', t) -> Reductionops.is_conv env sigma' t' t) pairs
+    end
+  with e when CErrors.noncritical e -> false
+
+(* Printing terms while checking reversibility (e.g. from the
+   elaboration of the reparsed term) must not recursively trigger the
+   check. *)
+let in_check = ref false
+
+let checked_extern ~flags ~extern ~kind env sigma t =
+  match !current_mode with
+  | None -> flags, extern ~flags
+  | Some _ when !in_check -> flags, extern ~flags
+  | Some mode ->
+    in_check := true;
+    try
+      let rec aux = function
+        | [] -> assert false
+        | [flags] ->
+          let expr = extern ~flags in
+          if not (reparses ~mode ~kind ~flags env sigma t expr) then
+            warn_not_reversible mode;
+          (flags, expr)
+        | flags :: rest ->
+          let expr = extern ~flags in
+          if reparses ~mode ~kind ~flags env sigma t expr then (flags, expr)
+          else aux rest
+      in
+      let v = aux (ladder flags) in
+      in_check := false;
+      v
+    with e ->
+      let e = Exninfo.capture e in
+      in_check := false;
+      Exninfo.iraise e

--- a/printing/reversiblePrinting.ml
+++ b/printing/reversiblePrinting.ml
@@ -1,0 +1,280 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+type kind = Term | Type
+
+type mode =
+  | UpToUnification
+  (** The reparsed term, with its holes, must unify with the original
+      term (holes and universes get instantiated by unification). *)
+  | UpToConversionModuloSortsAndUniverses
+  (** The reparsed term must elaborate on its own (no hole may need the
+      original term to be resolved) to a term convertible with the
+      original one when sorts and universes are ignored entirely: sort
+      qualities, universe levels and universe instances may all differ.
+      The laxest of the conversion-based checks. *)
+  | UpToConversionModuloUniverses
+  (** The reparsed term must elaborate on its own (no hole may need the
+      original term to be resolved) to a term convertible with the
+      original one when universe levels (and the level components of
+      universe instances) are ignored but sort qualities must agree.
+      Thus [Set] and [Type@{u}] are accepted, but [Prop], [SProp] and
+      [Type] are pairwise distinguished. *)
+  | UpToConversionModuloUniverseUnification
+  (** The reparsed term must elaborate on its own to a term convertible
+      with the original one, allowing new universe (in)equations to be
+      enforced on the universes introduced by the reparsing (universe
+      unification through the evar map). Stricter than
+      [UpToConversionModuloUniverses] (a universe level cannot be set
+      equal to an algebraic universe), laxer than [UpToConversion]. *)
+  | UpToConversion
+  (** The reparsed term must elaborate on its own to a term convertible
+      with the original one, with universe (in)equations valid in the
+      current graph. *)
+
+let mode_eq m1 m2 = match m1, m2 with
+  | UpToUnification, UpToUnification
+  | UpToConversionModuloSortsAndUniverses, UpToConversionModuloSortsAndUniverses
+  | UpToConversionModuloUniverses, UpToConversionModuloUniverses
+  | UpToConversionModuloUniverseUnification, UpToConversionModuloUniverseUnification
+  | UpToConversion, UpToConversion -> true
+  | (UpToUnification | UpToConversionModuloSortsAndUniverses
+    | UpToConversionModuloUniverses
+    | UpToConversionModuloUniverseUnification | UpToConversion), _ -> false
+
+(* The single piece of state behind the flags below, and the only one
+   registered with the summary. *)
+let current_mode : mode option Summary.Ref.t =
+  Summary.ref ~name:"printing-reversible-mode" None
+
+(* These flags behave like a radio button: setting one unsets the
+   others; unsetting the one currently set disables the check. They
+   are all views of [current_mode], which is what the summary tracks,
+   so they are declared without a summary entry of their own. *)
+let declare_mode_option key mode =
+  let open Goptions in
+  declare_option ~no_summary:true ~kind:BoolKind {
+    optstage = Summary.Stage.Interp;
+    optdepr  = None;
+    optkey   = key;
+    optread  = (fun () -> match Summary.Ref.get current_mode with
+        | Some m -> mode_eq m mode
+        | None -> false);
+    optwrite = (fun b ->
+        if b then Summary.Ref.set current_mode (Some mode)
+        else match Summary.Ref.get current_mode with
+          | Some m when mode_eq m mode -> Summary.Ref.set current_mode None
+          | _ -> ());
+  }
+
+let () = declare_mode_option
+    ["Printing";"Reversible";"Up";"To";"Unification"] UpToUnification
+let () = declare_mode_option
+    ["Printing";"Reversible";"Up";"To";"Conversion";"Modulo";"Sorts";"And";"Universes"]
+    UpToConversionModuloSortsAndUniverses
+let () = declare_mode_option
+    ["Printing";"Reversible";"Up";"To";"Conversion";"Modulo";"Universes"]
+    UpToConversionModuloUniverses
+let () = declare_mode_option
+    ["Printing";"Reversible";"Up";"To";"Conversion";"Modulo";"Universe";"Unification"]
+    UpToConversionModuloUniverseUnification
+let () = declare_mode_option
+    ["Printing";"Reversible";"Up";"To";"Conversion"] UpToConversion
+
+let pr_mode = function
+  | UpToUnification -> Pp.str "unification"
+  | UpToConversionModuloSortsAndUniverses ->
+    Pp.str "conversion modulo sorts and universes"
+  | UpToConversionModuloUniverses -> Pp.str "conversion modulo universes"
+  | UpToConversionModuloUniverseUnification ->
+    Pp.str "conversion modulo universe unification"
+  | UpToConversion -> Pp.str "conversion"
+
+let warn_not_reversible =
+  CWarnings.create ~name:"reversible-printing"
+    (fun mode ->
+       Pp.(strbrk "The printed form of this term could not be re-parsed \
+                   and re-elaborated to an equal term (up to " ++ pr_mode mode ++
+           strbrk "), even with all printing options turned on."))
+
+let lconstr_eoi = Procq.eoi_entry Procq.Constr.lconstr
+
+(* Successively more explicit printing flags: coercions, implicit
+   arguments, no notations, universes (first with, then without
+   notations), parentheses, ending with the equivalent of
+   [Printing All] plus [Printing Universes] and [Printing
+   Parentheses]. Unsetting notations is tried after implicit arguments
+   and before universes, but is not kept when escalating to universes:
+   configurations are ordered by explicitness, not included in each
+   other. Only extern/detype-level flags and the [parentheses] flag may
+   vary along the ladder: the rendering of the returned [constr_expr]
+   must be fully determined by the returned flags (see
+   [Ppconstr.of_printing_flags]). *)
+let ladder flags =
+  let open PrintingFlags in
+  let e0 = flags.extern in
+  let e1 = { e0 with Extern.coercions = true } in
+  let e2 = { e1 with Extern.implicits = true; Extern.implicits_defensive = true } in
+  let e3 = { e2 with Extern.notations = false } in
+  let d4 = { flags.detype with Detype.universes = true } in
+  let e5 = { e3 with Extern.parentheses = true } in
+  let raw = make_raw flags in
+  let raw = { detype = { raw.detype with Detype.universes = true };
+              extern = { raw.extern with Extern.parentheses = true } } in
+  [ flags;
+    { flags with extern = e1 };
+    { flags with extern = e2 };
+    { flags with extern = e3 };
+    { detype = d4; extern = e2 };
+    { detype = d4; extern = e3 };
+    { detype = d4; extern = e5 };
+    raw ]
+
+(* Reparsing a term can spuriously emit warnings (e.g. deprecation
+   warnings for notations it reuses); silence them during the check. *)
+let no_warnings f =
+  let saved = CWarnings.get_flags () in
+  CWarnings.set_flags "-all";
+  Util.try_finally f () CWarnings.set_flags saved
+
+(* Conversion for the [UpToConversionModuloUniverses] mode: universe
+   levels (and the level components of universe instances) are ignored,
+   but sort qualities must agree. So [Set] and [Type@{u}] (both of
+   [QType] quality) are accepted, and [Type@{u}] vs [Type@{v}] is
+   accepted, but [Prop], [SProp] and [Type] are pairwise rejected; the
+   quality components of instances (for sort-polymorphic constants) must
+   also agree. This lets [Check Type] print plain [Type] while still
+   catching a reparse whose sort quality differs from the original. *)
+let modulo_universes_compare =
+  let open Conversion in
+  let compare_sorts _pb s1 s2 () =
+    if Sorts.Quality.equal (Sorts.quality s1) (Sorts.quality s2)
+    then Result.Ok () else Result.Error None
+  in
+  let compare_instances ~flex:_ i1 i2 () =
+    let (q1, _), (q2, _) = UVars.Instance.to_array i1, UVars.Instance.to_array i2 in
+    if CArray.equal Sorts.Quality.equal q1 q2
+    then Result.Ok () else Result.Error None
+  in
+  let compare_cumul_instances _pb _variance i1 i2 () =
+    compare_instances ~flex:false i1 i2 ()
+  in
+  { compare_sorts; compare_instances; compare_cumul_instances }
+
+(* No [eq_constr_nounivs] fast-path here: it would treat sorts of
+   different qualities as equal, defeating the sort-sensitivity we want. *)
+let is_conv_modulo_universes env sigma t1 t2 =
+  let evars = Evd.evar_handler sigma in
+  let t1 = EConstr.Unsafe.to_constr t1 in
+  let t2 = EConstr.Unsafe.to_constr t2 in
+  let env = Environ.set_universes (Evd.universes sigma) env in
+  match Conversion.generic_conv ~l2r:false Conversion.CONV ~evars
+          TransparentState.full env ((), modulo_universes_compare) t1 t2 with
+  | Result.Ok () -> true
+  | Result.Error None -> false
+  | Result.Error (Some e) -> Util.Empty.abort e
+
+let reparses ~mode ~kind ~flags env sigma t expr =
+  try
+    no_warnings begin fun () ->
+      let ppflags = Ppconstr.of_printing_flags flags in
+      let str = Pp.string_of_ppcmds (Ppconstr.pr_lconstr_expr ~flags:ppflags env sigma expr) in
+      let expr = Procq.parse_string lconstr_eoi str in
+      let expected_type = match kind with
+        | Type -> Pretyping.IsType
+        | Term -> Pretyping.WithoutTypeConstraint
+      in
+      let sigma', t' = Constrintern.interp_open_constr ~expected_type env sigma expr in
+      let no_new_undefined () =
+        Evar.Set.for_all (fun ev -> Evd.mem sigma ev)
+          (Evarutil.undefined_evars_of_term sigma' t')
+      in
+      (* Conversion (and unification) of terms does not imply that they
+         have convertible types (e.g. binder types of lambdas are not
+         compared), so for terms we compare the types too. For [Type]
+         kind we do not compare the (algebraic) sorts the types live
+         in, as elaboration is anyway allowed to pick different such
+         sorts for the very same expression. *)
+      let pairs = match kind with
+        | Type -> [t', t]
+        | Term ->
+          let ty' = Retyping.get_type_of env sigma' t' in
+          let ty = Retyping.get_type_of env sigma' t in
+          [ty', ty; t', t]
+      in
+      match mode with
+      | UpToUnification ->
+        let sigma' = List.fold_left (fun sigma' (t', t) ->
+            Evarconv.unify_delay env sigma' t' t) sigma' pairs in
+        let (_ : Evd.evar_map) = Evarconv.solve_unif_constraints_with_heuristics env sigma' in
+        true
+      | UpToConversionModuloSortsAndUniverses ->
+        (* Convertibility ignoring sorts and universes entirely
+           ([Reductionops.is_conv_nounivs]): unlike modulo universes
+           below, even sort qualities need not agree, so e.g. dropping a
+           sort-polymorphic instance whose omission changes the
+           elaborated quality is accepted. *)
+        no_new_undefined () &&
+        List.for_all (fun (t', t) -> Reductionops.is_conv_nounivs env sigma' t' t) pairs
+      | UpToConversionModuloUniverses ->
+        (* Convertibility ignoring universe levels (and the level
+           components of instances) but requiring sort qualities to
+           agree. Unlike a conversion enforcing universe equalities,
+           this accepts e.g. a freshly elaborated [Type@{v}] against the
+           original [Type@{u+1}], where [v] is a plain level that cannot
+           be set equal to the algebraic [u+1]; but it still rejects a
+           reparse whose sort quality differs (e.g. [Prop] vs [Type]). *)
+        no_new_undefined () &&
+        List.for_all (fun (t', t) -> is_conv_modulo_universes env sigma' t' t) pairs
+      | UpToConversionModuloUniverseUnification ->
+        (* Convertibility enforcing universe unification: the universes
+           introduced by the reparsing may be unified against the
+           original ones through the evar map, but a universe level
+           cannot be set equal to an algebraic universe, so e.g. [Check
+           Type] does not check under this mode. *)
+        no_new_undefined () &&
+        (let rec conv sigma' = function
+           | [] -> true
+           | (t', t) :: pairs ->
+             match Reductionops.infer_conv ~pb:Conversion.CONV env sigma' t' t with
+             | Some sigma' -> conv sigma' pairs
+             | None -> false
+         in
+         conv sigma' pairs)
+      | UpToConversion ->
+        no_new_undefined () &&
+        List.for_all (fun (t', t) -> Reductionops.is_conv env sigma' t' t) pairs
+    end
+  with e when CErrors.noncritical e -> false
+
+(* Printing terms while checking reversibility (e.g. from the
+   elaboration of the reparsed term) must not recursively trigger the
+   check. *)
+let in_check = ref false
+
+let checked_extern ~flags ~extern ~kind env sigma t =
+  match Summary.Ref.get current_mode with
+  | None -> flags, extern ~flags
+  | Some _ when !in_check -> flags, extern ~flags
+  | Some mode ->
+    let rec aux = function
+      | [] -> assert false
+      | [flags] ->
+        let expr = extern ~flags in
+        if not (reparses ~mode ~kind ~flags env sigma t expr) then
+          warn_not_reversible mode;
+        (flags, expr)
+      | flags :: rest ->
+        let expr = extern ~flags in
+        if reparses ~mode ~kind ~flags env sigma t expr then (flags, expr)
+        else aux rest
+    in
+    in_check := true;
+    Util.try_finally (fun () -> aux (ladder flags)) () (fun () -> in_check := false) ()

--- a/printing/reversiblePrinting.mli
+++ b/printing/reversiblePrinting.mli
@@ -1,0 +1,35 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Support for the [Printing Reversible Up To ...] flags: when one of
+    them is set, terms are printed in a form whose reparsing is checked
+    to produce a term equal to the original one, up to the equivalence
+    selected by the flag. If the check fails, printing options
+    (coercions, implicit arguments, notations off, universes,
+    parentheses, and finally all raw printing options) are
+    progressively turned on until the printed form passes the check;
+    if no form does, the most explicit form is printed and a
+    [reversible-printing] warning is emitted. *)
+
+(** Whether the printed expression stands for a term or a type, which
+    determines how its reparsing is elaborated. *)
+type kind = Term | Type
+
+(** [checked_extern ~flags ~extern ~kind env sigma c] returns the
+    externalization of [c] ([extern] is expected to externalize [c]
+    with the printing flags it receives), together with the printing
+    flags that were used to produce it, to be used for printing it.
+    When no [Printing Reversible] flag is set, this is just
+    [flags, extern ~flags]. *)
+val checked_extern :
+  flags:PrintingFlags.t ->
+  extern:(flags:PrintingFlags.t -> Constrexpr.constr_expr) ->
+  kind:kind -> Environ.env -> Evd.evar_map -> EConstr.constr ->
+  PrintingFlags.t * Constrexpr.constr_expr

--- a/test-suite/output/ReversiblePrinting.out
+++ b/test-suite/output/ReversiblePrinting.out
@@ -1,0 +1,62 @@
+eq_refl
+     : 0 = 0
+eq_refl
+     : 0 = 0
+@eq_refl nat 0
+     : 0 = 0
+Printing Reversible Up To Unification is off
+Printing Reversible Up To Conversion Modulo Sorts And Universes is off
+Printing Reversible Up To Conversion Modulo Universe Unification is off
+Printing Reversible Up To Conversion is on
+pid@{u}
+     : forall A : Type@{u}, A -> A
+pid
+     : forall A : Type, A -> A
+Type
+     : Type
+pid
+     : forall A : Type, A -> A
+File "./output/ReversiblePrinting.v", line 50, characters 0-11:
+Warning: The printed form of this term could not be re-parsed and
+re-elaborated to an equal term (up to
+conversion modulo universe unification), even with all printing options
+turned on. [reversible-printing,default]
+File "./output/ReversiblePrinting.v", line 50, characters 0-11:
+Warning: The printed form of this term could not be re-parsed and
+re-elaborated to an equal term (up to
+conversion modulo universe unification), even with all printing options
+turned on. [reversible-printing,default]
+Type@{ReversiblePrinting.47}
+     : Type@{ReversiblePrinting.47+1}
+pid
+     : forall A : Type, A -> A
+idT@{Prop ; Set}
+     : forall A : Prop, A -> A
+idT
+     : forall A : Prop, A -> A
+idT
+     : forall A : Prop, A -> A
+Type
+     : Type
+@eq_refl nat 0
+     : 0 = 0
+eq_refl
+     : 0 = 0
+2 * 3
+     : nat
+Nat.add 2 3
+     : nat
+1 goal
+  
+  ============================
+  @eq_refl nat 0 = @eq_refl nat 0
+File "./output/ReversiblePrinting.v", line 106, characters 0-11:
+Warning: The printed form of this term could not be re-parsed and
+re-elaborated to an equal term (up to conversion), even with all printing
+options turned on. [reversible-printing,default]
+File "./output/ReversiblePrinting.v", line 106, characters 0-11:
+Warning: The printed form of this term could not be re-parsed and
+re-elaborated to an equal term (up to conversion), even with all printing
+options turned on. [reversible-printing,default]
+Type@{ReversiblePrinting.88}
+     : Type@{ReversiblePrinting.88+1}

--- a/test-suite/output/ReversiblePrinting.v
+++ b/test-suite/output/ReversiblePrinting.v
@@ -1,0 +1,106 @@
+(* Printing Reversible Up To Unification / Conversion Modulo Sorts And
+   Universes / Conversion Modulo Universes / Conversion Modulo Universe
+   Unification / Conversion: printing options get progressively turned
+   on until the printed form re-parses and re-elaborates to an equal
+   term. *)
+
+(* Baseline: no check, hidden arguments are not re-inferable from the
+   printed form alone. *)
+Check @eq_refl nat 0.
+
+(* Unification is enough to re-infer the hidden arguments from the
+   original term, so nothing needs to be made explicit. *)
+Set Printing Reversible Up To Unification.
+Check @eq_refl nat 0.
+
+(* Standalone re-elaboration of [eq_refl] leaves unresolved holes, so
+   implicit arguments get printed. *)
+Set Printing Reversible Up To Conversion.
+Check @eq_refl nat 0.
+
+(* The five flags behave like a radio button. *)
+Test Printing Reversible Up To Unification.
+Test Printing Reversible Up To Conversion Modulo Sorts And Universes.
+Test Printing Reversible Up To Conversion Modulo Universe Unification.
+Test Printing Reversible Up To Conversion.
+
+(* Universe instances: re-elaboration introduces a fresh flexible
+   universe. Unifying it with the original instance is fine up to
+   conversion modulo universes, but not up to strict conversion, which
+   requires the instance to be printed. *)
+Polymorphic Definition pid@{u} (A : Type@{u}) (a : A) := a.
+Universe u.
+Check pid@{u}.
+Set Printing Reversible Up To Conversion Modulo Universes.
+Check pid@{u}.
+(* [Check Type] prints its type as [Type@{u+1}] (an algebraic universe);
+   re-elaborating the plain [Type] yields a fresh level. Up to conversion
+   modulo universes these are equal, so [Type] prints with no annotation
+   and no warning (contrast with the strict conversion case below). *)
+Check Type.
+
+(* Conversion Modulo Universe Unification: universes introduced by the
+   reparse may be unified against the original ones, but a level cannot
+   be unified with an algebraic universe. So [pid@{u}] still prints
+   plainly (fresh level unifies with [u])... *)
+Set Printing Reversible Up To Conversion Modulo Universe Unification.
+Check pid@{u}.
+(* ...but [Check Type] does not check (fresh level vs algebraic [u+1]),
+   so it warns and escalates, unlike modulo universes above. *)
+Check Type.
+
+Set Printing Reversible Up To Unification.
+Check pid@{u}.
+
+(* Sort qualities must elaborate the same under modulo universes, even
+   though universe levels need not. [idT] is polymorphic over a sort
+   quality [s]; used at [Prop], its printed form must keep the sort
+   instance, because dropping it re-elaborates [idT] at a fresh quality
+   (defaulting to [Type], quality [QType]) which differs from [Prop]. *)
+Set Universe Polymorphism.
+Definition idT@{s;u} (A : Type@{s;u}) (a : A) := a.
+Set Printing Reversible Up To Conversion Modulo Universes.
+Check idT@{Prop;Set}.
+(* Modulo universe unification is laxer on sorts: the fresh sort quality
+   is unified with [Prop], so the instance drops to plain [idT]. *)
+Set Printing Reversible Up To Conversion Modulo Universe Unification.
+Check idT@{Prop;Set}.
+(* Modulo sorts and universes ignores sort qualities as well as
+   universe levels, so the instance also drops, even though the
+   re-elaboration of plain [idT] lives at quality Type rather than
+   Prop... *)
+Set Printing Reversible Up To Conversion Modulo Sorts And Universes.
+Check idT@{Prop;Set}.
+(* ...and [Check Type] prints plainly, as with modulo universes... *)
+Check Type.
+(* ...but re-elaboration is still standalone, so hidden arguments that
+   cannot be re-inferred from the printed form alone get printed. *)
+Check @eq_refl nat 0.
+Unset Universe Polymorphism.
+
+(* Unsetting the active flag turns the check off entirely (unsetting a
+   flag other than the active one would be a no-op). *)
+Unset Printing Reversible Up To Conversion Modulo Sorts And Universes.
+Check @eq_refl nat 0.
+
+(* A printing-only notation that does not print what it parses is
+   detected and bypassed by turning notations off. *)
+Set Printing Reversible Up To Unification.
+Module LyingNotation.
+  Notation "x ** y" := (Nat.mul x y) (at level 40).
+  Set Warnings "-notation-overridden".
+  Notation "x ** y" := (Nat.add x y) (at level 40, only printing).
+  Check 2 * 3.
+  Check 2 + 3.
+End LyingNotation.
+
+(* Goal display is checked too. *)
+Set Printing Reversible Up To Conversion.
+Goal @eq_refl nat 0 = eq_refl.
+Show.
+Abort.
+
+(* Sort universes of [Check Type] cannot be re-parsed at all (their
+   names are not declared), so a warning is emitted and the most
+   explicit form is printed. *)
+Check Type.


### PR DESCRIPTION
Written by Claude (Anthropic AI) at the request of and under the supervision of @JasonGross.

### What

Adds five mutually exclusive flags:

- `Set Printing Reversible Up To Unification`
- `Set Printing Reversible Up To Conversion Modulo Sorts And Universes`
- `Set Printing Reversible Up To Conversion Modulo Universes`
- `Set Printing Reversible Up To Conversion Modulo Universe Unification`
- `Set Printing Reversible Up To Conversion`

When enabled, term printing through `Printer.pr_econstr_env` and related paths renders the externalized term, parses it through an end-of-input `lconstr` entry, re-elaborates it with `interp_open_constr`, and compares it with the original under the selected equivalence. On failure, it progressively enables coercions, implicit arguments, disabled notations, universes, parentheses, and finally `Printing All` options. If no form passes, it uses the most explicit form and emits a `reversible-printing` warning.

Unification permits holes and flexible universes; the conversion-based modes require standalone elaboration with no unresolved holes. *Modulo Sorts And Universes* uses `Reductionops.is_conv_nounivs`; *Modulo Universes* ignores universe levels but compares sort qualities using `Conversion.generic_conv`; *Modulo Universe Unification* threads universe unification through the evar map with `Reductionops.infer_conv`; and strict *Up To Conversion* uses `Reductionops.is_conv`. Universe unification is stricter on levels but laxer on qualities than *Modulo Universes*, so those modes are not linearly ordered. The original and reparsed types are also compared when the expression denotes a term, because term conversion alone does not compare all binder types.

### Example

```coq
Check @eq_refl nat 0.
(* eq_refl : 0 = 0                    -- baseline *)
Set Printing Reversible Up To Unification.
Check @eq_refl nat 0.
(* eq_refl : 0 = 0                    -- unification re-infers the hidden args *)
Set Printing Reversible Up To Conversion.
Check @eq_refl nat 0.
(* @eq_refl nat 0 : 0 = 0             -- standalone elaboration needs them *)

Polymorphic Definition pid@{u} (A : Type@{u}) (a : A) := a.
Universe u.
Check pid@{u}.
(* pid@{u} : forall A : Type@{u}, A -> A   -- strict conversion *)
Set Printing Reversible Up To Conversion Modulo Universes.
Check pid@{u}.
(* pid : forall A : Type, A -> A           -- universe levels are ignored *)
Check Type.
(* Type : Type                             -- Type@{u+1} vs fresh level: fine here,
                                              warns+escalates under strict conversion
                                              and under universe unification *)

Set Universe Polymorphism.
Definition idT@{s;u} (A : Type@{s;u}) (a : A) := a.
Check idT@{Prop;Set}.
(* idT@{Prop ; Set} : forall A : Prop, A -> A  -- modulo universes: dropping the
                                                  instance would change the sort quality *)
Set Printing Reversible Up To Conversion Modulo Sorts And Universes.
Check idT@{Prop;Set}.
(* idT : forall A : Prop, A -> A               -- sorts ignored too, instance drops *)
```

A printing-only notation that parses differently escalates to disabled notation printing, and goal display is checked as covered by `test-suite/output/ReversiblePrinting.v`.

### Implementation and caveats

The round trip lives in `printing/reversiblePrinting.ml` and passes through the parser. `PrintingFlags.t` records define the escalation ladder, and `Printer` renders with the same flags used for externalization. Re-elaboration warnings are silenced during checking, reentrancy is guarded, and noncritical parse or elaboration failures advance to the next rung.

The flags are off by default because each displayed term may be parsed and elaborated several times. Nonempty scope stacks are not preserved during reparsing and can cause spurious escalation. Unnameable sort universes such as in `Check Type` cannot round-trip under strict conversion or universe unification and emit the warning, though the modulo-universes modes accept them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Wordsmithed by Codex.
