### PR TITLE
Add Set Printing Unnamed Universes Anonymously

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/22310-printing-anon-qvars-Added.rst
+++ b/doc/changelog/08-vernac-commands-and-options/22310-printing-anon-qvars-Added.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  flag ``Printing Sort Quality Variables Anonymously``, which prints
+  sort quality variables that cannot be referred to by name as ``_``
+  (which can be parsed back, denoting a fresh quality variable)
+  instead of their raw ``α``-names (which cannot)
+  (`#22310 <https://github.com/rocq-prover/rocq/pull/22310>`_,
+  written by Claude (Anthropic), for Jason Gross).

--- a/doc/changelog/08-vernac-commands-and-options/22310-printing-anon-qvars-Added.rst
+++ b/doc/changelog/08-vernac-commands-and-options/22310-printing-anon-qvars-Added.rst
@@ -1,7 +1,9 @@
 - **Added:**
-  flag ``Printing Sort Quality Variables Anonymously``, which prints
-  sort quality variables that cannot be referred to by name as ``_``
-  (which can be parsed back, denoting a fresh quality variable)
-  instead of their raw ``α``-names (which cannot)
+  flag ``Printing Unnamed Universes Anonymously``, which prints
+  universe levels and sort quality variables that cannot be referred
+  to by name as ``_`` (which can be parsed back, denoting a fresh
+  level or quality variable) instead of their raw forms such as
+  ``Lib.23`` or ``α3`` (which cannot); a sort whose universe is a
+  ``max`` with such a level prints as ``Type@{_}``
   (`#22310 <https://github.com/rocq-prover/rocq/pull/22310>`_,
   written by Claude (Anthropic), for Jason Gross).

--- a/doc/sphinx/addendum/universe-polymorphism.rst
+++ b/doc/sphinx/addendum/universe-polymorphism.rst
@@ -1033,6 +1033,16 @@ It means that `s` and `s'` can respectively be instantiated to e.g., `Type` and 
    become at the end of the definition unless it is unified with
    another rigid quality).
 
+.. flag:: Printing Sort Quality Variables Anonymously
+
+   When this :term:`flag` is on (it is off by default), sort quality
+   variables that cannot be referred to by name are printed as ``_``
+   (which, when parsed back, denotes a fresh quality variable) instead
+   of their raw representation — ``α`` followed by a number — which
+   cannot be parsed back. Quality variables that have a name (such as
+   the ``s`` of a ``@{s;u}`` universe declaration, in contexts where it
+   is bound) are printed by name as usual.
+
 Explicit Sorts
 ---------------
 

--- a/doc/sphinx/addendum/universe-polymorphism.rst
+++ b/doc/sphinx/addendum/universe-polymorphism.rst
@@ -1033,15 +1033,20 @@ It means that `s` and `s'` can respectively be instantiated to e.g., `Type` and 
    become at the end of the definition unless it is unified with
    another rigid quality).
 
-.. flag:: Printing Sort Quality Variables Anonymously
+.. flag:: Printing Unnamed Universes Anonymously
 
-   When this :term:`flag` is on (it is off by default), sort quality
-   variables that cannot be referred to by name are printed as ``_``
-   (which, when parsed back, denotes a fresh quality variable) instead
-   of their raw representation — ``α`` followed by a number — which
-   cannot be parsed back. Quality variables that have a name (such as
-   the ``s`` of a ``@{s;u}`` universe declaration, in contexts where it
-   is bound) are printed by name as usual.
+   When this :term:`flag` is on (it is off by default), universe levels
+   and sort quality variables that cannot be referred to by name are
+   printed as ``_`` (which, when parsed back, denotes a fresh level or
+   quality variable) instead of their raw representation — a library
+   name followed by a number such as ``Lib.23``, or ``α`` followed by a
+   number — which cannot be parsed back. Levels and quality variables
+   that have a name (such as the ``s`` and ``u`` of a ``@{s;u}``
+   universe declaration, in contexts where they are bound, or the
+   ``foo.u0`` of a monomorphic definition ``foo``) are printed by name
+   as usual. Since ``_`` cannot appear as one component of a ``max``,
+   a sort whose universe involves an unnamed level prints as
+   ``Type@{_}`` as a whole.
 
 Explicit Sorts
 ---------------

--- a/doc/sphinx/language/core/sorts.rst
+++ b/doc/sphinx/language/core/sorts.rst
@@ -18,6 +18,7 @@ Sorts
    | Type
    | Type @%{ _ %}
    | Type @%{ {? @qualid {| %| | ; } } @universe %}
+   | Type @%{ _ ; @universe %}
    universe ::= max ( {+, @universe_expr } )
    | _
    | @universe_expr

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -170,6 +170,7 @@ DELETE: [
 | test_leftsquarebracket_equal
 | test_old_sort_qvar
 | test_sort_qvar
+| test_sort_anon_qvar
 | test_ltac2_ident
 | test_doublepipe_univ_decl
 | test_doublepipe_cumul_univ_decl

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -29,6 +29,7 @@ sort: [
 | "Type" "@{" "_" "}"
 | "Type" "@{" test_old_sort_qvar reference "|" universe "}"
 | "Type" "@{" test_sort_qvar reference ";" universe "}"
+| "Type" "@{" test_sort_anon_qvar "_" ";" universe "}"
 | "Type" "@{" universe "}"
 ]
 

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -290,6 +290,7 @@ sort: [
 | "Type"
 | "Type" "@{" "_" "}"
 | "Type" "@{" OPT [ qualid [ "|" | ";" ] ] universe "}"
+| "Type" "@{" "_" ";" universe "}"
 ]
 
 universe: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -285,6 +285,7 @@ sort: [
 | "Type"
 | "Type" "@{" "_" "}"
 | "Type" "@{" OPT [ qualid [ "|" | ";" ] ] universe "}"
+| "Type" "@{" "_" ";" universe "}"
 ]
 
 universe: [

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -787,36 +787,44 @@ let extern_glob_sort_name uvars = function
       | None -> CRawType u
     end
 
-let extern_glob_quality uvars = function
+let extern_glob_quality ~anon uvars = function
   | GLocalQVar {v=Anonymous;loc} -> CQAnon loc
   | GLocalQVar {v=Name id; loc} -> CQVar (qualid_of_ident ?loc id)
   | GRawQVar q -> CRawQuality (QVar q)
   | GQuality q -> begin match UnivNames.qualid_of_quality uvars q with
     | Some qid -> CQVar qid
-    | None -> CRawQuality q
+    | None ->
+      (* A quality variable with no name has no parsable form; print it
+         as "_" (a fresh quality variable when parsed back) when
+         [anon]. *)
+      match q with
+      | QVar _ when anon -> CQAnon None
+      | _ -> CRawQuality q
     end
 
-let extern_relevance uvars = function
+let extern_relevance ~anon uvars = function
   | GRelevant -> CRelevant
   | GIrrelevant -> CIrrelevant
-  | GRelevanceVar q -> CRelevanceVar (extern_glob_quality uvars q)
+  | GRelevanceVar q -> CRelevanceVar (extern_glob_quality ~anon uvars q)
 
-let extern_relevance_info uvars = Option.map (extern_relevance uvars)
+let extern_relevance_info ~anon uvars = Option.map (extern_relevance ~anon uvars)
 
-let extern_glob_sort uvars (q, l) =
-  Option.map (extern_glob_quality uvars) q,
+let extern_glob_sort ~anon uvars (q, l) =
+  Option.map (extern_glob_quality ~anon uvars) q,
   map_glob_sort_gen (List.map (on_fst (extern_glob_sort_name uvars))) l
 
-let extern_instance uvars = function
+let extern_instance ~anon uvars = function
   | Some (ql,ul) ->
-    let ql = List.map (extern_glob_quality uvars) ql in
+    let ql = List.map (extern_glob_quality ~anon uvars) ql in
     let ul = List.map (map_glob_sort_gen (extern_glob_sort_name uvars)) ul in
     Some (ql,ul)
   | None -> None
 
-let extern_ref {vars; uvars} ref us =
+let anon_qvars eenv = eenv.flags.ExternFlags.anonymous_qvars
+
+let extern_ref ({vars; uvars; _} as eenv) ref us =
   extern_global (select_stronger_impargs (implicits_of_global ref))
-    (extern_reference vars ref) (extern_instance uvars us)
+    (extern_reference vars ref) (extern_instance ~anon:(anon_qvars eenv) uvars us)
 
 let extern_var ?loc id = CRef (qualid_of_ident ?loc id,None)
 
@@ -926,7 +934,7 @@ let rec extern depth0 inctx scopes (eenv:extern_env) r =
              (* Otherwise... *)
                extern_applied_ref ~flags inctx
                  (select_stronger_impargs (implicits_of_global ref))
-                 (ref,extern_reference ?loc eenv.vars ref) (extern_instance eenv.uvars us) args)
+                 (ref,extern_reference ?loc eenv.vars ref) (extern_instance ~anon:(anon_qvars eenv) eenv.uvars us) args)
          | GProj (f,params,c) ->
              extern_applied_proj depth inctx scopes eenv f params c args
          | _ ->
@@ -1030,7 +1038,7 @@ let rec extern depth0 inctx scopes (eenv:extern_env) r =
              in
              CCoFix (CAst.(make ?loc idv.(n)),Array.to_list listdecl))
 
-  | GSort s -> CSort (extern_glob_sort eenv.uvars s)
+  | GSort s -> CSort (extern_glob_sort ~anon:(anon_qvars eenv) eenv.uvars s)
 
   | GHole e -> CHole (Some e)
 
@@ -1056,7 +1064,7 @@ let rec extern depth0 inctx scopes (eenv:extern_env) r =
 
   | GArray(u,t,def,ty) ->
     CArray(
-      extern_instance eenv.uvars u,
+      extern_instance ~anon:(anon_qvars eenv) eenv.uvars u,
       Array.map (extern depth inctx scopes eenv) t,
       extern depth inctx scopes eenv def,
       extern_typ depth scopes eenv ty)
@@ -1070,7 +1078,7 @@ and sub_extern depth inctx (subentry,(_,scopes)) = extern depth inctx (subentry,
 
 and factorize_prod depth scopes eenv na r bk t c =
   let implicit_type = is_reserved_type ~flags:eenv.flags na t in
-  let r = extern_relevance_info eenv.uvars r in
+  let r = extern_relevance_info ~anon:(anon_qvars eenv) eenv.uvars r in
   let aty = extern_typ depth scopes eenv t in
   let eenv = add_vname eenv na in
   let store, get = set_temporary_memory () in
@@ -1107,7 +1115,7 @@ and factorize_prod depth scopes eenv na r bk t c =
 
 and factorize_lambda depth inctx scopes eenv na r bk t c =
   let implicit_type = is_reserved_type ~flags:eenv.flags na t in
-  let r = extern_relevance_info eenv.uvars r in
+  let r = extern_relevance_info ~anon:(anon_qvars eenv) eenv.uvars r in
   let aty = extern_typ depth scopes eenv t in
   let eenv = add_vname eenv na in
   let store, get = set_temporary_memory () in
@@ -1150,7 +1158,7 @@ and extern_local_binder depth scopes eenv = function
       let (assums,ids,l) =
         extern_local_binder depth scopes (on_eenv_vars (Name.fold_right Id.Set.add na) eenv) l in
       (assums,na::ids,
-       CLocalDef(CAst.make na, extern_relevance_info eenv.uvars r, extern depth false scopes eenv bd,
+       CLocalDef(CAst.make na, extern_relevance_info ~anon:(anon_qvars eenv) eenv.uvars r, extern depth false scopes eenv bd,
                    Option.map (extern_typ depth scopes eenv) ty) :: l)
 
     | GLocalAssum (na,r,bk,ty) ->
@@ -1167,7 +1175,7 @@ and extern_local_binder depth scopes eenv = function
        | (assums,ids,l) ->
          let ty = if implicit_type then hole else ty in
          (na::assums,na::ids,
-          CLocalAssum([CAst.make na],extern_relevance_info eenv.uvars r,Default bk,ty) :: l))
+          CLocalAssum([CAst.make na],extern_relevance_info ~anon:(anon_qvars eenv) eenv.uvars r,Default bk,ty) :: l))
 
     | GLocalPattern ((p,_),_,bk,_) ->
       let p = mkCPatOr (List.map (extern_cases_pattern ~flags:eenv.flags eenv.vars) p) in
@@ -1305,7 +1313,7 @@ and extern_applied_proj depth inctx scopes eenv (cst,us) params c extraargs =
   let args = extern_args (extern depth true) eenv args in
   let imps = select_stronger_impargs (implicits_of_global ref) in
   let f = extern_reference eenv.vars ref in
-  let us = extern_instance eenv.uvars us in
+  let us = extern_instance ~anon:(anon_qvars eenv) eenv.uvars us in
   extern_projection ~flags:eenv.flags inctx (f,us) nparams args imps
 
 let extern inctx scopes eenv c : constr_expr = extern (init_depth eenv.flags) inctx scopes eenv c
@@ -1346,8 +1354,8 @@ let extern_type ?(goal_concl_style=false) ~(flags:PrintingFlags.t) env sigma ?im
   let r = Detyping.detype Detyping.Later ~isgoal:goal_concl_style ~avoid ~flags:flags.detype env sigma t in
   extern_glob_type ?impargs (extern_env ~flags:flags.extern env sigma) r
 
-let extern_sort ~universes ~qualities sigma s =
-  extern_glob_sort (Evd.universe_binders sigma)
+let extern_sort ~universes ~qualities ~anonymous_qvars sigma s =
+  extern_glob_sort ~anon:anonymous_qvars (Evd.universe_binders sigma)
     (detype_sort ~universes ~qualities sigma s)
 
 let extern_closed_glob ?(goal_concl_style=false) ?(inctx=false) ?scope ~(flags:PrintingFlags.t) env sigma t =

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -787,36 +787,44 @@ let extern_glob_sort_name uvars = function
       | None -> CRawType u
     end
 
-let extern_glob_quality uvars = function
+let extern_glob_quality ~anon_qvars uvars = function
   | GLocalQVar {v=Anonymous;loc} -> CQAnon loc
   | GLocalQVar {v=Name id; loc} -> CQVar (qualid_of_ident ?loc id)
   | GRawQVar q -> CRawQuality (QVar q)
   | GQuality q -> begin match UnivNames.qualid_of_quality uvars q with
     | Some qid -> CQVar qid
-    | None -> CRawQuality q
+    | None ->
+      (* A quality variable with no name has no parsable form; print it
+         as "_" (a fresh quality variable when parsed back) when
+         [anon_qvars]. *)
+      match q with
+      | QVar _ when anon_qvars -> CQAnon None
+      | _ -> CRawQuality q
     end
 
-let extern_relevance uvars = function
+let extern_relevance ~anon_qvars uvars = function
   | GRelevant -> CRelevant
   | GIrrelevant -> CIrrelevant
-  | GRelevanceVar q -> CRelevanceVar (extern_glob_quality uvars q)
+  | GRelevanceVar q -> CRelevanceVar (extern_glob_quality ~anon_qvars uvars q)
 
-let extern_relevance_info uvars = Option.map (extern_relevance uvars)
+let extern_relevance_info ~anon_qvars uvars = Option.map (extern_relevance ~anon_qvars uvars)
 
-let extern_glob_sort uvars (q, l) =
-  Option.map (extern_glob_quality uvars) q,
+let extern_glob_sort ~anon_qvars uvars (q, l) =
+  Option.map (extern_glob_quality ~anon_qvars uvars) q,
   map_glob_sort_gen (List.map (on_fst (extern_glob_sort_name uvars))) l
 
-let extern_instance uvars = function
+let extern_instance ~anon_qvars uvars = function
   | Some (ql,ul) ->
-    let ql = List.map (extern_glob_quality uvars) ql in
+    let ql = List.map (extern_glob_quality ~anon_qvars uvars) ql in
     let ul = List.map (map_glob_sort_gen (extern_glob_sort_name uvars)) ul in
     Some (ql,ul)
   | None -> None
 
-let extern_ref {vars; uvars} ref us =
+let anon_qvars eenv = eenv.flags.ExternFlags.anonymous_qvars
+
+let extern_ref ({vars; uvars; _} as eenv) ref us =
   extern_global (select_stronger_impargs (implicits_of_global ref))
-    (extern_reference vars ref) (extern_instance uvars us)
+    (extern_reference vars ref) (extern_instance ~anon_qvars:(anon_qvars eenv) uvars us)
 
 let extern_var ?loc id = CRef (qualid_of_ident ?loc id,None)
 
@@ -926,7 +934,7 @@ let rec extern depth0 inctx scopes (eenv:extern_env) r =
              (* Otherwise... *)
                extern_applied_ref ~flags inctx
                  (select_stronger_impargs (implicits_of_global ref))
-                 (ref,extern_reference ?loc eenv.vars ref) (extern_instance eenv.uvars us) args)
+                 (ref,extern_reference ?loc eenv.vars ref) (extern_instance ~anon_qvars:(anon_qvars eenv) eenv.uvars us) args)
          | GProj (f,params,c) ->
              extern_applied_proj depth inctx scopes eenv f params c args
          | _ ->
@@ -1030,7 +1038,7 @@ let rec extern depth0 inctx scopes (eenv:extern_env) r =
              in
              CCoFix (CAst.(make ?loc idv.(n)),Array.to_list listdecl))
 
-  | GSort s -> CSort (extern_glob_sort eenv.uvars s)
+  | GSort s -> CSort (extern_glob_sort ~anon_qvars:(anon_qvars eenv) eenv.uvars s)
 
   | GHole e -> CHole (Some e)
 
@@ -1056,7 +1064,7 @@ let rec extern depth0 inctx scopes (eenv:extern_env) r =
 
   | GArray(u,t,def,ty) ->
     CArray(
-      extern_instance eenv.uvars u,
+      extern_instance ~anon_qvars:(anon_qvars eenv) eenv.uvars u,
       Array.map (extern depth inctx scopes eenv) t,
       extern depth inctx scopes eenv def,
       extern_typ depth scopes eenv ty)
@@ -1070,7 +1078,7 @@ and sub_extern depth inctx (subentry,(_,scopes)) = extern depth inctx (subentry,
 
 and factorize_prod depth scopes eenv na r bk t c =
   let implicit_type = is_reserved_type ~flags:eenv.flags na t in
-  let r = extern_relevance_info eenv.uvars r in
+  let r = extern_relevance_info ~anon_qvars:(anon_qvars eenv) eenv.uvars r in
   let aty = extern_typ depth scopes eenv t in
   let eenv = add_vname eenv na in
   let store, get = set_temporary_memory () in
@@ -1107,7 +1115,7 @@ and factorize_prod depth scopes eenv na r bk t c =
 
 and factorize_lambda depth inctx scopes eenv na r bk t c =
   let implicit_type = is_reserved_type ~flags:eenv.flags na t in
-  let r = extern_relevance_info eenv.uvars r in
+  let r = extern_relevance_info ~anon_qvars:(anon_qvars eenv) eenv.uvars r in
   let aty = extern_typ depth scopes eenv t in
   let eenv = add_vname eenv na in
   let store, get = set_temporary_memory () in
@@ -1150,7 +1158,7 @@ and extern_local_binder depth scopes eenv = function
       let (assums,ids,l) =
         extern_local_binder depth scopes (on_eenv_vars (Name.fold_right Id.Set.add na) eenv) l in
       (assums,na::ids,
-       CLocalDef(CAst.make na, extern_relevance_info eenv.uvars r, extern depth false scopes eenv bd,
+       CLocalDef(CAst.make na, extern_relevance_info ~anon_qvars:(anon_qvars eenv) eenv.uvars r, extern depth false scopes eenv bd,
                    Option.map (extern_typ depth scopes eenv) ty) :: l)
 
     | GLocalAssum (na,r,bk,ty) ->
@@ -1167,7 +1175,7 @@ and extern_local_binder depth scopes eenv = function
        | (assums,ids,l) ->
          let ty = if implicit_type then hole else ty in
          (na::assums,na::ids,
-          CLocalAssum([CAst.make na],extern_relevance_info eenv.uvars r,Default bk,ty) :: l))
+          CLocalAssum([CAst.make na],extern_relevance_info ~anon_qvars:(anon_qvars eenv) eenv.uvars r,Default bk,ty) :: l))
 
     | GLocalPattern ((p,_),_,bk,_) ->
       let p = mkCPatOr (List.map (extern_cases_pattern ~flags:eenv.flags eenv.vars) p) in
@@ -1305,7 +1313,7 @@ and extern_applied_proj depth inctx scopes eenv (cst,us) params c extraargs =
   let args = extern_args (extern depth true) eenv args in
   let imps = select_stronger_impargs (implicits_of_global ref) in
   let f = extern_reference eenv.vars ref in
-  let us = extern_instance eenv.uvars us in
+  let us = extern_instance ~anon_qvars:(anon_qvars eenv) eenv.uvars us in
   extern_projection ~flags:eenv.flags inctx (f,us) nparams args imps
 
 let extern inctx scopes eenv c : constr_expr = extern (init_depth eenv.flags) inctx scopes eenv c
@@ -1346,8 +1354,8 @@ let extern_type ?(goal_concl_style=false) ~(flags:PrintingFlags.t) env sigma ?im
   let r = Detyping.detype Detyping.Later ~isgoal:goal_concl_style ~avoid ~flags:flags.detype env sigma t in
   extern_glob_type ?impargs (extern_env ~flags:flags.extern env sigma) r
 
-let extern_sort ~universes ~qualities sigma s =
-  extern_glob_sort (Evd.universe_binders sigma)
+let extern_sort ~universes ~qualities ~anonymous_qvars sigma s =
+  extern_glob_sort ~anon_qvars:anonymous_qvars (Evd.universe_binders sigma)
     (detype_sort ~universes ~qualities sigma s)
 
 let extern_closed_glob ?(goal_concl_style=false) ?(inctx=false) ?scope ~(flags:PrintingFlags.t) env sigma t =

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -787,7 +787,7 @@ let extern_glob_sort_name uvars = function
       | None -> CRawType u
     end
 
-let extern_glob_quality ~anon_qvars uvars = function
+let extern_glob_quality ~anon_univs uvars = function
   | GLocalQVar {v=Anonymous;loc} -> CQAnon loc
   | GLocalQVar {v=Name id; loc} -> CQVar (qualid_of_ident ?loc id)
   | GRawQVar q -> CRawQuality (QVar q)
@@ -796,35 +796,57 @@ let extern_glob_quality ~anon_qvars uvars = function
     | None ->
       (* A quality variable with no name has no parsable form; print it
          as "_" (a fresh quality variable when parsed back) when
-         [anon_qvars]. *)
+         [anon_univs]. *)
       match q with
-      | QVar _ when anon_qvars -> CQAnon None
+      | QVar _ when anon_univs -> CQAnon None
       | _ -> CRawQuality q
     end
 
-let extern_relevance ~anon_qvars uvars = function
+(* A universe level with no name (a fresh level such as [Lib.23], or a
+   bound level whose binder is anonymous) has no parsable form either. *)
+let is_unnamed_level uvars = function
+  | GUniv u -> Option.is_empty (UnivNames.qualid_of_level uvars u)
+  | GSProp | GProp | GSet | GLocalUniv _ | GRawUniv _ -> false
+
+let anonymous_univ = UAnonymous { rigid = UState.UnivFlexible false }
+
+(* In a universe instance each slot is a single level, so an unnamed
+   level prints as "_" (a fresh level when parsed back) when [anon_univs]. *)
+let extern_glob_level ~anon_univs uvars = function
+  | UNamed l when anon_univs && is_unnamed_level uvars l -> anonymous_univ
+  | l -> map_glob_sort_gen (extern_glob_sort_name uvars) l
+
+(* In a sort the universe may be a [max] of several levels, and the
+   grammar has no "_" for a single component of a [max], so when
+   [anon_univs] a universe with any unnamed level prints as "_" as a
+   whole. *)
+let extern_glob_universe ~anon_univs uvars = function
+  | UNamed l when anon_univs && List.exists (fun (l, _) -> is_unnamed_level uvars l) l -> anonymous_univ
+  | u -> map_glob_sort_gen (List.map (on_fst (extern_glob_sort_name uvars))) u
+
+let extern_relevance ~anon_univs uvars = function
   | GRelevant -> CRelevant
   | GIrrelevant -> CIrrelevant
-  | GRelevanceVar q -> CRelevanceVar (extern_glob_quality ~anon_qvars uvars q)
+  | GRelevanceVar q -> CRelevanceVar (extern_glob_quality ~anon_univs uvars q)
 
-let extern_relevance_info ~anon_qvars uvars = Option.map (extern_relevance ~anon_qvars uvars)
+let extern_relevance_info ~anon_univs uvars = Option.map (extern_relevance ~anon_univs uvars)
 
-let extern_glob_sort ~anon_qvars uvars (q, l) =
-  Option.map (extern_glob_quality ~anon_qvars uvars) q,
-  map_glob_sort_gen (List.map (on_fst (extern_glob_sort_name uvars))) l
+let extern_glob_sort ~anon_univs uvars (q, l) =
+  Option.map (extern_glob_quality ~anon_univs uvars) q,
+  extern_glob_universe ~anon_univs uvars l
 
-let extern_instance ~anon_qvars uvars = function
+let extern_instance ~anon_univs uvars = function
   | Some (ql,ul) ->
-    let ql = List.map (extern_glob_quality ~anon_qvars uvars) ql in
-    let ul = List.map (map_glob_sort_gen (extern_glob_sort_name uvars)) ul in
+    let ql = List.map (extern_glob_quality ~anon_univs uvars) ql in
+    let ul = List.map (extern_glob_level ~anon_univs uvars) ul in
     Some (ql,ul)
   | None -> None
 
-let anon_qvars eenv = eenv.flags.ExternFlags.anonymous_qvars
+let anon_univs eenv = eenv.flags.ExternFlags.anonymous_univs
 
 let extern_ref ({vars; uvars; _} as eenv) ref us =
   extern_global (select_stronger_impargs (implicits_of_global ref))
-    (extern_reference vars ref) (extern_instance ~anon_qvars:(anon_qvars eenv) uvars us)
+    (extern_reference vars ref) (extern_instance ~anon_univs:(anon_univs eenv) uvars us)
 
 let extern_var ?loc id = CRef (qualid_of_ident ?loc id,None)
 
@@ -934,7 +956,7 @@ let rec extern depth0 inctx scopes (eenv:extern_env) r =
              (* Otherwise... *)
                extern_applied_ref ~flags inctx
                  (select_stronger_impargs (implicits_of_global ref))
-                 (ref,extern_reference ?loc eenv.vars ref) (extern_instance ~anon_qvars:(anon_qvars eenv) eenv.uvars us) args)
+                 (ref,extern_reference ?loc eenv.vars ref) (extern_instance ~anon_univs:(anon_univs eenv) eenv.uvars us) args)
          | GProj (f,params,c) ->
              extern_applied_proj depth inctx scopes eenv f params c args
          | _ ->
@@ -1038,7 +1060,7 @@ let rec extern depth0 inctx scopes (eenv:extern_env) r =
              in
              CCoFix (CAst.(make ?loc idv.(n)),Array.to_list listdecl))
 
-  | GSort s -> CSort (extern_glob_sort ~anon_qvars:(anon_qvars eenv) eenv.uvars s)
+  | GSort s -> CSort (extern_glob_sort ~anon_univs:(anon_univs eenv) eenv.uvars s)
 
   | GHole e -> CHole (Some e)
 
@@ -1064,7 +1086,7 @@ let rec extern depth0 inctx scopes (eenv:extern_env) r =
 
   | GArray(u,t,def,ty) ->
     CArray(
-      extern_instance ~anon_qvars:(anon_qvars eenv) eenv.uvars u,
+      extern_instance ~anon_univs:(anon_univs eenv) eenv.uvars u,
       Array.map (extern depth inctx scopes eenv) t,
       extern depth inctx scopes eenv def,
       extern_typ depth scopes eenv ty)
@@ -1078,7 +1100,7 @@ and sub_extern depth inctx (subentry,(_,scopes)) = extern depth inctx (subentry,
 
 and factorize_prod depth scopes eenv na r bk t c =
   let implicit_type = is_reserved_type ~flags:eenv.flags na t in
-  let r = extern_relevance_info ~anon_qvars:(anon_qvars eenv) eenv.uvars r in
+  let r = extern_relevance_info ~anon_univs:(anon_univs eenv) eenv.uvars r in
   let aty = extern_typ depth scopes eenv t in
   let eenv = add_vname eenv na in
   let store, get = set_temporary_memory () in
@@ -1115,7 +1137,7 @@ and factorize_prod depth scopes eenv na r bk t c =
 
 and factorize_lambda depth inctx scopes eenv na r bk t c =
   let implicit_type = is_reserved_type ~flags:eenv.flags na t in
-  let r = extern_relevance_info ~anon_qvars:(anon_qvars eenv) eenv.uvars r in
+  let r = extern_relevance_info ~anon_univs:(anon_univs eenv) eenv.uvars r in
   let aty = extern_typ depth scopes eenv t in
   let eenv = add_vname eenv na in
   let store, get = set_temporary_memory () in
@@ -1158,7 +1180,7 @@ and extern_local_binder depth scopes eenv = function
       let (assums,ids,l) =
         extern_local_binder depth scopes (on_eenv_vars (Name.fold_right Id.Set.add na) eenv) l in
       (assums,na::ids,
-       CLocalDef(CAst.make na, extern_relevance_info ~anon_qvars:(anon_qvars eenv) eenv.uvars r, extern depth false scopes eenv bd,
+       CLocalDef(CAst.make na, extern_relevance_info ~anon_univs:(anon_univs eenv) eenv.uvars r, extern depth false scopes eenv bd,
                    Option.map (extern_typ depth scopes eenv) ty) :: l)
 
     | GLocalAssum (na,r,bk,ty) ->
@@ -1175,7 +1197,7 @@ and extern_local_binder depth scopes eenv = function
        | (assums,ids,l) ->
          let ty = if implicit_type then hole else ty in
          (na::assums,na::ids,
-          CLocalAssum([CAst.make na],extern_relevance_info ~anon_qvars:(anon_qvars eenv) eenv.uvars r,Default bk,ty) :: l))
+          CLocalAssum([CAst.make na],extern_relevance_info ~anon_univs:(anon_univs eenv) eenv.uvars r,Default bk,ty) :: l))
 
     | GLocalPattern ((p,_),_,bk,_) ->
       let p = mkCPatOr (List.map (extern_cases_pattern ~flags:eenv.flags eenv.vars) p) in
@@ -1313,7 +1335,7 @@ and extern_applied_proj depth inctx scopes eenv (cst,us) params c extraargs =
   let args = extern_args (extern depth true) eenv args in
   let imps = select_stronger_impargs (implicits_of_global ref) in
   let f = extern_reference eenv.vars ref in
-  let us = extern_instance ~anon_qvars:(anon_qvars eenv) eenv.uvars us in
+  let us = extern_instance ~anon_univs:(anon_univs eenv) eenv.uvars us in
   extern_projection ~flags:eenv.flags inctx (f,us) nparams args imps
 
 let extern inctx scopes eenv c : constr_expr = extern (init_depth eenv.flags) inctx scopes eenv c
@@ -1354,8 +1376,8 @@ let extern_type ?(goal_concl_style=false) ~(flags:PrintingFlags.t) env sigma ?im
   let r = Detyping.detype Detyping.Later ~isgoal:goal_concl_style ~avoid ~flags:flags.detype env sigma t in
   extern_glob_type ?impargs (extern_env ~flags:flags.extern env sigma) r
 
-let extern_sort ~universes ~qualities ~anonymous_qvars sigma s =
-  extern_glob_sort ~anon_qvars:anonymous_qvars (Evd.universe_binders sigma)
+let extern_sort ~universes ~qualities ~anonymous_univs sigma s =
+  extern_glob_sort ~anon_univs:anonymous_univs (Evd.universe_binders sigma)
     (detype_sort ~universes ~qualities sigma s)
 
 let extern_closed_glob ?(goal_concl_style=false) ?(inctx=false) ?scope ~(flags:PrintingFlags.t) env sigma t =

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -53,7 +53,7 @@ val extern_reference : ?loc:Loc.t -> Id.Set.t -> GlobRef.t -> qualid
 val extern_type : ?goal_concl_style:bool ->
   flags:PrintingFlags.t -> env -> Evd.evar_map ->
   ?impargs:Glob_term.binding_kind list -> types -> constr_expr
-val extern_sort : universes:bool -> qualities:bool -> Evd.evar_map -> Sorts.t -> sort_expr
+val extern_sort : universes:bool -> qualities:bool -> anonymous_qvars:bool -> Evd.evar_map -> Sorts.t -> sort_expr
 val extern_rel_context : flags:PrintingFlags.t -> env -> Evd.evar_map ->
   rel_context -> local_binder_expr list
 

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -53,7 +53,7 @@ val extern_reference : ?loc:Loc.t -> Id.Set.t -> GlobRef.t -> qualid
 val extern_type : ?goal_concl_style:bool ->
   flags:PrintingFlags.t -> env -> Evd.evar_map ->
   ?impargs:Glob_term.binding_kind list -> types -> constr_expr
-val extern_sort : universes:bool -> qualities:bool -> anonymous_qvars:bool -> Evd.evar_map -> Sorts.t -> sort_expr
+val extern_sort : universes:bool -> qualities:bool -> anonymous_univs:bool -> Evd.evar_map -> Sorts.t -> sort_expr
 val extern_rel_context : flags:PrintingFlags.t -> env -> Evd.evar_map ->
   rel_context -> local_binder_expr list
 

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -92,6 +92,12 @@ let test_sort_qvar =
     lk_ident >> lk_list lk_field >> lk_kw ";"
   end
 
+let test_sort_anon_qvar =
+  let open Procq.Lookahead in
+  to_entry "test_sort_anon_qvar" begin
+    lk_kw "_" >> lk_kw ";"
+  end
+
 let test_record_nowith =
   let open Procq.Lookahead in
   to_entry "test_record_nowith" begin
@@ -164,6 +170,9 @@ GRAMMAR EXTEND Gram
         }
       | "Type"; "@{"; test_sort_qvar; q = reference; ";"; u = universe; "}" -> {
           Some (CQVar q), u
+        }
+      | "Type"; "@{"; test_sort_anon_qvar; "_"; ";"; u = universe; "}" -> {
+          Some (CQAnon (Some loc)), u
         }
       | "Type"; "@{"; u = universe; "}" -> { None, u } ] ]
   ;

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -92,6 +92,12 @@ let test_sort_qvar =
     lk_ident >> lk_list lk_field >> lk_kw ";"
   end
 
+let test_sort_anon_qvar =
+  let open Procq.Lookahead in
+  to_entry "test_sort_anon_qvar" begin
+    lk_kw "_" >> lk_kw ";"
+  end
+
 let test_record_nowith =
   let open Procq.Lookahead in
   to_entry "test_record_nowith" begin
@@ -162,6 +168,9 @@ GRAMMAR EXTEND Gram
         }
       | "Type"; "@{"; test_sort_qvar; q = reference; ";"; u = universe; "}" -> {
           Some (CQVar q), u
+        }
+      | "Type"; "@{"; test_sort_anon_qvar; "_"; ";"; u = universe; "}" -> {
+          Some (CQAnon (Some loc)), u
         }
       | "Type"; "@{"; u = universe; "}" -> { None, u } ] ]
   ;

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -35,6 +35,13 @@ let { Goptions.get = print_sort_quality } =
     ~value:true
     ()
 
+(* extern *)
+let { Goptions.get = print_anonymous_qvars } =
+  Goptions.declare_bool_option_and_ref
+    ~key:["Printing";"Sort";"Quality";"Variables";"Anonymously"]
+    ~value:false
+    ()
+
 (* detyping *)
 let print_evar_arguments = make_flag ["Printing";"Existential";"Instances"] false
 
@@ -340,6 +347,9 @@ module Extern = struct
     coercions : bool;
     parentheses : bool;
     notations : bool;
+    (* Print sort quality variables that have no name as "_" instead of
+       their raw (unparsable) α-names *)
+    anonymous_qvars : bool;
     raw_literals : bool;
     projections : bool;
     float : bool;
@@ -356,6 +366,7 @@ module Extern = struct
     coercions = !print_coercions;
     parentheses = !print_parentheses;
     notations = not !print_no_symbol;
+    anonymous_qvars = print_anonymous_qvars();
     raw_literals = !print_raw_literal;
     projections = !print_projections;
     float = print_float();
@@ -372,6 +383,7 @@ module Extern = struct
     coercions = true;
     raw_literals = true;
     notations = false;
+    anonymous_qvars = false;
     projections = false;
     factorize_eqns = FactorizeEqns.make_raw flags.factorize_eqns;
   }

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -36,9 +36,9 @@ let { Goptions.get = print_sort_quality } =
     ()
 
 (* extern *)
-let { Goptions.get = print_anonymous_qvars } =
+let { Goptions.get = print_anonymous_univs } =
   Goptions.declare_bool_option_and_ref
-    ~key:["Printing";"Sort";"Quality";"Variables";"Anonymously"]
+    ~key:["Printing";"Unnamed";"Universes";"Anonymously"]
     ~value:false
     ()
 
@@ -349,7 +349,7 @@ module Extern = struct
     notations : bool;
     (* Print sort quality variables that have no name as "_" instead of
        their raw (unparsable) α-names *)
-    anonymous_qvars : bool;
+    anonymous_univs : bool;
     raw_literals : bool;
     projections : bool;
     float : bool;
@@ -366,7 +366,7 @@ module Extern = struct
     coercions = !print_coercions;
     parentheses = !print_parentheses;
     notations = not !print_no_symbol;
-    anonymous_qvars = print_anonymous_qvars();
+    anonymous_univs = print_anonymous_univs();
     raw_literals = !print_raw_literal;
     projections = !print_projections;
     float = print_float();
@@ -383,7 +383,7 @@ module Extern = struct
     coercions = true;
     raw_literals = true;
     notations = false;
-    anonymous_qvars = false;
+    anonymous_univs = false;
     projections = false;
     factorize_eqns = FactorizeEqns.make_raw flags.factorize_eqns;
   }

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -83,6 +83,9 @@ module Extern : sig
     coercions : bool;
     parentheses : bool;
     notations : bool;
+    (** Print sort quality variables that have no name as ["_"] instead
+        of their raw (unparsable) α-names. *)
+    anonymous_qvars : bool;
     (* primitive tokens, like strings *)
     raw_literals : bool;
     (* This governs printing of projections using the dot notation symbols *)

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -85,7 +85,7 @@ module Extern : sig
     notations : bool;
     (** Print sort quality variables that have no name as ["_"] instead
         of their raw (unparsable) α-names. *)
-    anonymous_qvars : bool;
+    anonymous_univs : bool;
     (* primitive tokens, like strings *)
     raw_literals : bool;
     (* This governs printing of projections using the dot notation symbols *)

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -131,11 +131,13 @@ let pr_cases_pattern ?(flags=current_extern()) t =
   pr_cases_pattern_expr ~flags:ppflags
     (extern_cases_pattern ~flags Names.Id.Set.empty t)
 
-let pr_sort ?universes ?qualities sigma s =
+let pr_sort ?universes ?qualities ?anonymous_qvars sigma s =
   let flags = PrintingFlags.Detype.current() in
   let universes = Option.default flags.universes universes in
   let qualities = Option.default flags.qualities qualities in
-  pr_sort_expr (extern_sort ~universes ~qualities sigma s)
+  let anonymous_qvars =
+    Option.default (current_extern()).PrintingFlags.Extern.anonymous_qvars anonymous_qvars in
+  pr_sort_expr (extern_sort ~universes ~qualities ~anonymous_qvars sigma s)
 
 let () = Termops.Internal.set_print_constr
   (fun env sigma t -> pr_leconstr_env ~flags:(current_combined()) env sigma t)

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -150,13 +150,13 @@ let pr_cases_pattern ?(flags=current_extern()) t =
   pr_cases_pattern_expr ~flags:ppflags
     (extern_cases_pattern ~flags Names.Id.Set.empty t)
 
-let pr_sort ?universes ?qualities ?anonymous_qvars sigma s =
+let pr_sort ?universes ?qualities ?anonymous_univs sigma s =
   let flags = PrintingFlags.Detype.current() in
   let universes = Option.default flags.universes universes in
   let qualities = Option.default flags.qualities qualities in
-  let anonymous_qvars =
-    Option.default (current_extern()).PrintingFlags.Extern.anonymous_qvars anonymous_qvars in
-  pr_sort_expr (extern_sort ~universes ~qualities ~anonymous_qvars sigma s)
+  let anonymous_univs =
+    Option.default (current_extern()).PrintingFlags.Extern.anonymous_univs anonymous_univs in
+  pr_sort_expr (extern_sort ~universes ~qualities ~anonymous_univs sigma s)
 
 let () = Termops.Internal.set_print_constr
   (fun env sigma t -> pr_leconstr_env ~flags:(current_combined()) env sigma t)

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -150,11 +150,13 @@ let pr_cases_pattern ?(flags=current_extern()) t =
   pr_cases_pattern_expr ~flags:ppflags
     (extern_cases_pattern ~flags Names.Id.Set.empty t)
 
-let pr_sort ?universes ?qualities sigma s =
+let pr_sort ?universes ?qualities ?anonymous_qvars sigma s =
   let flags = PrintingFlags.Detype.current() in
   let universes = Option.default flags.universes universes in
   let qualities = Option.default flags.qualities qualities in
-  pr_sort_expr (extern_sort ~universes ~qualities sigma s)
+  let anonymous_qvars =
+    Option.default (current_extern()).PrintingFlags.Extern.anonymous_qvars anonymous_qvars in
+  pr_sort_expr (extern_sort ~universes ~qualities ~anonymous_qvars sigma s)
 
 let () = Termops.Internal.set_print_constr
   (fun env sigma t -> pr_leconstr_env ~flags:(current_combined()) env sigma t)

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -138,7 +138,7 @@ val pr_uninstantiated_constr_pattern_env : ?flags:PrintingFlags.Extern.t ->
 
 val pr_cases_pattern : ?flags:PrintingFlags.Extern.t -> cases_pattern -> Pp.t
 
-val pr_sort : ?universes:bool -> ?qualities:bool -> evar_map -> Sorts.t -> Pp.t
+val pr_sort : ?universes:bool -> ?qualities:bool -> ?anonymous_qvars:bool -> evar_map -> Sorts.t -> Pp.t
 
 (** Universe constraints *)
 

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -138,7 +138,7 @@ val pr_uninstantiated_constr_pattern_env : ?flags:PrintingFlags.Extern.t ->
 
 val pr_cases_pattern : ?flags:PrintingFlags.Extern.t -> cases_pattern -> Pp.t
 
-val pr_sort : ?universes:bool -> ?qualities:bool -> ?anonymous_qvars:bool -> evar_map -> Sorts.t -> Pp.t
+val pr_sort : ?universes:bool -> ?qualities:bool -> ?anonymous_univs:bool -> evar_map -> Sorts.t -> Pp.t
 
 (** Universe constraints *)
 

--- a/test-suite/output/PrintingAnonQVars.out
+++ b/test-suite/output/PrintingAnonQVars.out
@@ -1,0 +1,30 @@
+idT@{α2 ; PrintingAnonQVars.22}
+     : forall A : Type@{α2 ; PrintingAnonQVars.22}, A -> A
+(* {α2}; {PrintingAnonQVars.22} | 
+Collapsed sorts:
+ α2 := Type
+Normalized constraints:
+ {PrintingAnonQVars.22} |  *)
+idT@{_ ; PrintingAnonQVars.23}
+     : forall A : Type@{_ ; PrintingAnonQVars.23}, A -> A
+(* {α3}; {PrintingAnonQVars.23} | 
+Collapsed sorts:
+ α3 := Type
+Normalized constraints:
+ {PrintingAnonQVars.23} |  *)
+idT@{s ; u} =
+fun (A : Type@{s ; _}) (a : A) => a
+     : forall A : Type@{s ; _}, A -> A
+
+Arguments idT A%_type_scope a
+idT@{s ; u} : forall A : Type@{s ; _}, A -> A
+
+idT is universe polymorphic
+Arguments idT A%_type_scope a
+idT is transparent
+Expands to: Constant PrintingAnonQVars.idT
+Declared in library PrintingAnonQVars, line 5, characters 11-14
+Type
+     : Type
+idT
+     : forall A : Type, A -> A

--- a/test-suite/output/PrintingAnonQVars.out
+++ b/test-suite/output/PrintingAnonQVars.out
@@ -5,13 +5,27 @@ Collapsed sorts:
  α2 := Type
 Normalized constraints:
  {PrintingAnonQVars.22} |  *)
-idT@{_ ; PrintingAnonQVars.23}
-     : forall A : Type@{_ ; PrintingAnonQVars.23}, A -> A
+idT@{_ ; _}
+     : forall A : Type@{_ ; _}, A -> A
 (* {α3}; {PrintingAnonQVars.23} | 
 Collapsed sorts:
  α3 := Type
 Normalized constraints:
  {PrintingAnonQVars.23} |  *)
+Type@{u}
+     : Type@{u+1}
+foo
+     : Type@{foo.u0+1}
+(Type@{u} * Type@{_})%type
+     : Type@{_}
+(* {PrintingAnonQVars.28 PrintingAnonQVars.27 PrintingAnonQVars.26} |
+     u < PrintingAnonQVars.26
+     PrintingAnonQVars.28 < PrintingAnonQVars.27
+Minimized universes:
+ PrintingAnonQVars.27 := PrintingAnonQVars.28+1
+ PrintingAnonQVars.26 := u+1
+Normalized constraints:
+ {PrintingAnonQVars.28} |  *)
 idT@{s ; u} =
 fun (A : Type@{s ; _}) (a : A) => a
      : forall A : Type@{s ; _}, A -> A
@@ -23,7 +37,7 @@ idT is universe polymorphic
 Arguments idT A%_type_scope a
 idT is transparent
 Expands to: Constant PrintingAnonQVars.idT
-Declared in library PrintingAnonQVars, line 5, characters 11-14
+Declared in library PrintingAnonQVars, line 6, characters 11-14
 Type
      : Type
 idT

--- a/test-suite/output/PrintingAnonQVars.v
+++ b/test-suite/output/PrintingAnonQVars.v
@@ -1,0 +1,27 @@
+(* Printing Sort Quality Variables Anonymously: sort quality variables
+   that have no name print as "_" (which parses back, denoting a fresh
+   quality variable) instead of their raw α-names (which do not). *)
+Set Universe Polymorphism.
+Definition idT@{s;u} (A : Type@{s;u}) (a : A) := a.
+
+(* Under Printing Universes, the fresh quality variable of the
+   instance (and of the displayed sort) prints as a raw α-name by
+   default... *)
+Set Printing Universes.
+Check idT.
+(* ...and as _ under the flag. *)
+Set Printing Sort Quality Variables Anonymously.
+Check idT.
+Unset Printing Universes.
+
+(* Named quality variables are unaffected: the binder name is kept. *)
+Print idT.
+About idT.
+
+Unset Printing Sort Quality Variables Anonymously.
+
+(* The anonymous form parses back: "_" is accepted as the sort quality
+   of a sort annotation (it was already accepted in universe
+   instances), denoting a fresh quality variable. *)
+Check Type@{_ ; Set}.
+Check idT@{_ ; Set}.

--- a/test-suite/output/PrintingAnonQVars.v
+++ b/test-suite/output/PrintingAnonQVars.v
@@ -1,24 +1,36 @@
-(* Printing Sort Quality Variables Anonymously: sort quality variables
-   that have no name print as "_" (which parses back, denoting a fresh
-   quality variable) instead of their raw α-names (which do not). *)
+(* Printing Unnamed Universes Anonymously: sort quality variables and
+   universe levels that have no name print as "_" (which parses back,
+   denoting a fresh variable) instead of their raw forms (which do
+   not). *)
 Set Universe Polymorphism.
 Definition idT@{s;u} (A : Type@{s;u}) (a : A) := a.
 
-(* Under Printing Universes, the fresh quality variable of the
-   instance (and of the displayed sort) prints as a raw α-name by
-   default... *)
+(* Under Printing Universes, the fresh quality variable and the fresh
+   level of the instance (and of the displayed sort) print in raw form
+   by default... *)
 Set Printing Universes.
 Check idT.
 (* ...and as _ under the flag. *)
-Set Printing Sort Quality Variables Anonymously.
+Set Printing Unnamed Universes Anonymously.
 Check idT.
+(* Named levels are unaffected, whether declared or derived from a
+   monomorphic definition. *)
+Unset Universe Polymorphism.
+Universe u.
+Check Type@{u}.
+Definition foo := Type.
+Check foo.
+(* A max mixing named and unnamed levels has no "_" for one component,
+   so the whole sort prints as _. *)
+Check (Type@{u} * Type)%type.
+Set Universe Polymorphism.
 Unset Printing Universes.
 
 (* Named quality variables are unaffected: the binder name is kept. *)
 Print idT.
 About idT.
 
-Unset Printing Sort Quality Variables Anonymously.
+Unset Printing Unnamed Universes Anonymously.
 
 (* The anonymous form parses back: "_" is accepted as the sort quality
    of a sort annotation (it was already accepted in universe


### PR DESCRIPTION
Written by Claude (Anthropic AI) at the request of and under the supervision of @JasonGross.

## What

Add `Set Printing Unnamed Universes Anonymously`, off by default. It prints unnamed sort quality variables and unnamed universe levels as `_` instead of their raw forms (`α` followed by a number, or a library name followed by a number such as `PrintingAnonQVars.23`). The raw forms cannot be parsed back; `_` is a fresh variable, enabling round-tripping while forgetting which occurrences shared a variable. Named variables such as `s` and `u` in `@{s;u}`, or `foo.u0` from a monomorphic definition, are unchanged.

```coq
Set Universe Polymorphism.
Definition idT@{s;u} (A : Type@{s;u}) (a : A) := a.
Set Printing Universes.
Check idT.
(* idT@{α2 ; PrintingAnonQVars.22}
     : forall A : Type@{α2 ; PrintingAnonQVars.22}, A -> A *)
Set Printing Unnamed Universes Anonymously.
Check idT.
(* idT@{_ ; _}
     : forall A : Type@{_ ; _}, A -> A *)
Print idT. (* binder names s, u are kept *)
```

The grammar has no `_` for a single component of a `max`, so a sort whose universe involves an unnamed level prints as `Type@{_}` as a whole: `Check (Type@{u} * Type)%type` gives `: Type@{_}`.

The universe-context comment under `Printing Universes` (`Collapsed sorts: α3 := Type`, …) keeps raw names because it defines the variables.

## Grammar and implementation

`_` was accepted in instances such as `idT@{_ ; Set}`, but `Type@{_ ; Set}` was a syntax error. Add the missing `sort` production (`"Type" "@{" "_" ";" universe "}"`) and regenerate docgram's `fullGrammar`/`orderedGrammar`/`sorts.rst` production. This works independently of the flag.

`PrintingFlags.Extern.t` gains `anonymous_univs`, forced off by `make_raw`. When enabled, `GQuality (QVar _)` in `Constrextern.extern_glob_quality` emits `CQAnon` instead of `CRawQuality`, and a `GUniv` level with no name (`UnivNames.qualid_of_level` returns `None`) becomes `UAnonymous` in `extern_glob_level` (instances) and `extern_glob_universe` (sorts, whole universe). `GLocalQVar`, `GLocalUniv`, and the funind `GRawQVar`/`GRawUniv` hacks are unchanged. Thread the flag through `extern_glob_sort`, `extern_instance`, and `extern_relevance`; `Constrextern.extern_sort` and `Printer.pr_sort` gain an optional argument.

The second commit extends the flag from quality variables to levels and renames it, following the review discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5.1)

Wordsmithed by Codex.
