### PR TITLE
Filter STM worker teardown noise in the test-suite output comparison (alternative to #22286)

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -70,6 +70,24 @@ else
   CLEANUP_WINPATH=
 endif
 
+# When an STM worker loses its connection to the master during teardown,
+# the worker's read/write to the (now closed) master fails with a
+# connection-loss error that does not surface as End_of_file: on Windows
+# the socket is reset (WSAECONNRESET/WSAECONNABORTED) and on Unix a write
+# to the dead master fails with EPIPE. These take the loud "Slave:
+# critical exception" / "Fatal marshal error" branches of the worker main
+# loop, and the message can race into the master's output, making output
+# tests that use par: / async workers (e.g. output/Partac.v) fail
+# intermittently, mostly on Windows CI. Such a line looks like:
+#   260:tactic:1:1:0] Slave: critical exception: System error: "An existing connection was forcibly closed by the remote host."
+# This is pure teardown noise, unrelated to what the test exercises, so we
+# drop those lines from the captured output before comparison. The pattern
+# is anchored on both a worker-error marker and one of the connection-loss
+# strerror texts so it cannot swallow any legitimate test output. See
+# rocq-prover/rocq#22286 for the alternative of fixing this in the STM.
+CLEANUP_STM_WORKER_NOISE=| grep -a -v -E \
+  '(Slave: critical exception|Fatal marshal error).*(Connection reset by peer|Broken pipe|forcibly closed by the remote host|aborted by the software in your host machine)'
+
 # The $(shell echo) trick is necessary due to configure quoting
 # filenames, still, this issue is tricky when paths contain spaces
 export OCAMLPATH := $(shell echo $(COQPREFIX)/lib$(FINDLIB_SEP)$$OCAMLPATH)
@@ -442,6 +460,7 @@ $(addsuffix .log,$(wildcard output/*.v)): %.v.log: %.v %.out $(PREREQUISITELOG)
 	    | grep -a -v "Skipping rcfile loading" \
 	    | grep -a -v "^<W>" \
 	    $(CLEANUP_WINPATH) \
+	    $(CLEANUP_STM_WORKER_NOISE) \
 	    > $$output; \
 	  diff -a -u --strip-trailing-cr $*.out $$output 2>&1; R=$$?; times; \
 	  if [ $$R = 0 ]; then \
@@ -466,6 +485,7 @@ $(addsuffix .log,$(wildcard output-coqtop/*.v)): %.v.log: %.v %.out $(PREREQUISI
 	    | grep -v "\[Loading ML file" \
 	    | grep -v "Skipping rcfile loading" \
 	    | grep -v "^<W>" \
+	    $(CLEANUP_STM_WORKER_NOISE) \
 	    > $$output; \
 	  diff -u --strip-trailing-cr $*.out $$output 2>&1; R=$$?; times; \
 	  if [ $$R = 0 ]; then \

--- a/test-suite/README.md
+++ b/test-suite/README.md
@@ -81,6 +81,15 @@ and a `.out` file with the expected output.  Output tests in this directory are
 run with coqc in -test-mode.  Output tests in [`output-coqtop`](output-coqtop)
 work the same way, but are run with coqtop.
 
+Before comparison, the captured output goes through a small post-processing
+pipeline in the `Makefile` (dropping the banner, `Loading ML file` lines,
+etc.). That pipeline also drops STM worker "connection lost" teardown noise
+(a line combining a worker-error marker such as `Slave: critical exception`
+with a connection-loss message like `Broken pipe` or `... forcibly closed
+by the remote host`), which a background worker may otherwise race into the
+output when the master tears it down — see the `CLEANUP_STM_WORKER_NOISE`
+filter and its comment for the exact, narrowly-anchored pattern.
+
 There are unit tests of OCaml code in [`unit-tests`](unit-tests). These tests
 are contained in `.ml` files, and rely on the `OUnit` unit-test framework, as
 described at <http://ounit.forge.ocamlcore.org/>.  Use `make unit-tests` in the


### PR DESCRIPTION
This is the runner-side alternative proposed in the [#22286 review](https://github.com/rocq-prover/rocq/pull/22286#discussion_r3623351769) for the flaky `output/Partac.v` Windows CI test; it contains **no `stm/` changes**. The multiple-expected-output alternative is #22297.

### Problem

When the master closes an STM worker's channels, reads and writes can report WSAECONNRESET/WSAECONNABORTED on Windows or EPIPE on Unix instead of `End_of_file`. The resulting `Slave: critical exception` or `Fatal marshal error` message can race into output from tests using `par:` or async workers, causing intermittent failures such as:

```
260:tactic:1:1:0] Slave: critical exception: System error: "An existing connection was forcibly closed by the remote host."
```

### Change

Filter these teardown-noise lines before output comparison, where captured output is already post-processed. A new `CLEANUP_STM_WORKER_NOISE` variable adds this `grep -a -v -E` pattern to the `output/` and `output-coqtop/` pipelines:

```
(Slave: critical exception|Fatal marshal error).*(Connection reset by peer|Broken pipe|forcibly closed by the remote host|aborted by the software in your host machine)
```

Requiring both a worker-error marker and a connection-loss strerror preserves legitimate output and genuine worker crashes. Substring matching accommodates variable `<worker-id>]` prefixes. `approve-output` uses the same pipeline, and the rationale is documented next to the filters and in `test-suite/README.md`.

The four texts and polluted-line format come from #22286. No real polluted Windows log was retrieved because #22266 was rebased and its Windows check is now green, so the patterns were not further grounded against one.

### Validation

- `output/Partac.v` passes on a clean run.
- Synthetic cases covering all four texts with varying prefixes and positions are removed.
- A `Slave: critical exception` without a connection-loss text is preserved.
- A line mentioning connection loss without a worker-error marker is preserved.
- `test-suite/Makefile` parses and `dev/lint-commits.sh` passes.

No changelog entry is included because this is an internal test-suite/CI change with no user-visible effect.

Written by Claude (Anthropic AI) at the request of and under the supervision of @JasonGross.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Wordsmithed by Codex.
