### PR TITLE
Allow record syntax for record with anonymous fields

### DIFF
--- a/doc/changelog/02-specification-language/22307-record-anon-Changed.rst
+++ b/doc/changelog/02-specification-language/22307-record-anon-Changed.rst
@@ -1,0 +1,8 @@
+- **Changed:**
+  record syntax is now allowed for records with anonymous fields, producing holes for the non provided fields
+  (anonymous fields cannot be provided since they have no name).
+  Note that records without anonymous fields already produced holes for non provided fields instead of producing an error,
+  so `{[ x := 0 |}` now works to produce a value of either `Record R := { x : nat; y : P x }` or `Record R := { x : nat; _ : P x }`
+  where previously only the former would work
+  (`#22307 <https://github.com/rocq-prover/rocq/pull/22307>`_,
+  by Gaëtan Gilbert).

--- a/engine/evar_kinds.ml
+++ b/engine/evar_kinds.ml
@@ -21,8 +21,7 @@ type matching_var_kind = FirstOrderPatVar of Id.t | SecondOrderPatVar of Id.t
 
 type subevar_kind = Domain | Codomain | Body
 
-(* maybe this should be a Projection.t *)
-type record_field = { fieldname : Constant.t; recordname : Names.inductive }
+type record_field = { field_idx : int; recordname : Names.inductive }
 
 type question_mark = {
      qm_obligation: obligation_definition_status;

--- a/engine/evar_kinds.mli
+++ b/engine/evar_kinds.mli
@@ -21,9 +21,9 @@ type matching_var_kind = FirstOrderPatVar of Id.t | SecondOrderPatVar of Id.t
 
 type subevar_kind = Domain | Codomain | Body
 
-(* maybe this should be a Projection.t *)
-(* Represents missing record field *)
-type record_field = { fieldname : Constant.t; recordname : Names.inductive }
+(** Represents missing record field
+    field_idx is 1-indexed *)
+type record_field = { field_idx : int; recordname : Names.inductive }
 
 type question_mark = {
      qm_obligation: obligation_definition_status;

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1659,11 +1659,7 @@ let sort_fields genv ~complete loc fields completer =
         let base_constructor = GlobRef.ConstructRef (record.Structure.name,1) in
         let () = check_duplicate ?loc fields in
         let build_proj idx proj =
-          if proj.Structure.proj_body = None && complete then
-            (* we don't want anonymous fields *)
-            user_err ?loc (str "This record contains anonymous fields.")
-          else
-            (idx, proj.Structure.proj_body, proj.Structure.proj_true) in
+          (idx, proj.Structure.proj_body, proj.Structure.proj_true) in
         let proj_list =
           List.map_i build_proj 1 record.Structure.projections in
         (* now we want to have all fields assignments indexed by their place in
@@ -2616,13 +2612,12 @@ let proj self genv env lvar ?loc (expl, f, args, c) =
 let record self genv env lvar ?loc (def,fs) =
   let st = Evar_kinds.Define (not (Program.get_proofs_transparency ())) in
   let used_default = Stdlib.ref false in
-  let completer _idx fieldname constructorname =
-    let fieldname = Option.get fieldname in
+  let completer idx fieldname constructorname =
     match def with
     | None ->
       let open Evar_kinds in
       let fieldinfo : Evar_kinds.record_field =
-        {fieldname; recordname=inductive_of_constructor constructorname}
+        {field_idx = idx; recordname=inductive_of_constructor constructorname}
       in
       CAst.make ?loc @@
       CHole (Some
@@ -2633,6 +2628,11 @@ let record self genv env lvar ?loc (def,fs) =
     | Some def ->
       (* duplicating internalization of the default value is not ideal *)
       used_default := true;
+      let fieldname = match fieldname with
+        | Some v -> v
+        | None ->
+          CErrors.user_err ?loc (str "Cannot use \"with\": this record contains anonymous fields.")
+      in
       let fieldname =
         Libnames.qualid_of_path @@ Nametab.XRefs.to_path (TrueGlobal (ConstRef fieldname))
       in

--- a/test-suite/output/Record.out
+++ b/test-suite/output/Record.out
@@ -102,3 +102,16 @@ File "./output/Record.v", line 101, characters 2-33:
 Warning:
 The record anonproj could not be defined as a primitive record because it has
 an anonymous projection. [non-primitive-record,records,default]
+Build_foo 10 ?c
+     : foo
+where
+?c : [ |- C 10]
+File "./output/Record.v", line 112, characters 2-39:
+The command has indeed failed with message:
+The following term contains unresolved implicit arguments:
+  (Build_foo 10 ?c)
+More precisely: 
+- ?c: Cannot infer 2nd field of record foo (no type class instance found).
+File "./output/Record.v", line 118, characters 28-44:
+The command has indeed failed with message:
+Cannot use "with": this record contains anonymous fields.

--- a/test-suite/output/Record.v
+++ b/test-suite/output/Record.v
@@ -101,3 +101,19 @@ Module WhyNotPrim.
   Record anonproj := { _ : nat }.
 
 End WhyNotPrim.
+
+Module AnonField.
+  Class C (n:nat) := c {}.
+
+  Record foo := { x : nat ; _ : C x }.
+
+  Check {| x := 10 |}.
+
+  Fail Definition bar := {| x := 10 |}.
+
+  Existing Instance c.
+
+  Definition bar := {| x := 10 |}.
+
+  Fail Definition baz := {| bar with x := 10 |}.
+End AnonField.

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -712,8 +712,14 @@ let rec explain_evar_kind env sigma evk ty =
       strbrk "the existential variable named " ++ Id.print id
   | Evar_kinds.QuestionMark {qm_record_field=None} ->
       strbrk "this placeholder of type " ++ ty
-  | Evar_kinds.QuestionMark {qm_record_field=Some {fieldname; recordname}} ->
-          str "field " ++ (Printer.pr_constant env fieldname) ++ str " of record " ++ (Printer.pr_inductive env recordname)
+  | Evar_kinds.QuestionMark {qm_record_field=Some {field_idx; recordname}} ->
+    let projs = Structures.Structure.find_projections env recordname in
+    let field = match List.nth_opt projs (field_idx-1) with
+      | None -> assert false
+      | Some (Some c) -> str "field " ++ (Printer.pr_constant env c)
+      | Some None -> str (String.ordinal field_idx) ++ str " field"
+    in
+    field ++ str " of record " ++ (Printer.pr_inductive env recordname)
   | Evar_kinds.CasesType false ->
       strbrk "the type of this pattern-matching problem"
   | Evar_kinds.CasesType true ->


### PR DESCRIPTION
For `Record foo := mk { x : nat ; y : 0 < x }.`, `{| x := 10 |}` already got turned into `mk 10 _`, so there is no reason to error if `y` was instead anonymous.

We still error for
~~~coq
Record foo := mk { x : nat ; _ : 0 < x }.
Check {| bar with x := 10 |}.
~~~
since there is no constant for the needed projection.

Close #4611
