### PR TITLE
kernel: cache conversion results within a session

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -122,19 +122,104 @@ let fterm_of v = v.term
 
 (* Identities are drawn from a global counter, so they are dense and
    distinct; 0 is reserved for "not yet assigned" and never handed out.
-   Clients see them through [Uid] only, so the counter representation
-   stays local to this module. *)
-module Uid = struct
-  type t = int
-  let equal = Int.equal
-  (* dense small integers: the identity is already a good hash *)
-  let hash x = x
-end
-
+   They are only ever consumed by [ConvCache] below, so both the counter
+   and the identities stay local to this module. *)
 let fid_counter = ref 0
 let uid v =
   if v.fid != 0 then v.fid
   else begin incr fid_counter; v.fid <- !fid_counter; !fid_counter end
+
+(* Conversion result cache. Within one conversion session the same pair of
+   cells is typically compared many times over, because beta-substitution
+   shares payload cells across all the occurrences of a variable. Entries
+   record the outcome (success or failure) for a pair of cells, identified
+   by their stable ids, at a given lift pair and conversion problem. Only
+   sound for checked conversion, where results are deterministic and no
+   universe constraints are accumulated. *)
+module ConvCache = struct
+
+  module Key = struct
+    (* ids of the two cells, and whether the problem is cumulativity *)
+    type t = int * int * bool
+    let equal (u1, v1, b1) (u2, v2, b2) =
+      Int.equal u1 u2 && Int.equal v1 v2 && Bool.equal b1 b2
+    let hash (u, v, b) =
+      (* ids are dense small integers, already good hashes *)
+      let h = u * 0x3B9ACA07 + v in
+      let h = h lxor (h lsr 16) in
+      if b then h lxor 0x5BF03635 else h
+  end
+
+  module Tbl = Hashtbl.Make(Key)
+
+  type t = {
+    tbl : (lift * lift * bool) list ref Tbl.t;
+    mutable size : int;
+  }
+
+  (* Optional cap on cached entries per session (ROCQ_CONV_CACHE_MAX; 0 means
+     unlimited). Unbounded by default: like [clos_tab], the table is
+     session-scoped, so its lifetime bounds memory. *)
+  let max_size =
+    match int_of_string (Sys.getenv "ROCQ_CONV_CACHE_MAX") with
+    | 0 -> max_int
+    | n -> n
+    | exception _ -> max_int
+
+  (* The cache is enabled by default; set ROCQ_CONV_CACHE=0 to disable. *)
+  let enabled =
+    match Sys.getenv "ROCQ_CONV_CACHE" with
+    | "0" -> false
+    | _ -> true
+    | exception Not_found -> true
+
+  let create () = if enabled then Some { tbl = Tbl.create 16; size = 0 } else None
+
+  (* Lifts are part of the entries rather than the keys: cells are shared
+     under beta-substitution at varying depths, so the same pair recurs
+     under a handful of lift pairs and a short scan beats hashing them. *)
+  let rec strip_flift k v = match [@ocaml.warning "-4"] v.term with
+  | FLIFT (n, v') -> strip_flift (k + n) v'
+  | _ -> (k, v)
+
+  (* [probe] and [record] renormalize the pair independently, so nothing
+     probe computed needs to stay live across the comparison run between
+     the two calls: a memoized lookup state would be promoted to the major
+     heap whenever the comparison spans a minor collection. *)
+
+  let probe cache ~cumul lft1 t1 lft2 t2 =
+    let (k1, v1) = strip_flift 0 t1 in
+    let (k2, v2) = strip_flift 0 t2 in
+    let l1 = el_shft k1 lft1 in
+    let l2 = el_shft k2 lft2 in
+    let key = (uid v1, uid v2, cumul) in
+    match Tbl.find_opt cache.tbl key with
+    | None -> None
+    | Some entries ->
+      let rec find = function
+      | [] -> None
+      | (l1', l2', r) :: rest ->
+        if eq_lift l1' l1 && eq_lift l2' l2 then
+          (* constant blocks: the hit path does not allocate *)
+          if r then Some true else Some false
+        else find rest
+      in
+      find !entries
+
+  let record cache ~cumul lft1 t1 lft2 t2 r =
+    if cache.size < max_size then begin
+      let (k1, v1) = strip_flift 0 t1 in
+      let (k2, v2) = strip_flift 0 t2 in
+      let l1 = el_shft k1 lft1 in
+      let l2 = el_shft k2 lft2 in
+      let key = (uid v1, uid v2, cumul) in
+      cache.size <- cache.size + 1;
+      match Tbl.find_opt cache.tbl key with
+      | Some entries -> entries := (l1, l2, r) :: !entries
+      | None -> Tbl.add cache.tbl key (ref [(l1, l2, r)])
+    end
+
+end
 
 let set_ntrl v = v.mark <- Ntrl
 

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -120,8 +120,19 @@ let get_invert fiv = fiv
 
 let fterm_of v = v.term
 
+(* Identities are drawn from a global counter, so they are dense and
+   distinct; 0 is reserved for "not yet assigned" and never handed out.
+   Clients see them through [Uid] only, so the counter representation
+   stays local to this module. *)
+module Uid = struct
+  type t = int
+  let equal = Int.equal
+  (* dense small integers: the identity is already a good hash *)
+  let hash x = x
+end
+
 let fid_counter = ref 0
-let get_fid v =
+let uid v =
   if v.fid != 0 then v.fid
   else begin incr fid_counter; v.fid <- !fid_counter; !fid_counter end
 

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -78,6 +78,9 @@ type evar_repack = Evar.t * constr list -> constr
 type fconstr = {
   mutable mark : red_state;
   mutable term: fterm;
+  (* Stable cell id for the conversion cache; 0 = unassigned. Preserved by
+     in-place [update], reset by copies. *)
+  mutable fid : int;
 }
 
 and fterm =
@@ -116,6 +119,12 @@ and finvert = fconstr array
 let get_invert fiv = fiv
 
 let fterm_of v = v.term
+
+let fid_counter = ref 0
+let get_fid v =
+  if v.fid != 0 then v.fid
+  else begin incr fid_counter; v.fid <- !fid_counter; !fid_counter end
+
 let set_ntrl v = v.mark <- Ntrl
 
 (* Could issue a warning if no is still Red, pointing out that we loose
@@ -240,17 +249,17 @@ let usubs_shft (n,(e,u)) = subs_shft (n, e), u
 let rec lft_fconstr n ft =
   match ft.term with
     | (FInd _|FConstruct (_,[||])|FFlex(ConstKey _|VarKey _)|FInt _|FFloat _|FString _|FIrrelevant) -> ft
-    | FRel i -> {mark=ft.mark;term=FRel(i+n)}
-    | FLambda(k,tys,f,e) -> {mark=Cstr; term=FLambda(k,tys,f,usubs_shft(n,e))}
+    | FRel i -> {fid = 0; mark=ft.mark;term=FRel(i+n)}
+    | FLambda(k,tys,f,e) -> {fid = 0; mark=Cstr; term=FLambda(k,tys,f,usubs_shft(n,e))}
     | FFix(fx,e) ->
-      {mark=Cstr; term=FFix(fx,usubs_shft(n,e))}
+      {fid = 0; mark=Cstr; term=FFix(fx,usubs_shft(n,e))}
     | FCoFix(cfx,e) ->
-      {mark=Cstr; term=FCoFix(cfx,usubs_shft(n,e))}
+      {fid = 0; mark =Cstr; term=FCoFix(cfx,usubs_shft(n,e))}
     | FLIFT(k,m) -> lft_fconstr (n+k) m
-    | FConstruct (c,args) -> {mark=Cstr; term=FConstruct(c,Array.Fun1.map lft_fconstr n args)}
+    | FConstruct (c,args) -> {fid = 0; mark =Cstr; term=FConstruct(c,Array.Fun1.map lft_fconstr n args)}
     | FLOCKED -> assert false
     | FFlex (RelKey _) | FAtom _ | FApp _ | FProj _ | FCaseT _ | FCaseInvert _ | FProd _
-    | FLetIn _ | FEvar _ | FCLOS _ | FArray _ -> {mark=ft.mark; term=FLIFT(n,ft)}
+    | FLetIn _ | FEvar _ | FCLOS _ | FArray _ -> {fid = 0; mark =ft.mark; term=FLIFT(n,ft)}
 let lift_fconstr k f =
   if Int.equal k 0 then f else lft_fconstr k f
 
@@ -259,9 +268,9 @@ let clos_rel e i =
     | Inl (n, Regular mt) -> Regular (lift_fconstr n mt)
     | Inl (_, HigherOrder (0, mt)) -> Regular mt
     | Inl (_, HigherOrder (nargs, mt)) -> HigherOrder (nargs, mt)
-    | Inr (k, None) -> Regular {mark=Ntrl; term= FRel k}
+    | Inr (k, None) -> Regular {fid = 0; mark =Ntrl; term= FRel k}
     | Inr (k, Some p) ->
-      Regular (lift_fconstr (k-p) {mark=Red;term=FFlex(RelKey p)})
+      Regular (lift_fconstr (k-p) {fid = 0; mark =Red;term=FFlex(RelKey p)})
 
 (* since the head may be reducible, we might introduce lifts of 0 *)
 let compact_stack head stk =
@@ -324,7 +333,7 @@ let destFLambda clos_fun t =
   | FLambda(_,[(na,ty)],b,e) ->
     (usubst_binder e na,clos_fun e ty,clos_fun (usubs_lift e) b)
   | FLambda(n,(na,ty)::tys,b,e) ->
-    (usubst_binder e na,clos_fun e ty,{mark=t.mark;term=FLambda(n-1,tys,b,usubs_lift e)})
+    (usubst_binder e na,clos_fun e ty,{fid = 0; mark =t.mark;term=FLambda(n-1,tys,b,usubs_lift e)})
   | _ -> assert false
 
 (* Optimization: do not enclose variables in a closure.
@@ -336,26 +345,26 @@ let mk_clos (e:usubs) t =
       | Regular v -> v
       | HigherOrder _ -> CErrors.anomaly Pp.(str "Uncaught pattern variable")
       end
-    | Var x -> {mark = Red; term = FFlex (VarKey x) }
-    | Const c -> {mark = Red; term = FFlex (ConstKey (usubst_punivs e c)) }
+    | Var x -> {fid = 0; mark = Red; term = FFlex (VarKey x) }
+    | Const c -> {fid = 0; mark = Red; term = FFlex (ConstKey (usubst_punivs e c)) }
     | Sort s ->
       let s = usubst_sort e s in
-      {mark = Ntrl; term = FAtom (mkSort s) }
-    | Meta _ -> {mark = Ntrl; term = FAtom t }
-    | Ind kn -> {mark = Ntrl; term = FInd (usubst_punivs e kn) }
-    | Construct kn -> {mark = Cstr; term = FConstruct (usubst_punivs e kn,[||]) }
-    | Int i -> {mark = Cstr; term = FInt i}
-    | Float f -> {mark = Cstr; term = FFloat f}
-    | String s -> {mark = Cstr; term = FString s}
+      {fid = 0; mark = Ntrl; term = FAtom (mkSort s) }
+    | Meta _ -> {fid = 0; mark = Ntrl; term = FAtom t }
+    | Ind kn -> {fid = 0; mark = Ntrl; term = FInd (usubst_punivs e kn) }
+    | Construct kn -> {fid = 0; mark = Cstr; term = FConstruct (usubst_punivs e kn,[||]) }
+    | Int i -> {fid = 0; mark = Cstr; term = FInt i}
+    | Float f -> {fid = 0; mark = Cstr; term = FFloat f}
+    | String s -> {fid = 0; mark = Cstr; term = FString s}
     | (CoFix _|Lambda _|Fix _|Prod _|Evar _|App _|Case _|Cast _|LetIn _|Proj _|Array _) ->
-        {mark = Red; term = FCLOS(t,e)}
+        {fid = 0; mark = Red; term = FCLOS(t,e)}
   (* Invariant, pattern variables under apps are deferred to knht by being wrapped in FCLOS *)
 
 let injectu c u = mk_clos (subs_id 0, u) c
 
 let inject c = injectu c UVars.Instance.empty
 
-let mk_irrelevant = { mark = Cstr; term = FIrrelevant }
+let mk_irrelevant = { fid = 0; mark = Cstr; term = FIrrelevant }
 
 let is_irrelevant info r = match info.i_cache.i_mode with
 | Reduction -> false
@@ -672,47 +681,47 @@ let rec resubst subs v =
     | FRel i ->
       let args = Array.Fun1.map resubst subs ve in
       begin match clos_rel subs i with
-      | Regular t -> { v with term = FApp (t, args) }
+      | Regular t -> { v with fid = 0; term = FApp (t, args) }
       | HigherOrder (nargs, term) ->
         let subs', args = Array.chop nargs args in
         let subs' = Array.fold_left (fun s v -> subs_cons (Regular v) s) (subs_id 0) subs' in
         let head = resubst subs' term in
-        { v with term = FApp (head, args) }
+        { v with fid = 0; term = FApp (head, args) }
       end
     | _ ->
-      { v with term =
+      { v with fid = 0; term =
           FApp (resubst subs f,
                 Array.Fun1.map resubst subs ve) }
     end
   | FCaseT (ci, u, pms, p, c, ve, env) ->
     let env = comp_subs subs env in
-    { v with term = FCaseT (ci, u, pms, p, resubst subs c, ve, env) }
+    { v with fid = 0; term = FCaseT (ci, u, pms, p, resubst subs c, ve, env) }
   | FCaseInvert (ci, u, pms, p, indices, c, ve, env) ->
     let env = comp_subs subs env in
     let indices = Array.Fun1.map resubst subs indices in
-    { v with term = FCaseInvert (ci, u, pms, p, indices, resubst subs c, ve, env) }
+    { v with fid = 0; term = FCaseInvert (ci, u, pms, p, indices, resubst subs c, ve, env) }
   | FFix (fx, e) ->
     let e = comp_subs subs e in
-    { v with term = FFix (fx, e) }
+    { v with fid = 0; term = FFix (fx, e) }
   | FCoFix (cfx, e) ->
     let e = comp_subs subs e in
-    { v with term = FCoFix (cfx, e) }
+    { v with fid = 0; term = FCoFix (cfx, e) }
   | FProj (p, r, c) ->
-    { v with term =
+    { v with fid = 0; term =
       FProj (p, r, resubst subs c) }
   | FLambda (len, tys, f, e) ->
     let e = comp_subs subs e in
-    { v with term = FLambda (len, tys, f, e) }
+    { v with fid = 0; term = FLambda (len, tys, f, e) }
   | FProd (n, t, c, e) ->
     let e = comp_subs subs e in
-    { v with term = FProd (n, resubst subs t, c, e) }
+    { v with fid = 0; term = FProd (n, resubst subs t, c, e) }
   | FLetIn (n, b, t, f, e) ->
     let e = comp_subs subs e in
-    { v with term =
+    { v with fid = 0; term =
       FLetIn (n, resubst subs b, resubst subs t, f, e) }
   | FEvar (ev, args, env, repack) ->
     let env = comp_subs subs env in
-    { v with term =
+    { v with fid = 0; term =
       FEvar (ev, args, env, repack) }
   | FLIFT (k, a) ->
     resubst (subs_popn k subs) a
@@ -720,12 +729,12 @@ let rec resubst subs v =
   | FArray (u, t, ty) ->
     let t = Parray.map (resubst subs) t in
     let ty = resubst subs ty in
-    { v with term =
+    { v with fid = 0; term =
       FArray (u, t, ty) }
 
   | FCLOS (t,env) ->
     let env = comp_subs subs env in
-    { v with term =
+    { v with fid = 0; term =
       FCLOS (t, env) }
 
   | FFlex (RelKey _) -> v (* outside the substitution *)
@@ -753,10 +762,10 @@ let mkFApp h args =
   else match[@warning "-4"] h.term with
     | FConstruct (c, args0) ->
       let args = if CArray.is_empty args0 then args else Array.append args0 args in
-      {mark=Cstr; term=FConstruct(c, args)}
+      {fid = 0; mark =Cstr; term=FConstruct(c, args)}
     | _ ->
       (* don't bother collapsing FApp nodes *)
-      {mark=neutr h.mark; term=FApp(h,args)}
+      {fid = 0; mark =neutr h.mark; term=FApp(h,args)}
 
 let rec zip m stk =
   match stk with
@@ -765,10 +774,10 @@ let rec zip m stk =
     | ZcaseT(ci, u, pms, p, br, e)::s ->
         let t = FCaseT(ci, u, pms, p, m, br, e) in
         let mark = (neutr m.mark) in
-        zip {mark; term=t} s
+        zip {fid = 0; mark; term=t} s
     | Zproj (p,r) :: s ->
         let mark = (neutr m.mark) in
-        zip {mark; term=FProj(Projection.make p true,r,m)} s
+        zip {fid = 0; mark; term=FProj(Projection.make p true,r,m)} s
     | Zfix(fx,par)::s ->
         zip fx (par @ append_stack [|m|] s)
     | Zshift(n)::s ->
@@ -779,9 +788,9 @@ let rec zip m stk =
         zip rf s
     | Zprimitive(_op,c,rargs,kargs)::s ->
       let args = List.rev_append rargs (m::List.map snd kargs) in
-      let f = {mark = Red; term = FFlex (ConstKey c)} in
+      let f = {fid = 0; mark = Red; term = FFlex (ConstKey c)} in
       (* don't need to mkFApp because not a constructor *)
-      zip {mark=(neutr m.mark); term = FApp (f, Array.of_list args)} s
+      zip {fid = 0; mark =(neutr m.mark); term = FApp (f, Array.of_list args)} s
 
 let fapp_stack (m,stk) = zip m stk
 
@@ -887,7 +896,7 @@ let rec get_args n tys f e = function
           let etys = List.skipn na tys in
           get_args (n-na) etys f (usubs_consn l 0 na e) s
     | ((ZcaseT _ | Zproj _ | Zfix _ | Zprimitive _) :: _ | []) as stk ->
-      (Inr {mark=Cstr; term=FLambda(n,tys,f,e)}, stk)
+      (Inr {fid = 0; mark =Cstr; term=FLambda(n,tys,f,e)}, stk)
 
 (* Eta expansion: add a reference to implicit surrounding lambda at end of stack *)
 let rec eta_expand_stack info na = function
@@ -897,7 +906,7 @@ let rec eta_expand_stack info na = function
   | [] ->
     let arg =
       if is_irrelevant info na.binder_relevance then mk_irrelevant
-      else {mark = Ntrl; term = FRel 1}
+      else {fid = 0; mark = Ntrl; term = FRel 1}
     in
     [Zshift 1; Zapp [|arg|]]
 
@@ -928,13 +937,13 @@ let get_native_args op c stk =
            Zapp (Array.of_list eargs) :: s')
         | rnargs, kargs, _ ->
           (* head of h is not constructor -> no need to mkFApp *)
-          strip_rec rnargs {mark = h.mark;term=FApp(h, args)} depth kargs s'
+          strip_rec rnargs {fid = 0; mark = h.mark;term=FApp(h, args)} depth kargs s'
       end
     | Zupdate(m) :: s ->
       let () = update m h.mark h.term in
       strip_rec rnargs m depth  kargs s
     | (Zprimitive _ | ZcaseT _ | Zproj _ | Zfix _) :: _ | [] -> assert false
-  in strip_rec [] {mark = Red; term = FFlex(ConstKey c)} 0 kargs stk
+  in strip_rec [] {fid = 0; mark = Red; term = FFlex(ConstKey c)} 0 kargs stk
 
 let get_native_args1 op c stk =
   match get_native_args op c stk with
@@ -1048,7 +1057,7 @@ let eta_expand_ind_stack env (ind,u) args m' =
       then raise Not_found (* partially applied constructor (missing non-param arguments) *)
     in
     let hstack = Array.map (fun (p,r) ->
-        { mark = Red; (* right can't be a constructor though *)
+        { fid = 0; mark = Red; (* right can't be a constructor though *)
           term = FProj (Projection.make p true, UVars.subst_instance_relevance u r, right) })
         projs
     in
@@ -1068,12 +1077,12 @@ let contract_fix_vect fix =
     match [@ocaml.warning "-4"] fix with
       | FFix (((reci,i),(_,_,bds as rdcl)),env) ->
           (bds.(i),
-           (fun j -> { mark = Cstr;
+           (fun j -> { fid = 0; mark = Cstr;
                        term = FFix (((reci,j),rdcl),env) }),
            env, Array.length bds)
       | FCoFix ((i,(_,_,bds as rdcl)),env) ->
           (bds.(i),
-           (fun j -> { mark = Cstr;
+           (fun j -> { fid = 0; mark = Cstr;
                        term = FCoFix ((j,rdcl),env) }),
            env, Array.length bds)
       | _ -> assert false
@@ -1104,7 +1113,7 @@ module FNativeEntries =
 
     let mk_construct c =
       (* All constructors used in primitive functions are relevant *)
-      { mark = Cstr; term = FConstruct (UVars.in_punivs c, [||]) }
+      { fid = 0; mark = Cstr; term = FConstruct (UVars.in_punivs c, [||]) }
 
     let get = Array.get
 
@@ -1128,7 +1137,7 @@ module FNativeEntries =
       | FArray (_u,t,_ty) -> t
       | _ -> assert false
 
-    let dummy = {mark = Ntrl; term = FRel 0}
+    let dummy = {fid = 0; mark = Ntrl; term = FRel 0}
 
     let current_retro = ref Retroknowledge.empty
     let defined_int = ref false
@@ -1138,7 +1147,7 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_int63 with
       | Some c ->
         defined_int := true;
-        fint := { mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
+        fint := { fid = 0; mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
       | None -> defined_int := false
 
     let defined_float = ref false
@@ -1148,7 +1157,7 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_float64 with
       | Some c ->
         defined_float := true;
-        ffloat := { mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
+        ffloat := { fid = 0; mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
       | None -> defined_float := false
 
     let defined_string = ref false
@@ -1158,7 +1167,7 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_string with
       | Some c ->
         defined_string := true;
-        fstring := { mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
+        fstring := { fid = 0; mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
       | None -> defined_string := false
 
     let defined_bool = ref false
@@ -1209,7 +1218,7 @@ module FNativeEntries =
         fLt := mk_construct cLt;
         fGt := mk_construct cGt;
         let (icmp, _) = cEq in
-        fcmp := { mark = Ntrl; term = FInd (UVars.in_punivs icmp) }
+        fcmp := { fid = 0; mark = Ntrl; term = FInd (UVars.in_punivs icmp) }
       | None -> defined_cmp := false
 
     let defined_f_cmp = ref false
@@ -1318,15 +1327,15 @@ module FNativeEntries =
 
     let mkInt env i =
       check_int env;
-      { mark = Cstr; term = FInt i }
+      { fid = 0; mark = Cstr; term = FInt i }
 
     let mkFloat env f =
       check_float env;
-      { mark = Cstr; term = FFloat f }
+      { fid = 0; mark = Cstr; term = FFloat f }
 
     let mkString env s =
       check_string env;
-      { mark = Cstr; term = FString s }
+      { fid = 0; mark = Cstr; term = FString s }
 
     let mkBool env b =
       check_bool env;
@@ -1411,7 +1420,7 @@ module FNativeEntries =
 
     let mkArray env u t ty =
       check_array env;
-      { mark = Cstr; term = FArray (u,t,ty)}
+      { fid = 0; mark = Cstr; term = FArray (u,t,ty)}
 
   end
 
@@ -1508,30 +1517,30 @@ and knht info e t stk =
         (mk_irrelevant, skip_irrelevant_stack info stk)
       else
         let term = FCaseInvert (ci, u, pms, p, (Array.map (mk_clos e) indices), mk_clos e t, br, e) in
-        { mark = Red; term }, stk
+        { fid = 0; mark = Red; term }, stk
     | Fix (((_, n), (lna, _, _)) as fx) ->
       if is_irrelevant info (usubst_relevance e (lna.(n)).binder_relevance) then
         (mk_irrelevant, skip_irrelevant_stack info stk)
       else
-        knh info { mark = Cstr; term = FFix (fx, e) } stk
+        knh info { fid = 0; mark = Cstr; term = FFix (fx, e) } stk
     | Cast(a,_,_) -> knht info e a stk
     | Proj (p, r, c) ->
       let r = usubst_relevance e r in
       if is_irrelevant info r then
         (mk_irrelevant, skip_irrelevant_stack info stk)
       else begin match unfold_projection info p r with
-      | None -> ({ mark = Red; term = FProj (p, r, mk_clos e c) }, stk)
+      | None -> ({ fid = 0; mark = Red; term = FProj (p, r, mk_clos e c) }, stk)
       | Some s -> knht info e c (s :: stk)
       end
     | Construct _ -> knh info (mk_clos e t) stk
     | (Ind _|Const _|Var _|Meta _ | Sort _ | Int _|Float _|String _) -> (mk_clos e t, stk)
     | CoFix cfx ->
-      { mark = Cstr; term = FCoFix (cfx,e) }, stk
-    | Lambda _ -> { mark = Cstr ; term = mk_lambda e t }, stk
+      { fid = 0; mark = Cstr; term = FCoFix (cfx,e) }, stk
+    | Lambda _ -> { fid = 0; mark = Cstr ; term = mk_lambda e t }, stk
     | Prod (n, t, c) ->
-      { mark = Ntrl; term = FProd (n, mk_clos e t, c, e) }, stk
+      { fid = 0; mark = Ntrl; term = FProd (n, mk_clos e t, c, e) }, stk
     | LetIn (n,b,t,c) ->
-      { mark = Red; term = FLetIn (n, mk_clos e b, mk_clos e t, c, e) }, stk
+      { fid = 0; mark = Red; term = FLetIn (n, mk_clos e b, mk_clos e t, c, e) }, stk
     | Evar ev ->
       begin match info.i_cache.i_sigma.evar_expand ev with
       | EvarDefined c -> knht info e c stk
@@ -1541,7 +1550,7 @@ and knht info e t stk =
           (mk_irrelevant, skip_irrelevant_stack info stk)
         else
           let repack = info.i_cache.i_sigma.evar_repack in
-          { mark = Ntrl; term = FEvar (evk, args, e, repack) }, stk
+          { fid = 0; mark = Ntrl; term = FEvar (evk, args, e, repack) }, stk
       end
     | Array(u,t,def,ty) ->
       let u = usubst_instance e u in
@@ -1549,7 +1558,7 @@ and knht info e t stk =
       let ty = mk_clos e ty in
       let t = Parray.init (Uint63.of_int len) (fun i -> mk_clos e t.(i)) (mk_clos e def) in
       let term = FArray (u,t,ty) in
-      knh info { mark = Cstr; term } stk
+      knh info { fid = 0; mark = Cstr; term } stk
 
 (************************************************************************)
 
@@ -1757,7 +1766,7 @@ and match_elim : 'a. ('a, 'a depth) reduction -> _ -> _ -> pat_state:'a depth ->
   | ZcaseT (ci, u, pms, ((pctx, p), _ as pred), brs, e) :: s ->
       let t = FCaseT (ci, u, pms, pred, head, brs, e) in
       let mark = neutr head.mark in
-      let head = {mark; term=t} in
+      let head = {fid = 0; mark; term=t} in
       let prets, pbrss, elims, states = extract_or_kill4 (function [@ocaml.warning "-4"]
       | PECase (pind, pret, pbrs) :: es, subst ->
         if not @@ QInd.equal (info_env info) pind ci.ci_ind then None else
@@ -1797,7 +1806,7 @@ and match_elim : 'a. ('a, 'a depth) reduction -> _ -> _ -> pat_state:'a depth ->
       match_main red info tab ~pat_state states loc
   | Zproj (proj', r) :: s ->
       let mark = (neutr head.mark) in
-      let head = {mark; term=FProj(Projection.make proj' true, r, head)} in
+      let head = {fid = 0; mark; term=FProj(Projection.make proj' true, r, head)} in
       let elims, states = extract_or_kill2 (function [@ocaml.warning "-4"]
       | PEProj proj :: es, subst ->
         if not @@ QProjection.Repr.equal (info_env info) proj proj' then None else
@@ -1967,7 +1976,7 @@ let match_symbol red info tab ~pat_state fl (u, b, r) stk =
       | None -> Dead, Ignore
     ) (Array.of_list r)
   in
-  let m = { mark = Red; term = FFlex fl } in
+  let m = { fid = 0; mark = Red; term = FFlex fl } in
   let loc = LocStart { elims; depth=0; head = m; stack = stk; next = Return (unfold_fix, m, stk) } in
   match_main red info tab ~pat_state states loc
 
@@ -2159,7 +2168,7 @@ and klt info tab e t = match kind t with
   | Inl (n, Regular mt) -> kl info tab @@ lift_fconstr n mt
   | Inl (_, HigherOrder (nargs, term)) -> assert (Int.equal nargs 0); kl info tab term
   | Inr (k, None) -> if Int.equal k i then t else mkRel k
-  | Inr (k, Some p) -> kl info tab @@ lift_fconstr (k-p) {mark=Red;term=FFlex(RelKey p)}
+  | Inr (k, Some p) -> kl info tab @@ lift_fconstr (k-p) {fid = 0; mark =Red;term=FFlex(RelKey p)}
   end
 | App (hd, args) ->
   let is_stuck = match kind hd with

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -117,7 +117,7 @@ val fterm_of : fconstr -> fterm
     only equality and hashing are meaningful, and in particular the
     numeric value carries no information a client may rely on. *)
 module Uid : sig
-  type t
+  type t [@@immediate]
   val equal : t -> t -> bool
   val hash : t -> int
 end

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -113,9 +113,21 @@ val zip : fconstr -> stack -> fconstr
 
 val fterm_of : fconstr -> fterm
 
-(** Stable id of a cell, lazily assigned; survives in-place reduction
-    updates. Used by the conversion cache. *)
-val get_fid : fconstr -> int
+(** Stable identity of a cell. The representation is opaque on purpose:
+    only equality and hashing are meaningful, and in particular the
+    numeric value carries no information a client may rely on. *)
+module Uid : sig
+  type t
+  val equal : t -> t -> bool
+  val hash : t -> int
+end
+
+(** Identity of a cell, {e assigned on demand}: the first call on a given
+    cell allocates a fresh identity and stores it, later calls return that
+    one. The identity survives the in-place [update] performed during
+    reduction, and a copy of a cell gets a fresh one. Used to key the
+    conversion cache. *)
+val uid : fconstr -> Uid.t
 
 val term_of_fconstr : fconstr -> constr
 val term_of_process : fconstr -> stack -> constr

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -112,6 +112,11 @@ val mk_clos_vect : usubs -> constr array -> fconstr array
 val zip : fconstr -> stack -> fconstr
 
 val fterm_of : fconstr -> fterm
+
+(** Stable id of a cell, lazily assigned; survives in-place reduction
+    updates. Used by the conversion cache. *)
+val get_fid : fconstr -> int
+
 val term_of_fconstr : fconstr -> constr
 val term_of_process : fconstr -> stack -> constr
 val destFLambda :

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -113,21 +113,31 @@ val zip : fconstr -> stack -> fconstr
 
 val fterm_of : fconstr -> fterm
 
-(** Stable identity of a cell. The representation is opaque on purpose:
-    only equality and hashing are meaningful, and in particular the
-    numeric value carries no information a client may rely on. *)
-module Uid : sig
-  type t [@@immediate]
-  val equal : t -> t -> bool
-  val hash : t -> int
-end
+(** Conversion result cache, recording the outcome (success or failure)
+    of comparing a pair of cells at a given lift pair and conversion
+    problem. Within one conversion session the same pair of cells is
+    typically compared many times over, because beta-substitution shares
+    payload cells across all the occurrences of a variable. Pairs are
+    identified by stable cell identities, assigned on demand: an identity
+    survives the in-place [update] performed during reduction, and a copy
+    of a cell gets a fresh one. The identity bookkeeping is internal to
+    this module. Only sound for checked conversion, where results are
+    deterministic and no universe constraints are accumulated. *)
+module ConvCache : sig
+  type t
 
-(** Identity of a cell, {e assigned on demand}: the first call on a given
-    cell allocates a fresh identity and stores it, later calls return that
-    one. The identity survives the in-place [update] performed during
-    reduction, and a copy of a cell gets a fresh one. Used to key the
-    conversion cache. *)
-val uid : fconstr -> Uid.t
+  val create : unit -> t option
+  (** [None] when the cache is disabled ([ROCQ_CONV_CACHE=0]). *)
+
+  val probe : t -> cumul:bool -> lift -> fconstr -> lift -> fconstr -> bool option
+  (** Looks up the outcome of comparing the two cells (which may still
+      carry [FLIFT]s) at the given lifts, for conversion ([cumul:false])
+      or cumulativity ([cumul:true]). *)
+
+  val record : t -> cumul:bool -> lift -> fconstr -> lift -> fconstr -> bool -> unit
+  (** Records an outcome for a pair on which [probe] returned [None].
+      No-op once the [ROCQ_CONV_CACHE_MAX] cap is reached. *)
+end
 
 val term_of_fconstr : fconstr -> constr
 val term_of_process : fconstr -> stack -> constr

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -201,8 +201,23 @@ let convert_inductives_gen cmp_instances cmp_cumul cv_pb (mind,ind) nargs u1 u2 
    by their stable ids, at a given lift pair and conversion problem. Only
    sound for checked conversion, where results are deterministic and no
    universe constraints are accumulated. *)
+module CCKey = struct
+  type t = CClosure.Uid.t * CClosure.Uid.t * conv_pb
+  let equal (u1, v1, pb1) (u2, v2, pb2) =
+    CClosure.Uid.equal u1 u2 && CClosure.Uid.equal v1 v2 &&
+    (match pb1, pb2 with
+     | CONV, CONV | CUMUL, CUMUL -> true
+     | (CONV | CUMUL), _ -> false)
+  let hash (u, v, pb) =
+    let h = CClosure.Uid.hash u * 0x3B9ACA07 + CClosure.Uid.hash v in
+    let h = h lxor (h lsr 16) in
+    match pb with CONV -> h | CUMUL -> h lxor 0x5BF03635
+end
+
+module CCTbl = Hashtbl.Make(CCKey)
+
 type conv_cache = {
-  cc_tbl : (int * int * conv_pb, (lift * lift * bool) list ref) Hashtbl.t;
+  cc_tbl : (lift * lift * bool) list ref CCTbl.t;
   mutable cc_size : int;
 }
 
@@ -445,8 +460,8 @@ let rec ccnv cv_pb l2r infos lft1 lft2 term1 term2 cuniv =
       let (k2, v2) = strip_flift 0 term2 in
       let l1 = el_shft k1 lft1 in
       let l2 = el_shft k2 lft2 in
-      let key = (CClosure.get_fid v1, CClosure.get_fid v2, cv_pb) in
-      let bucket = Hashtbl.find_opt cache.cc_tbl key in
+      let key = (CClosure.uid v1, CClosure.uid v2, cv_pb) in
+      let bucket = CCTbl.find_opt cache.cc_tbl key in
       let cached = match bucket with
       | None -> None
       | Some entries ->
@@ -466,7 +481,7 @@ let rec ccnv cv_pb l2r infos lft1 lft2 term1 term2 cuniv =
             cache.cc_size <- cache.cc_size + 1;
             match bucket with
             | Some entries -> entries := (l1, l2, r) :: !entries
-            | None -> Hashtbl.add cache.cc_tbl key (ref [(l1, l2, r)])
+            | None -> CCTbl.add cache.cc_tbl key (ref [(l1, l2, r)])
           end
         in
         match eqappr cv_pb l2r infos (lft1, (term1,[])) (lft2, (term2,[])) cuniv with
@@ -1055,7 +1070,7 @@ let clos_gen_conv (type err) ~typed ~use_cache trans cv_pb l2r evars env graph u
       let box e = Error.Error e in
       let cache =
         if use_cache && cc_enabled then
-          Some { cc_tbl = Hashtbl.create 16; cc_size = 0 }
+          Some { cc_tbl = CCTbl.create 16; cc_size = 0 }
         else None
       in
       let infos = {

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -194,40 +194,13 @@ let convert_inductives_gen cmp_instances cmp_cumul cv_pb (mind,ind) nargs u1 u2 
     else
       cmp_cumul cv_pb variances u1 u2 s
 
-(* Conversion result cache. Within one conversion session the same pair of
-   cells is typically compared many times over, because beta-substitution
-   shares payload cells across all the occurrences of a variable. Entries
-   record the outcome (success or failure) for a pair of cells, identified
-   by their stable ids, at a given lift pair and conversion problem. Only
-   sound for checked conversion, where results are deterministic and no
-   universe constraints are accumulated. *)
-module CCKey = struct
-  type t = CClosure.Uid.t * CClosure.Uid.t * conv_pb
-  let equal (u1, v1, pb1) (u2, v2, pb2) =
-    CClosure.Uid.equal u1 u2 && CClosure.Uid.equal v1 v2 &&
-    (match pb1, pb2 with
-     | CONV, CONV | CUMUL, CUMUL -> true
-     | (CONV | CUMUL), _ -> false)
-  let hash (u, v, pb) =
-    let h = CClosure.Uid.hash u * 0x3B9ACA07 + CClosure.Uid.hash v in
-    let h = h lxor (h lsr 16) in
-    match pb with CONV -> h | CUMUL -> h lxor 0x5BF03635
-end
-
-module CCTbl = Hashtbl.Make(CCKey)
-
-type conv_cache = {
-  cc_tbl : (lift * lift * bool) list ref CCTbl.t;
-  mutable cc_size : int;
-}
-
 type 'e conv_tab = {
   cnv_inf : clos_infos;
   cnv_typ : bool; (* true if the input terms were well-typed *)
   lft_tab : clos_tab;
   rgt_tab : clos_tab;
   err_ret : 'e -> payload;
-  cnv_cache : conv_cache option;
+  cnv_cache : ConvCache.t option;
 }
 (** Invariant: for any tl ∈ lft_tab and tr ∈ rgt_tab, there is no mutable memory
     location contained both in tl and in tr. *)
@@ -427,26 +400,6 @@ let assert_reduced_constructor s =
   if not @@ CList.is_empty s then
     CErrors.anomaly Pp.(str "conversion was given unreduced term (FConstruct).")
 
-let rec strip_flift k v = match fterm_of v with
-| FLIFT (n, v') -> strip_flift (k + n) v'
-| _ -> (k, v)
-
-(* Optional cap on cached entries per session (ROCQ_CONV_CACHE_MAX; 0 means
-   unlimited). Unbounded by default: like [clos_tab], the table is
-   session-scoped, so its lifetime bounds memory. *)
-let cc_max_size =
-  match int_of_string (Sys.getenv "ROCQ_CONV_CACHE_MAX") with
-  | 0 -> max_int
-  | n -> n
-  | exception _ -> max_int
-
-(* The cache is enabled by default; set ROCQ_CONV_CACHE=0 to disable. *)
-let cc_enabled =
-  match Sys.getenv "ROCQ_CONV_CACHE" with
-  | "0" -> false
-  | _ -> true
-  | exception Not_found -> true
-
 (* Conversion between  [lft1]term1 and [lft2]term2 *)
 let rec ccnv cv_pb l2r infos lft1 lft2 term1 term2 cuniv =
   let fast = fast_test lft1 term1 lft2 term2 in
@@ -456,38 +409,17 @@ let rec ccnv cv_pb l2r infos lft1 lft2 term1 term2 cuniv =
     | None ->
       eqappr cv_pb l2r infos (lft1, (term1,[])) (lft2, (term2,[])) cuniv
     | Some cache ->
-      let (k1, v1) = strip_flift 0 term1 in
-      let (k2, v2) = strip_flift 0 term2 in
-      let l1 = el_shft k1 lft1 in
-      let l2 = el_shft k2 lft2 in
-      let key = (CClosure.uid v1, CClosure.uid v2, cv_pb) in
-      let bucket = CCTbl.find_opt cache.cc_tbl key in
-      let cached = match bucket with
-      | None -> None
-      | Some entries ->
-        let rec find = function
-        | [] -> None
-        | (l1', l2', r) :: rest ->
-          if eq_lift l1' l1 && eq_lift l2' l2 then Some r else find rest
-        in
-        find !entries
-      in
-      begin match cached with
+      let cumul = match cv_pb with CONV -> false | CUMUL -> true in
+      match ConvCache.probe cache ~cumul lft1 term1 lft2 term2 with
       | Some true -> cuniv
       | Some false -> raise NotConvertible
       | None ->
-        let add r =
-          if cache.cc_size < cc_max_size then begin
-            cache.cc_size <- cache.cc_size + 1;
-            match bucket with
-            | Some entries -> entries := (l1, l2, r) :: !entries
-            | None -> CCTbl.add cache.cc_tbl key (ref [(l1, l2, r)])
-          end
-        in
         match eqappr cv_pb l2r infos (lft1, (term1,[])) (lft2, (term2,[])) cuniv with
-        | cuniv -> add true; cuniv
-        | exception NotConvertible -> add false; raise NotConvertible
-      end
+        | cuniv ->
+          ConvCache.record cache ~cumul lft1 term1 lft2 term2 true; cuniv
+        | exception NotConvertible ->
+          ConvCache.record cache ~cumul lft1 term1 lft2 term2 false;
+          raise NotConvertible
 
 (* Conversion between [lft1](hd1 v1) and [lft2](hd2 v2) *)
 and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
@@ -1068,11 +1000,7 @@ let clos_gen_conv (type err) ~typed ~use_cache trans cv_pb l2r evars env graph u
       let infos = create_conv_infos ~univs:graph ~evars reds env in
       let module Error = struct type payload += Error of err end in
       let box e = Error.Error e in
-      let cache =
-        if use_cache && cc_enabled then
-          Some { cc_tbl = CCTbl.create 16; cc_size = 0 }
-        else None
-      in
+      let cache = if use_cache then ConvCache.create () else None in
       let infos = {
         cnv_inf = infos;
         cnv_typ = typed;

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -202,7 +202,7 @@ let convert_inductives_gen cmp_instances cmp_cumul cv_pb (mind,ind) nargs u1 u2 
    sound for checked conversion, where results are deterministic and no
    universe constraints are accumulated. *)
 type conv_cache = {
-  cc_tbl : (int * int * int, (lift * lift * bool) list ref) Hashtbl.t;
+  cc_tbl : (int * int * conv_pb, (lift * lift * bool) list ref) Hashtbl.t;
   mutable cc_size : int;
 }
 
@@ -445,8 +445,7 @@ let rec ccnv cv_pb l2r infos lft1 lft2 term1 term2 cuniv =
       let (k2, v2) = strip_flift 0 term2 in
       let l1 = el_shft k1 lft1 in
       let l2 = el_shft k2 lft2 in
-      let pb = match cv_pb with CONV -> 0 | CUMUL -> 1 in
-      let key = (CClosure.get_fid v1, CClosure.get_fid v2, pb) in
+      let key = (CClosure.get_fid v1, CClosure.get_fid v2, cv_pb) in
       let bucket = Hashtbl.find_opt cache.cc_tbl key in
       let cached = match bucket with
       | None -> None

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -194,12 +194,25 @@ let convert_inductives_gen cmp_instances cmp_cumul cv_pb (mind,ind) nargs u1 u2 
     else
       cmp_cumul cv_pb variances u1 u2 s
 
+(* Conversion result cache. Within one conversion session the same pair of
+   cells is typically compared many times over, because beta-substitution
+   shares payload cells across all the occurrences of a variable. Entries
+   record the outcome (success or failure) for a pair of cells, identified
+   by their stable ids, at a given lift pair and conversion problem. Only
+   sound for checked conversion, where results are deterministic and no
+   universe constraints are accumulated. *)
+type conv_cache = {
+  cc_tbl : (int * int * int, (lift * lift * bool) list ref) Hashtbl.t;
+  mutable cc_size : int;
+}
+
 type 'e conv_tab = {
   cnv_inf : clos_infos;
   cnv_typ : bool; (* true if the input terms were well-typed *)
   lft_tab : clos_tab;
   rgt_tab : clos_tab;
   err_ret : 'e -> payload;
+  cnv_cache : conv_cache option;
 }
 (** Invariant: for any tl ∈ lft_tab and tr ∈ rgt_tab, there is no mutable memory
     location contained both in tl and in tr. *)
@@ -399,12 +412,68 @@ let assert_reduced_constructor s =
   if not @@ CList.is_empty s then
     CErrors.anomaly Pp.(str "conversion was given unreduced term (FConstruct).")
 
+let rec strip_flift k v = match fterm_of v with
+| FLIFT (n, v') -> strip_flift (k + n) v'
+| _ -> (k, v)
+
+(* Optional cap on cached entries per session (ROCQ_CONV_CACHE_MAX; 0 means
+   unlimited). Unbounded by default: like [clos_tab], the table is
+   session-scoped, so its lifetime bounds memory. *)
+let cc_max_size =
+  match int_of_string (Sys.getenv "ROCQ_CONV_CACHE_MAX") with
+  | 0 -> max_int
+  | n -> n
+  | exception _ -> max_int
+
+(* The cache is enabled by default; set ROCQ_CONV_CACHE=0 to disable. *)
+let cc_enabled =
+  match Sys.getenv "ROCQ_CONV_CACHE" with
+  | "0" -> false
+  | _ -> true
+  | exception Not_found -> true
+
 (* Conversion between  [lft1]term1 and [lft2]term2 *)
 let rec ccnv cv_pb l2r infos lft1 lft2 term1 term2 cuniv =
   let fast = fast_test lft1 term1 lft2 term2 in
   if fast then cuniv
   else
-    eqappr cv_pb l2r infos (lft1, (term1,[])) (lft2, (term2,[])) cuniv
+    match infos.cnv_cache with
+    | None ->
+      eqappr cv_pb l2r infos (lft1, (term1,[])) (lft2, (term2,[])) cuniv
+    | Some cache ->
+      let (k1, v1) = strip_flift 0 term1 in
+      let (k2, v2) = strip_flift 0 term2 in
+      let l1 = el_shft k1 lft1 in
+      let l2 = el_shft k2 lft2 in
+      let pb = match cv_pb with CONV -> 0 | CUMUL -> 1 in
+      let key = (CClosure.get_fid v1, CClosure.get_fid v2, pb) in
+      let bucket = Hashtbl.find_opt cache.cc_tbl key in
+      let cached = match bucket with
+      | None -> None
+      | Some entries ->
+        let rec find = function
+        | [] -> None
+        | (l1', l2', r) :: rest ->
+          if eq_lift l1' l1 && eq_lift l2' l2 then Some r else find rest
+        in
+        find !entries
+      in
+      begin match cached with
+      | Some true -> cuniv
+      | Some false -> raise NotConvertible
+      | None ->
+        let add r =
+          if cache.cc_size < cc_max_size then begin
+            cache.cc_size <- cache.cc_size + 1;
+            match bucket with
+            | Some entries -> entries := (l1, l2, r) :: !entries
+            | None -> Hashtbl.add cache.cc_tbl key (ref [(l1, l2, r)])
+          end
+        in
+        match eqappr cv_pb l2r infos (lft1, (term1,[])) (lft2, (term2,[])) cuniv with
+        | cuniv -> add true; cuniv
+        | exception NotConvertible -> add false; raise NotConvertible
+      end
 
 (* Conversion between [lft1](hd1 v1) and [lft2](hd2 v2) *)
 and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
@@ -979,18 +1048,24 @@ and convert_list l2r infos lft1 lft2 v1 v2 cuniv = match v1, v2 with
   convert_list l2r infos lft1 lft2 v1 v2 cuniv
 | _, _ -> raise NotConvertible
 
-let clos_gen_conv (type err) ~typed trans cv_pb l2r evars env graph univs t1 t2 =
+let clos_gen_conv (type err) ~typed ~use_cache trans cv_pb l2r evars env graph univs t1 t2 =
   NewProfile.profile "Conversion" begin fun () ->
       let reds = RedFlags.red_add_transparent RedFlags.betaiotazeta trans in
       let infos = create_conv_infos ~univs:graph ~evars reds env in
       let module Error = struct type payload += Error of err end in
       let box e = Error.Error e in
+      let cache =
+        if use_cache && cc_enabled then
+          Some { cc_tbl = Hashtbl.create 16; cc_size = 0 }
+        else None
+      in
       let infos = {
         cnv_inf = infos;
         cnv_typ = typed;
         lft_tab = create_tab ();
         rgt_tab = create_tab ();
         err_ret = box;
+        cnv_cache = cache;
       } in
       try Result.Ok (ccnv cv_pb l2r infos el_id el_id (inject t1) (inject t2) univs)
       with
@@ -1039,7 +1114,7 @@ let () =
       let box = Empty.abort in
       let state = info_univs infos in
       let qual_equal q1 q2 = CClosure.eq_quality infos q1 q2 in
-      let infos = { cnv_inf = infos; cnv_typ = true; lft_tab = tab; rgt_tab = tab; err_ret = box; } in
+      let infos = { cnv_inf = infos; cnv_typ = true; lft_tab = tab; rgt_tab = tab; err_ret = box; cnv_cache = None; } in
       let state', _ = ccnv CONV false infos el_id el_id a b (state, checked_universes_gen qual_equal) in
       assert (state==state');
       true
@@ -1057,7 +1132,7 @@ let gen_conv ~typed cv_pb ?(l2r=false) ?(reds=TransparentState.full) env ?(evars
     else eq_constr_univs univs t1 t2
   in
     if b then Result.Ok ()
-    else match clos_gen_conv ~typed reds cv_pb l2r evars env univs (state, checked_universes) t1 t2 with
+    else match clos_gen_conv ~typed ~use_cache:true reds cv_pb l2r evars env univs (state, checked_universes) t1 t2 with
     | Result.Ok (_ : 'a * ('a, Empty.t) universe_compare)-> Result.Ok ()
     | Result.Error None -> Result.Error ()
     | Result.Error (Some e) -> Empty.abort e
@@ -1067,7 +1142,7 @@ let conv_leq = gen_conv ~typed:false CUMUL
 
 let generic_conv cv_pb ~l2r reds env ?(evars=default_evar_handler env) state t1 t2 =
   let graph = Environ.universes env in
-  match clos_gen_conv ~typed:false reds cv_pb l2r evars env graph state t1 t2 with
+  match clos_gen_conv ~typed:false ~use_cache:false reds cv_pb l2r evars env graph state t1 t2 with
   | Result.Ok (s, _) -> Result.Ok s
   | Result.Error e -> Result.Error e
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Make sure you read the contributing guide and fill this template. -->

# Kernel: cache conversion results within a session

## Summary

Kernel conversion runs on the closure machine of `kernel/cClosure.ml`: the lazy reduction machine that represents a term as a graph of mutable cells (`fconstr`), each holding a subterm together with its environment, and updates a cell in place with its reduct once it has been forced. Because substitution is delayed in the environment rather than performed on the syntax, substituting a term for a variable makes every occurrence of that variable point at one and the same cell instead of at a copy of it.

Today, conversion does not exploit that sharing. A problem posed on two such terms decomposes into subproblems that confront the same pair of cells once per occurrence, and `ccnv` retains nothing between those encounters, so each is reduced and compared from scratch. The cost of the check then scales with how many times a shared subterm occurs, not with how large it is.

This PR makes conversion remember. Each cell gets a stable identity, and a table local to one conversion session records, for a pair of cells, whether they were found convertible. A pair that comes back is answered from the table instead of being reduced again.

This is a follow-up for the recently merged #22299, which discharges a pair up front when both sides are the same pointer.

## Implementation

- **Stable cell ids.** `fconstr` gains a mutable `fid` field (`0` = unassigned), handed out lazily by `CClosure.get_fid`. It is preserved by the in-place `update` the machine performs when it reduces a cell, and reset to `0` on every copy of a cell (`lft_fconstr`, `resubst`, `zip`, `mkFApp`, and the other places that build fresh cells). All the noise in `kernel/cClosure.ml` is just this field being added to record literals.
- **Session cache.** `conv_tab` gains an optional `conv_cache`: a `Hashtbl` from `(fid1, fid2, cv_pb)` to a bucket of `(lift1, lift2, result)` entries, compared with `eq_lift`. `ccnv` looks the pair up before calling `eqappr`, and records the outcome afterwards. Both successes and failures are cached: a hit replays `cuniv` unchanged or re-raises `NotConvertible`.
- **Lift normalization.** Before keying, outer `FLIFT` layers are stripped off both sides and folded into the corresponding lift with `el_shft`, so that cells that differ only by a lift wrapper share cache entries. This mirrors what the existing `fast_test` pre-check already does.
- **Knobs.** The cache is on by default; `ROCQ_CONV_CACHE=0` disables it and `ROCQ_CONV_CACHE_MAX=<n>` caps the number of entries (`0` or unset means unlimited). It is unbounded by default because, like `clos_tab`, the table is session-scoped, so its lifetime bounds its memory.

This PR was made with assistance of Claude Fable 5.

## Why it's correct

The cache is only installed for *checked* conversion (`gen_conv`, i.e. `conv` / `conv_leq`), where the answer is a deterministic function of a fixed environment and universe graph, and no universe constraints are accumulated that would need to be replayed on a hit. Inference-mode conversion (`generic_conv`, used by unification and evarconv, which backtracks and discards constraints) passes `~use_cache:false` and never consults the cache, as does the `compare_under`-style entry point registered on `CClosure`.

Two further points:

- Caching under `fid` is stable across in-place reduction: `update` rewrites a cell's `term` to a *reduct* of what was there, which is convertible to it, so a previously recorded verdict for that cell remains valid. Copies get a fresh `fid`, so no unrelated cell can inherit a verdict.
- Lifts and the conversion problem (`CONV` vs `CUMUL`) are part of the key, so a result is never reused at a different de Bruijn offset or in the wrong direction. `l2r` is fixed for the whole session and so needs no keying.

## Performance

The motivating development is [Bonak](https://github.com/artagnon/bonak), whose dimension-indexed definitions compare heavily shared closures over and over. Below is compilation of [`theories/νSet/SSGpd.v`](https://github.com/olympichek/bonak/blob/c9f8171a8112adb1920be51186e17ac133f2c4f9/theories/%CE%BDSet/SSGpd.v), each row adding to the previous one. All rows assume #22272 (refolding of global fixpoints), without which the file is too slow to measure.

| Configuration | Time | Peak memory |
| --- | ---: | ---: |
| #22272 alone | 2139.2s | 1.02 GB |
| \+ `compare_under` fast paths (#22299) | 812.6s (2.63x) | 1.00 GB |
| \+ conversion cache (this PR) | 171.5s (4.74x) | 8.13 GB |

The cache is worth 4.74x here, 12.5x cumulatively from the first row. It buys that with memory: peak usage goes from 1.00 GB to 8.13 GB, which `ROCQ_CONV_CACHE_MAX` can bound.

The broader impact is unknown: this is an extreme case, and we have not measured whether other developments gain, are unaffected, or lose to the bookkeeping and the extra memory. This can be tested by the CI benchmark. If the cache does not pay off outside workloads like this one, we are happy to make it off by default behind an explicit option, something like `Set Conversion Cache`.

## Checklist

<!-- No user-visible behavior change (the conversion relation is unchanged), so no test-suite entry. -->

- [ ] Added **changelog** (kernel performance improvement, type *Changed*).

<!-- Kernel-internal optimization: no new or changed user syntax, messages, or documentation, and no external-library breakage, so the documentation and overlay items do not apply. -->

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->
