### PR TITLE
kernel: store the conversion cache as flat integer arrays

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -78,6 +78,9 @@ type evar_repack = Evar.t * constr list -> constr
 type fconstr = {
   mutable mark : red_state;
   mutable term: fterm;
+  (* Stable cell id for the conversion cache; 0 = unassigned. Preserved by
+     in-place [update], reset by copies. *)
+  mutable fid : int;
 }
 
 and fterm =
@@ -116,6 +119,12 @@ and finvert = fconstr array
 let get_invert fiv = fiv
 
 let fterm_of v = v.term
+
+let fid_counter = ref 0
+let get_fid v =
+  if v.fid != 0 then v.fid
+  else begin incr fid_counter; v.fid <- !fid_counter; !fid_counter end
+
 let set_ntrl v = v.mark <- Ntrl
 
 (* Could issue a warning if no is still Red, pointing out that we loose
@@ -240,17 +249,17 @@ let usubs_shft (n,(e,u)) = subs_shft (n, e), u
 let rec lft_fconstr n ft =
   match ft.term with
     | (FInd _|FConstruct (_,[||])|FFlex(ConstKey _|VarKey _)|FInt _|FFloat _|FString _|FIrrelevant) -> ft
-    | FRel i -> {mark=ft.mark;term=FRel(i+n)}
-    | FLambda(k,tys,f,e) -> {mark=Cstr; term=FLambda(k,tys,f,usubs_shft(n,e))}
+    | FRel i -> {fid = 0; mark=ft.mark;term=FRel(i+n)}
+    | FLambda(k,tys,f,e) -> {fid = 0; mark=Cstr; term=FLambda(k,tys,f,usubs_shft(n,e))}
     | FFix(fx,e) ->
-      {mark=Cstr; term=FFix(fx,usubs_shft(n,e))}
+      {fid = 0; mark=Cstr; term=FFix(fx,usubs_shft(n,e))}
     | FCoFix(cfx,e) ->
-      {mark=Cstr; term=FCoFix(cfx,usubs_shft(n,e))}
+      {fid = 0; mark =Cstr; term=FCoFix(cfx,usubs_shft(n,e))}
     | FLIFT(k,m) -> lft_fconstr (n+k) m
-    | FConstruct (c,args) -> {mark=Cstr; term=FConstruct(c,Array.Fun1.map lft_fconstr n args)}
+    | FConstruct (c,args) -> {fid = 0; mark =Cstr; term=FConstruct(c,Array.Fun1.map lft_fconstr n args)}
     | FLOCKED -> assert false
     | FFlex (RelKey _) | FAtom _ | FApp _ | FProj _ | FCaseT _ | FCaseInvert _ | FProd _
-    | FLetIn _ | FEvar _ | FCLOS _ | FArray _ -> {mark=ft.mark; term=FLIFT(n,ft)}
+    | FLetIn _ | FEvar _ | FCLOS _ | FArray _ -> {fid = 0; mark =ft.mark; term=FLIFT(n,ft)}
 let lift_fconstr k f =
   if Int.equal k 0 then f else lft_fconstr k f
 
@@ -259,9 +268,9 @@ let clos_rel e i =
     | Inl (n, Regular mt) -> Regular (lift_fconstr n mt)
     | Inl (_, HigherOrder (0, mt)) -> Regular mt
     | Inl (_, HigherOrder (nargs, mt)) -> HigherOrder (nargs, mt)
-    | Inr (k, None) -> Regular {mark=Ntrl; term= FRel k}
+    | Inr (k, None) -> Regular {fid = 0; mark =Ntrl; term= FRel k}
     | Inr (k, Some p) ->
-      Regular (lift_fconstr (k-p) {mark=Red;term=FFlex(RelKey p)})
+      Regular (lift_fconstr (k-p) {fid = 0; mark =Red;term=FFlex(RelKey p)})
 
 (* since the head may be reducible, we might introduce lifts of 0 *)
 let compact_stack head stk =
@@ -324,7 +333,7 @@ let destFLambda clos_fun t =
   | FLambda(_,[(na,ty)],b,e) ->
     (usubst_binder e na,clos_fun e ty,clos_fun (usubs_lift e) b)
   | FLambda(n,(na,ty)::tys,b,e) ->
-    (usubst_binder e na,clos_fun e ty,{mark=t.mark;term=FLambda(n-1,tys,b,usubs_lift e)})
+    (usubst_binder e na,clos_fun e ty,{fid = 0; mark =t.mark;term=FLambda(n-1,tys,b,usubs_lift e)})
   | _ -> assert false
 
 (* Optimization: do not enclose variables in a closure.
@@ -336,26 +345,26 @@ let mk_clos (e:usubs) t =
       | Regular v -> v
       | HigherOrder _ -> CErrors.anomaly Pp.(str "Uncaught pattern variable")
       end
-    | Var x -> {mark = Red; term = FFlex (VarKey x) }
-    | Const c -> {mark = Red; term = FFlex (ConstKey (usubst_punivs e c)) }
+    | Var x -> {fid = 0; mark = Red; term = FFlex (VarKey x) }
+    | Const c -> {fid = 0; mark = Red; term = FFlex (ConstKey (usubst_punivs e c)) }
     | Sort s ->
       let s = usubst_sort e s in
-      {mark = Ntrl; term = FAtom (mkSort s) }
-    | Meta _ -> {mark = Ntrl; term = FAtom t }
-    | Ind kn -> {mark = Ntrl; term = FInd (usubst_punivs e kn) }
-    | Construct kn -> {mark = Cstr; term = FConstruct (usubst_punivs e kn,[||]) }
-    | Int i -> {mark = Cstr; term = FInt i}
-    | Float f -> {mark = Cstr; term = FFloat f}
-    | String s -> {mark = Cstr; term = FString s}
+      {fid = 0; mark = Ntrl; term = FAtom (mkSort s) }
+    | Meta _ -> {fid = 0; mark = Ntrl; term = FAtom t }
+    | Ind kn -> {fid = 0; mark = Ntrl; term = FInd (usubst_punivs e kn) }
+    | Construct kn -> {fid = 0; mark = Cstr; term = FConstruct (usubst_punivs e kn,[||]) }
+    | Int i -> {fid = 0; mark = Cstr; term = FInt i}
+    | Float f -> {fid = 0; mark = Cstr; term = FFloat f}
+    | String s -> {fid = 0; mark = Cstr; term = FString s}
     | (CoFix _|Lambda _|Fix _|Prod _|Evar _|App _|Case _|Cast _|LetIn _|Proj _|Array _) ->
-        {mark = Red; term = FCLOS(t,e)}
+        {fid = 0; mark = Red; term = FCLOS(t,e)}
   (* Invariant, pattern variables under apps are deferred to knht by being wrapped in FCLOS *)
 
 let injectu c u = mk_clos (subs_id 0, u) c
 
 let inject c = injectu c UVars.Instance.empty
 
-let mk_irrelevant = { mark = Cstr; term = FIrrelevant }
+let mk_irrelevant = { fid = 0; mark = Cstr; term = FIrrelevant }
 
 let is_irrelevant info r = match info.i_cache.i_mode with
 | Reduction -> false
@@ -672,47 +681,47 @@ let rec resubst subs v =
     | FRel i ->
       let args = Array.Fun1.map resubst subs ve in
       begin match clos_rel subs i with
-      | Regular t -> { v with term = FApp (t, args) }
+      | Regular t -> { v with fid = 0; term = FApp (t, args) }
       | HigherOrder (nargs, term) ->
         let subs', args = Array.chop nargs args in
         let subs' = Array.fold_left (fun s v -> subs_cons (Regular v) s) (subs_id 0) subs' in
         let head = resubst subs' term in
-        { v with term = FApp (head, args) }
+        { v with fid = 0; term = FApp (head, args) }
       end
     | _ ->
-      { v with term =
+      { v with fid = 0; term =
           FApp (resubst subs f,
                 Array.Fun1.map resubst subs ve) }
     end
   | FCaseT (ci, u, pms, p, c, ve, env) ->
     let env = comp_subs subs env in
-    { v with term = FCaseT (ci, u, pms, p, resubst subs c, ve, env) }
+    { v with fid = 0; term = FCaseT (ci, u, pms, p, resubst subs c, ve, env) }
   | FCaseInvert (ci, u, pms, p, indices, c, ve, env) ->
     let env = comp_subs subs env in
     let indices = Array.Fun1.map resubst subs indices in
-    { v with term = FCaseInvert (ci, u, pms, p, indices, resubst subs c, ve, env) }
+    { v with fid = 0; term = FCaseInvert (ci, u, pms, p, indices, resubst subs c, ve, env) }
   | FFix (fx, e) ->
     let e = comp_subs subs e in
-    { v with term = FFix (fx, e) }
+    { v with fid = 0; term = FFix (fx, e) }
   | FCoFix (cfx, e) ->
     let e = comp_subs subs e in
-    { v with term = FCoFix (cfx, e) }
+    { v with fid = 0; term = FCoFix (cfx, e) }
   | FProj (p, r, c) ->
-    { v with term =
+    { v with fid = 0; term =
       FProj (p, r, resubst subs c) }
   | FLambda (len, tys, f, e) ->
     let e = comp_subs subs e in
-    { v with term = FLambda (len, tys, f, e) }
+    { v with fid = 0; term = FLambda (len, tys, f, e) }
   | FProd (n, t, c, e) ->
     let e = comp_subs subs e in
-    { v with term = FProd (n, resubst subs t, c, e) }
+    { v with fid = 0; term = FProd (n, resubst subs t, c, e) }
   | FLetIn (n, b, t, f, e) ->
     let e = comp_subs subs e in
-    { v with term =
+    { v with fid = 0; term =
       FLetIn (n, resubst subs b, resubst subs t, f, e) }
   | FEvar (ev, args, env, repack) ->
     let env = comp_subs subs env in
-    { v with term =
+    { v with fid = 0; term =
       FEvar (ev, args, env, repack) }
   | FLIFT (k, a) ->
     resubst (subs_popn k subs) a
@@ -720,12 +729,12 @@ let rec resubst subs v =
   | FArray (u, t, ty) ->
     let t = Parray.map (resubst subs) t in
     let ty = resubst subs ty in
-    { v with term =
+    { v with fid = 0; term =
       FArray (u, t, ty) }
 
   | FCLOS (t,env) ->
     let env = comp_subs subs env in
-    { v with term =
+    { v with fid = 0; term =
       FCLOS (t, env) }
 
   | FFlex (RelKey _) -> v (* outside the substitution *)
@@ -753,10 +762,10 @@ let mkFApp h args =
   else match[@warning "-4"] h.term with
     | FConstruct (c, args0) ->
       let args = if CArray.is_empty args0 then args else Array.append args0 args in
-      {mark=Cstr; term=FConstruct(c, args)}
+      {fid = 0; mark =Cstr; term=FConstruct(c, args)}
     | _ ->
       (* don't bother collapsing FApp nodes *)
-      {mark=neutr h.mark; term=FApp(h,args)}
+      {fid = 0; mark =neutr h.mark; term=FApp(h,args)}
 
 let rec zip m stk =
   match stk with
@@ -765,10 +774,10 @@ let rec zip m stk =
     | ZcaseT(ci, u, pms, p, br, e)::s ->
         let t = FCaseT(ci, u, pms, p, m, br, e) in
         let mark = (neutr m.mark) in
-        zip {mark; term=t} s
+        zip {fid = 0; mark; term=t} s
     | Zproj (p,r) :: s ->
         let mark = (neutr m.mark) in
-        zip {mark; term=FProj(Projection.make p true,r,m)} s
+        zip {fid = 0; mark; term=FProj(Projection.make p true,r,m)} s
     | Zfix(fx,par)::s ->
         zip fx (par @ append_stack [|m|] s)
     | Zshift(n)::s ->
@@ -779,9 +788,9 @@ let rec zip m stk =
         zip rf s
     | Zprimitive(_op,c,rargs,kargs)::s ->
       let args = List.rev_append rargs (m::List.map snd kargs) in
-      let f = {mark = Red; term = FFlex (ConstKey c)} in
+      let f = {fid = 0; mark = Red; term = FFlex (ConstKey c)} in
       (* don't need to mkFApp because not a constructor *)
-      zip {mark=(neutr m.mark); term = FApp (f, Array.of_list args)} s
+      zip {fid = 0; mark =(neutr m.mark); term = FApp (f, Array.of_list args)} s
 
 let fapp_stack (m,stk) = zip m stk
 
@@ -887,7 +896,7 @@ let rec get_args n tys f e = function
           let etys = List.skipn na tys in
           get_args (n-na) etys f (usubs_consn l 0 na e) s
     | ((ZcaseT _ | Zproj _ | Zfix _ | Zprimitive _) :: _ | []) as stk ->
-      (Inr {mark=Cstr; term=FLambda(n,tys,f,e)}, stk)
+      (Inr {fid = 0; mark =Cstr; term=FLambda(n,tys,f,e)}, stk)
 
 (* Eta expansion: add a reference to implicit surrounding lambda at end of stack *)
 let rec eta_expand_stack info na = function
@@ -897,7 +906,7 @@ let rec eta_expand_stack info na = function
   | [] ->
     let arg =
       if is_irrelevant info na.binder_relevance then mk_irrelevant
-      else {mark = Ntrl; term = FRel 1}
+      else {fid = 0; mark = Ntrl; term = FRel 1}
     in
     [Zshift 1; Zapp [|arg|]]
 
@@ -928,13 +937,13 @@ let get_native_args op c stk =
            Zapp (Array.of_list eargs) :: s')
         | rnargs, kargs, _ ->
           (* head of h is not constructor -> no need to mkFApp *)
-          strip_rec rnargs {mark = h.mark;term=FApp(h, args)} depth kargs s'
+          strip_rec rnargs {fid = 0; mark = h.mark;term=FApp(h, args)} depth kargs s'
       end
     | Zupdate(m) :: s ->
       let () = update m h.mark h.term in
       strip_rec rnargs m depth  kargs s
     | (Zprimitive _ | ZcaseT _ | Zproj _ | Zfix _) :: _ | [] -> assert false
-  in strip_rec [] {mark = Red; term = FFlex(ConstKey c)} 0 kargs stk
+  in strip_rec [] {fid = 0; mark = Red; term = FFlex(ConstKey c)} 0 kargs stk
 
 let get_native_args1 op c stk =
   match get_native_args op c stk with
@@ -1048,7 +1057,7 @@ let eta_expand_ind_stack env (ind,u) args m' =
       then raise Not_found (* partially applied constructor (missing non-param arguments) *)
     in
     let hstack = Array.map (fun (p,r) ->
-        { mark = Red; (* right can't be a constructor though *)
+        { fid = 0; mark = Red; (* right can't be a constructor though *)
           term = FProj (Projection.make p true, UVars.subst_instance_relevance u r, right) })
         projs
     in
@@ -1068,12 +1077,12 @@ let contract_fix_vect fix =
     match [@ocaml.warning "-4"] fix with
       | FFix (((reci,i),(_,_,bds as rdcl)),env) ->
           (bds.(i),
-           (fun j -> { mark = Cstr;
+           (fun j -> { fid = 0; mark = Cstr;
                        term = FFix (((reci,j),rdcl),env) }),
            env, Array.length bds)
       | FCoFix ((i,(_,_,bds as rdcl)),env) ->
           (bds.(i),
-           (fun j -> { mark = Cstr;
+           (fun j -> { fid = 0; mark = Cstr;
                        term = FCoFix ((j,rdcl),env) }),
            env, Array.length bds)
       | _ -> assert false
@@ -1104,7 +1113,7 @@ module FNativeEntries =
 
     let mk_construct c =
       (* All constructors used in primitive functions are relevant *)
-      { mark = Cstr; term = FConstruct (UVars.in_punivs c, [||]) }
+      { fid = 0; mark = Cstr; term = FConstruct (UVars.in_punivs c, [||]) }
 
     let get = Array.get
 
@@ -1128,7 +1137,7 @@ module FNativeEntries =
       | FArray (_u,t,_ty) -> t
       | _ -> assert false
 
-    let dummy = {mark = Ntrl; term = FRel 0}
+    let dummy = {fid = 0; mark = Ntrl; term = FRel 0}
 
     let current_retro = ref Retroknowledge.empty
     let defined_int = ref false
@@ -1138,7 +1147,7 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_int63 with
       | Some c ->
         defined_int := true;
-        fint := { mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
+        fint := { fid = 0; mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
       | None -> defined_int := false
 
     let defined_float = ref false
@@ -1148,7 +1157,7 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_float64 with
       | Some c ->
         defined_float := true;
-        ffloat := { mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
+        ffloat := { fid = 0; mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
       | None -> defined_float := false
 
     let defined_string = ref false
@@ -1158,7 +1167,7 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_string with
       | Some c ->
         defined_string := true;
-        fstring := { mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
+        fstring := { fid = 0; mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
       | None -> defined_string := false
 
     let defined_bool = ref false
@@ -1209,7 +1218,7 @@ module FNativeEntries =
         fLt := mk_construct cLt;
         fGt := mk_construct cGt;
         let (icmp, _) = cEq in
-        fcmp := { mark = Ntrl; term = FInd (UVars.in_punivs icmp) }
+        fcmp := { fid = 0; mark = Ntrl; term = FInd (UVars.in_punivs icmp) }
       | None -> defined_cmp := false
 
     let defined_f_cmp = ref false
@@ -1318,15 +1327,15 @@ module FNativeEntries =
 
     let mkInt env i =
       check_int env;
-      { mark = Cstr; term = FInt i }
+      { fid = 0; mark = Cstr; term = FInt i }
 
     let mkFloat env f =
       check_float env;
-      { mark = Cstr; term = FFloat f }
+      { fid = 0; mark = Cstr; term = FFloat f }
 
     let mkString env s =
       check_string env;
-      { mark = Cstr; term = FString s }
+      { fid = 0; mark = Cstr; term = FString s }
 
     let mkBool env b =
       check_bool env;
@@ -1411,7 +1420,7 @@ module FNativeEntries =
 
     let mkArray env u t ty =
       check_array env;
-      { mark = Cstr; term = FArray (u,t,ty)}
+      { fid = 0; mark = Cstr; term = FArray (u,t,ty)}
 
   end
 
@@ -1508,30 +1517,30 @@ and knht info e t stk =
         (mk_irrelevant, skip_irrelevant_stack info stk)
       else
         let term = FCaseInvert (ci, u, pms, p, (Array.map (mk_clos e) indices), mk_clos e t, br, e) in
-        { mark = Red; term }, stk
+        { fid = 0; mark = Red; term }, stk
     | Fix (((_, n), (lna, _, _)) as fx) ->
       if is_irrelevant info (usubst_relevance e (lna.(n)).binder_relevance) then
         (mk_irrelevant, skip_irrelevant_stack info stk)
       else
-        knh info { mark = Cstr; term = FFix (fx, e) } stk
+        knh info { fid = 0; mark = Cstr; term = FFix (fx, e) } stk
     | Cast(a,_,_) -> knht info e a stk
     | Proj (p, r, c) ->
       let r = usubst_relevance e r in
       if is_irrelevant info r then
         (mk_irrelevant, skip_irrelevant_stack info stk)
       else begin match unfold_projection info p r with
-      | None -> ({ mark = Red; term = FProj (p, r, mk_clos e c) }, stk)
+      | None -> ({ fid = 0; mark = Red; term = FProj (p, r, mk_clos e c) }, stk)
       | Some s -> knht info e c (s :: stk)
       end
     | Construct _ -> knh info (mk_clos e t) stk
     | (Ind _|Const _|Var _|Meta _ | Sort _ | Int _|Float _|String _) -> (mk_clos e t, stk)
     | CoFix cfx ->
-      { mark = Cstr; term = FCoFix (cfx,e) }, stk
-    | Lambda _ -> { mark = Cstr ; term = mk_lambda e t }, stk
+      { fid = 0; mark = Cstr; term = FCoFix (cfx,e) }, stk
+    | Lambda _ -> { fid = 0; mark = Cstr ; term = mk_lambda e t }, stk
     | Prod (n, t, c) ->
-      { mark = Ntrl; term = FProd (n, mk_clos e t, c, e) }, stk
+      { fid = 0; mark = Ntrl; term = FProd (n, mk_clos e t, c, e) }, stk
     | LetIn (n,b,t,c) ->
-      { mark = Red; term = FLetIn (n, mk_clos e b, mk_clos e t, c, e) }, stk
+      { fid = 0; mark = Red; term = FLetIn (n, mk_clos e b, mk_clos e t, c, e) }, stk
     | Evar ev ->
       begin match info.i_cache.i_sigma.evar_expand ev with
       | EvarDefined c -> knht info e c stk
@@ -1541,7 +1550,7 @@ and knht info e t stk =
           (mk_irrelevant, skip_irrelevant_stack info stk)
         else
           let repack = info.i_cache.i_sigma.evar_repack in
-          { mark = Ntrl; term = FEvar (evk, args, e, repack) }, stk
+          { fid = 0; mark = Ntrl; term = FEvar (evk, args, e, repack) }, stk
       end
     | Array(u,t,def,ty) ->
       let u = usubst_instance e u in
@@ -1549,7 +1558,7 @@ and knht info e t stk =
       let ty = mk_clos e ty in
       let t = Parray.init (Uint63.of_int len) (fun i -> mk_clos e t.(i)) (mk_clos e def) in
       let term = FArray (u,t,ty) in
-      knh info { mark = Cstr; term } stk
+      knh info { fid = 0; mark = Cstr; term } stk
 
 (************************************************************************)
 
@@ -1757,7 +1766,7 @@ and match_elim : 'a. ('a, 'a depth) reduction -> _ -> _ -> pat_state:'a depth ->
   | ZcaseT (ci, u, pms, ((pctx, p), _ as pred), brs, e) :: s ->
       let t = FCaseT (ci, u, pms, pred, head, brs, e) in
       let mark = neutr head.mark in
-      let head = {mark; term=t} in
+      let head = {fid = 0; mark; term=t} in
       let prets, pbrss, elims, states = extract_or_kill4 (function [@ocaml.warning "-4"]
       | PECase (pind, pret, pbrs) :: es, subst ->
         if not @@ QInd.equal (info_env info) pind ci.ci_ind then None else
@@ -1797,7 +1806,7 @@ and match_elim : 'a. ('a, 'a depth) reduction -> _ -> _ -> pat_state:'a depth ->
       match_main red info tab ~pat_state states loc
   | Zproj (proj', r) :: s ->
       let mark = (neutr head.mark) in
-      let head = {mark; term=FProj(Projection.make proj' true, r, head)} in
+      let head = {fid = 0; mark; term=FProj(Projection.make proj' true, r, head)} in
       let elims, states = extract_or_kill2 (function [@ocaml.warning "-4"]
       | PEProj proj :: es, subst ->
         if not @@ QProjection.Repr.equal (info_env info) proj proj' then None else
@@ -1967,7 +1976,7 @@ let match_symbol red info tab ~pat_state fl (u, b, r) stk =
       | None -> Dead, Ignore
     ) (Array.of_list r)
   in
-  let m = { mark = Red; term = FFlex fl } in
+  let m = { fid = 0; mark = Red; term = FFlex fl } in
   let loc = LocStart { elims; depth=0; head = m; stack = stk; next = Return (unfold_fix, m, stk) } in
   match_main red info tab ~pat_state states loc
 
@@ -2159,7 +2168,7 @@ and klt info tab e t = match kind t with
   | Inl (n, Regular mt) -> kl info tab @@ lift_fconstr n mt
   | Inl (_, HigherOrder (nargs, term)) -> assert (Int.equal nargs 0); kl info tab term
   | Inr (k, None) -> if Int.equal k i then t else mkRel k
-  | Inr (k, Some p) -> kl info tab @@ lift_fconstr (k-p) {mark=Red;term=FFlex(RelKey p)}
+  | Inr (k, Some p) -> kl info tab @@ lift_fconstr (k-p) {fid = 0; mark =Red;term=FFlex(RelKey p)}
   end
 | App (hd, args) ->
   let is_stuck = match kind hd with

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -112,6 +112,11 @@ val mk_clos_vect : usubs -> constr array -> fconstr array
 val zip : fconstr -> stack -> fconstr
 
 val fterm_of : fconstr -> fterm
+
+(** Stable id of a cell, lazily assigned; survives in-place reduction
+    updates. Used by the conversion cache. *)
+val get_fid : fconstr -> int
+
 val term_of_fconstr : fconstr -> constr
 val term_of_process : fconstr -> stack -> constr
 val destFLambda :

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -195,16 +195,83 @@ let convert_inductives_gen cmp_instances cmp_cumul cv_pb (mind,ind) nargs u1 u2 
       cmp_cumul cv_pb variances u1 u2 s
 
 (* Conversion result cache. Within one conversion session the same pair of
-   cells is typically compared many times over, because beta-substitution
+   cells is typically compared many times over, because β-substitution
    shares payload cells across all the occurrences of a variable. Entries
-   record the outcome (success or failure) for a pair of cells, identified
-   by their stable ids, at a given lift pair and conversion problem. Only
-   sound for checked conversion, where results are deterministic and no
-   universe constraints are accumulated. *)
+   record the outcome (success or failure) for a pair of cells — identified
+   by their stable ids, modulo FLIFT wrappers — at a given lift pair and
+   conversion problem. Lifts are interned to small ids so that keys and
+   payloads fit in machine integers, stored in a flat open-addressing
+   table. Only sound for checked conversion, where results are
+   deterministic and no universe constraints are accumulated. *)
+
+module LiftTbl = Hashtbl.Make(struct
+  type t = lift
+  let equal = eq_lift
+  let hash = hash_lift
+end)
+
 type conv_cache = {
-  cc_tbl : (int * int * int, (lift * lift * bool) list ref) Hashtbl.t;
-  mutable cc_size : int;
+  (* cc_key.(i) = (fid1 lsl 31) lor fid2; 0 = empty slot *)
+  mutable cc_key : int array;
+  (* cc_meta.(i) = (lid1 lsl 18) lor (lid2 lsl 3) lor (pb lsl 1) lor result *)
+  mutable cc_meta : int array;
+  mutable cc_cnt : int;
+  cc_lifts : int LiftTbl.t;
+  mutable cc_nlifts : int;
 }
+
+let cc_intern cache l =
+  match LiftTbl.find_opt cache.cc_lifts l with
+  | Some id -> id
+  | None ->
+    let id = cache.cc_nlifts in
+    if id >= 1 lsl 15 then -1
+    else begin
+      cache.cc_nlifts <- id + 1;
+      LiftTbl.add cache.cc_lifts l id;
+      id
+    end
+
+let cc_mix pk m =
+  let h = pk + m * 0x9E3779B97F4A7C1 in
+  let h = h lxor (h lsr 29) in
+  let h = h * 0x3F58476D1CE4E5B9 in
+  h lxor (h lsr 32)
+
+(* -1 = absent, 0 = cached failure, 1 = cached success.
+   [meta0] must have the result bit clear. *)
+let cc_find cache pk meta0 =
+  let mask = Array.length cache.cc_key - 1 in
+  let rec go i =
+    let k = Array.unsafe_get cache.cc_key i in
+    if k == 0 then -1
+    else if k == pk
+         && (Array.unsafe_get cache.cc_meta i) lor 1 == meta0 lor 1 then
+      (Array.unsafe_get cache.cc_meta i) land 1
+    else go ((i + 1) land mask)
+  in
+  go ((cc_mix pk meta0) land mask)
+
+let cc_insert_raw key meta pk m =
+  let mask = Array.length key - 1 in
+  let rec go i =
+    if Array.unsafe_get key i == 0 then begin
+      Array.unsafe_set key i pk;
+      Array.unsafe_set meta i m
+    end else go ((i + 1) land mask)
+  in
+  go ((cc_mix pk (m land lnot 1)) land mask)
+
+let cc_resize cache =
+  let old_k = cache.cc_key and old_m = cache.cc_meta in
+  let n = Array.length old_k * 2 in
+  let key = Array.make n 0 and meta = Array.make n 0 in
+  for i = 0 to Array.length old_k - 1 do
+    let pk = Array.unsafe_get old_k i in
+    if pk != 0 then cc_insert_raw key meta pk (Array.unsafe_get old_m i)
+  done;
+  cache.cc_key <- key;
+  cache.cc_meta <- meta
 
 type 'e conv_tab = {
   cnv_inf : clos_infos;
@@ -437,42 +504,43 @@ let rec ccnv cv_pb l2r infos lft1 lft2 term1 term2 cuniv =
   let fast = fast_test lft1 term1 lft2 term2 in
   if fast then cuniv
   else
+    (* NOTE: entry-wise first-order comparison of same-body FCLOS pairs was
+       tried here and regressed badly (failing entries ground then thrown
+       away by the fallback); do not re-add without a failure cache. *)
     match infos.cnv_cache with
     | None ->
       eqappr cv_pb l2r infos (lft1, (term1,[])) (lft2, (term2,[])) cuniv
     | Some cache ->
       let (k1, v1) = strip_flift 0 term1 in
       let (k2, v2) = strip_flift 0 term2 in
-      let l1 = el_shft k1 lft1 in
-      let l2 = el_shft k2 lft2 in
-      let pb = match cv_pb with CONV -> 0 | CUMUL -> 1 in
-      let key = (CClosure.get_fid v1, CClosure.get_fid v2, pb) in
-      let bucket = Hashtbl.find_opt cache.cc_tbl key in
-      let cached = match bucket with
-      | None -> None
-      | Some entries ->
-        let rec find = function
-        | [] -> None
-        | (l1', l2', r) :: rest ->
-          if eq_lift l1' l1 && eq_lift l2' l2 then Some r else find rest
-        in
-        find !entries
-      in
-      begin match cached with
-      | Some true -> cuniv
-      | Some false -> raise NotConvertible
-      | None ->
-        let add r =
-          if cache.cc_size < cc_max_size then begin
-            cache.cc_size <- cache.cc_size + 1;
-            match bucket with
-            | Some entries -> entries := (l1, l2, r) :: !entries
-            | None -> Hashtbl.add cache.cc_tbl key (ref [(l1, l2, r)])
-          end
-        in
-        match eqappr cv_pb l2r infos (lft1, (term1,[])) (lft2, (term2,[])) cuniv with
-        | cuniv -> add true; cuniv
-        | exception NotConvertible -> add false; raise NotConvertible
+      let fid1 = CClosure.get_fid v1 in
+      let fid2 = CClosure.get_fid v2 in
+      let lid1 = cc_intern cache (el_shft k1 lft1) in
+      let lid2 = if lid1 < 0 then -1 else cc_intern cache (el_shft k2 lft2) in
+      if lid2 < 0 || fid1 >= 1 lsl 31 || fid2 >= 1 lsl 31 then
+        (* out of packing range: run uncached *)
+        eqappr cv_pb l2r infos (lft1, (term1,[])) (lft2, (term2,[])) cuniv
+      else begin
+        let pk = (fid1 lsl 31) lor fid2 in
+        let pb = match cv_pb with CONV -> 0 | CUMUL -> 1 in
+        let meta0 = (lid1 lsl 18) lor (lid2 lsl 3) lor (pb lsl 1) in
+        match cc_find cache pk meta0 with
+        | 1 -> cuniv
+        | 0 -> raise NotConvertible
+        | _ ->
+          let add r =
+            if cache.cc_cnt < cc_max_size then begin
+              if 2 * (cache.cc_cnt + 1) > Array.length cache.cc_key then
+                cc_resize cache;
+              cache.cc_cnt <- cache.cc_cnt + 1;
+              cc_insert_raw cache.cc_key cache.cc_meta pk (meta0 lor r)
+            end
+          in
+          (* NOTE: a post-whd second cache probe on the reduced bare states
+             was tried here and measured useless (2 hits in 13.2M probes). *)
+          match eqappr cv_pb l2r infos (lft1, (term1,[])) (lft2, (term2,[])) cuniv with
+          | cuniv -> add 1; cuniv
+          | exception NotConvertible -> add 0; raise NotConvertible
       end
 
 (* Conversion between [lft1](hd1 v1) and [lft2](hd2 v2) *)
@@ -1056,7 +1124,8 @@ let clos_gen_conv (type err) ~typed ~use_cache trans cv_pb l2r evars env graph u
       let box e = Error.Error e in
       let cache =
         if use_cache && cc_enabled then
-          Some { cc_tbl = Hashtbl.create 16; cc_size = 0 }
+          Some { cc_key = Array.make 256 0; cc_meta = Array.make 256 0;
+                 cc_cnt = 0; cc_lifts = LiftTbl.create 16; cc_nlifts = 0 }
         else None
       in
       let infos = {

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -194,12 +194,25 @@ let convert_inductives_gen cmp_instances cmp_cumul cv_pb (mind,ind) nargs u1 u2 
     else
       cmp_cumul cv_pb variances u1 u2 s
 
+(* Conversion result cache. Within one conversion session the same pair of
+   cells is typically compared many times over, because beta-substitution
+   shares payload cells across all the occurrences of a variable. Entries
+   record the outcome (success or failure) for a pair of cells, identified
+   by their stable ids, at a given lift pair and conversion problem. Only
+   sound for checked conversion, where results are deterministic and no
+   universe constraints are accumulated. *)
+type conv_cache = {
+  cc_tbl : (int * int * int, (lift * lift * bool) list ref) Hashtbl.t;
+  mutable cc_size : int;
+}
+
 type 'e conv_tab = {
   cnv_inf : clos_infos;
   cnv_typ : bool; (* true if the input terms were well-typed *)
   lft_tab : clos_tab;
   rgt_tab : clos_tab;
   err_ret : 'e -> payload;
+  cnv_cache : conv_cache option;
 }
 (** Invariant: for any tl ∈ lft_tab and tr ∈ rgt_tab, there is no mutable memory
     location contained both in tl and in tr. *)
@@ -399,12 +412,68 @@ let assert_reduced_constructor s =
   if not @@ CList.is_empty s then
     CErrors.anomaly Pp.(str "conversion was given unreduced term (FConstruct).")
 
+let rec strip_flift k v = match fterm_of v with
+| FLIFT (n, v') -> strip_flift (k + n) v'
+| _ -> (k, v)
+
+(* Optional cap on cached entries per session (ROCQ_CONV_CACHE_MAX; 0 means
+   unlimited). Unbounded by default: like [clos_tab], the table is
+   session-scoped, so its lifetime bounds memory. *)
+let cc_max_size =
+  match int_of_string (Sys.getenv "ROCQ_CONV_CACHE_MAX") with
+  | 0 -> max_int
+  | n -> n
+  | exception _ -> max_int
+
+(* The cache is enabled by default; set ROCQ_CONV_CACHE=0 to disable. *)
+let cc_enabled =
+  match Sys.getenv "ROCQ_CONV_CACHE" with
+  | "0" -> false
+  | _ -> true
+  | exception Not_found -> true
+
 (* Conversion between  [lft1]term1 and [lft2]term2 *)
 let rec ccnv cv_pb l2r infos lft1 lft2 term1 term2 cuniv =
   let fast = fast_test lft1 term1 lft2 term2 in
   if fast then cuniv
   else
-    eqappr cv_pb l2r infos (lft1, (term1,[])) (lft2, (term2,[])) cuniv
+    match infos.cnv_cache with
+    | None ->
+      eqappr cv_pb l2r infos (lft1, (term1,[])) (lft2, (term2,[])) cuniv
+    | Some cache ->
+      let (k1, v1) = strip_flift 0 term1 in
+      let (k2, v2) = strip_flift 0 term2 in
+      let l1 = el_shft k1 lft1 in
+      let l2 = el_shft k2 lft2 in
+      let pb = match cv_pb with CONV -> 0 | CUMUL -> 1 in
+      let key = (CClosure.get_fid v1, CClosure.get_fid v2, pb) in
+      let bucket = Hashtbl.find_opt cache.cc_tbl key in
+      let cached = match bucket with
+      | None -> None
+      | Some entries ->
+        let rec find = function
+        | [] -> None
+        | (l1', l2', r) :: rest ->
+          if eq_lift l1' l1 && eq_lift l2' l2 then Some r else find rest
+        in
+        find !entries
+      in
+      begin match cached with
+      | Some true -> cuniv
+      | Some false -> raise NotConvertible
+      | None ->
+        let add r =
+          if cache.cc_size < cc_max_size then begin
+            cache.cc_size <- cache.cc_size + 1;
+            match bucket with
+            | Some entries -> entries := (l1, l2, r) :: !entries
+            | None -> Hashtbl.add cache.cc_tbl key (ref [(l1, l2, r)])
+          end
+        in
+        match eqappr cv_pb l2r infos (lft1, (term1,[])) (lft2, (term2,[])) cuniv with
+        | cuniv -> add true; cuniv
+        | exception NotConvertible -> add false; raise NotConvertible
+      end
 
 (* Conversion between [lft1](hd1 v1) and [lft2](hd2 v2) *)
 and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
@@ -979,18 +1048,24 @@ and convert_list l2r infos lft1 lft2 v1 v2 cuniv = match v1, v2 with
   convert_list l2r infos lft1 lft2 v1 v2 cuniv
 | _, _ -> raise NotConvertible
 
-let clos_gen_conv (type err) ~typed trans cv_pb l2r evars env graph univs t1 t2 =
+let clos_gen_conv (type err) ~typed ~use_cache trans cv_pb l2r evars env graph univs t1 t2 =
   NewProfile.profile "Conversion" begin fun () ->
       let reds = RedFlags.red_add_transparent RedFlags.betaiotazeta trans in
       let infos = create_conv_infos ~univs:graph ~evars reds env in
       let module Error = struct type payload += Error of err end in
       let box e = Error.Error e in
+      let cache =
+        if use_cache && cc_enabled then
+          Some { cc_tbl = Hashtbl.create 16; cc_size = 0 }
+        else None
+      in
       let infos = {
         cnv_inf = infos;
         cnv_typ = typed;
         lft_tab = create_tab ();
         rgt_tab = create_tab ();
         err_ret = box;
+        cnv_cache = cache;
       } in
       try Result.Ok (ccnv cv_pb l2r infos el_id el_id (inject t1) (inject t2) univs)
       with
@@ -1039,7 +1114,7 @@ let () =
       let box = Empty.abort in
       let state = info_univs infos in
       let qual_equal q1 q2 = CClosure.eq_quality infos q1 q2 in
-      let infos = { cnv_inf = infos; cnv_typ = true; lft_tab = tab; rgt_tab = tab; err_ret = box; } in
+      let infos = { cnv_inf = infos; cnv_typ = true; lft_tab = tab; rgt_tab = tab; err_ret = box; cnv_cache = None; } in
       let state', _ = ccnv CONV false infos el_id el_id a b (state, checked_universes_gen qual_equal) in
       assert (state==state');
       true
@@ -1057,7 +1132,7 @@ let gen_conv ~typed cv_pb ?(l2r=false) ?(reds=TransparentState.full) env ?(evars
     else eq_constr_univs univs t1 t2
   in
     if b then Result.Ok ()
-    else match clos_gen_conv ~typed reds cv_pb l2r evars env univs (state, checked_universes) t1 t2 with
+    else match clos_gen_conv ~typed ~use_cache:true reds cv_pb l2r evars env univs (state, checked_universes) t1 t2 with
     | Result.Ok (_ : 'a * ('a, Empty.t) universe_compare)-> Result.Ok ()
     | Result.Error None -> Result.Error ()
     | Result.Error (Some e) -> Empty.abort e
@@ -1067,7 +1142,7 @@ let conv_leq = gen_conv ~typed:false CUMUL
 
 let generic_conv cv_pb ~l2r reds env ?(evars=default_evar_handler env) state t1 t2 =
   let graph = Environ.universes env in
-  match clos_gen_conv ~typed:false reds cv_pb l2r evars env graph state t1 t2 with
+  match clos_gen_conv ~typed:false ~use_cache:false reds cv_pb l2r evars env graph state t1 t2 with
   | Result.Ok (s, _) -> Result.Ok s
   | Result.Error e -> Result.Error e
 

--- a/kernel/esubst.ml
+++ b/kernel/esubst.ml
@@ -49,6 +49,12 @@ let rec eq_lift a b = match a, b with
   | ELLFT (i, a), ELLFT (j, b) -> Int.equal i j && eq_lift a b
   | ELLFT _, (ELID | ELSHFT _) -> false
 
+(* Structural hash consistent with [eq_lift]. *)
+let rec hash_lift = function
+  | ELID -> 1
+  | ELSHFT (e, n) -> (hash_lift e) * 65599 + 2 * n + 1
+  | ELLFT (n, e) -> (hash_lift e) * 65599 + 2 * n
+
 (* compose a relocation of magnitude n *)
 let el_shft_rec n = function
   | ELSHFT(el,k) -> ELSHFT(el,k+n)

--- a/kernel/esubst.mli
+++ b/kernel/esubst.mli
@@ -123,6 +123,9 @@ val lift_subst : (lift -> 'a -> 'b) -> lift -> 'a subs -> 'b subs
 (** Structural equality for lifts *)
 val eq_lift : lift -> lift -> bool
 
+(** Structural hash consistent with [eq_lift]. *)
+val hash_lift : lift -> int
+
 (** Debugging utilities *)
 module Internal :
 sig


### PR DESCRIPTION
This stacked follow-up to #22309 replaces the conversion cache's boxed `Hashtbl` entries with two flat integer arrays using open addressing. Its first five commits are #22309's current head (`da4b857b9`, which moves the cache into `CClosure.ConvCache`); the last is `kernel: store the conversion cache as flat integer arrays`, re-expressed on that moved cache. After #22309 lands, only the latter will remain.

On the motivating Bonak check, the cache can reach roughly 60 million entries in one conversion session, making boxed entries costly to allocate and trace. After interning lift values, one integer packs the closure-cell ID pair and another packs the lift IDs, conversion problem kind, and cached result. The new table uses linear probing, doubles on growth, allocates no per-entry object, and adds no GC-traced pointer fields.

Probe, hit, and insertion counts were identical digit-for-digit. Relative to #22309, this reportedly improved runtime by approximately 2.6x and reduced peak memory by about one third. It does not remove the additional ID field from `fconstr`; it only reduces cache-table overhead.

Both pass locally:

- `opam exec --switch=rocq-dev-testing -- dune build kernel/kernel.cma`
- `opam exec --switch=rocq-dev-testing -- dune runtest kernel`

> *Authorship note: this was researched and written by an AI coding agent (OpenAI Codex), working on Jason Gross's behalf; Jason reviews what is posted from this account. The rebase onto #22309's current head was done by Claude Fable 5.1.*

Wordsmithed by Codex.
