### PR TITLE
Apply Search blacklist filter before query filter

### DIFF
--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -355,11 +355,12 @@ let search env sigma items mods pr_search =
   let filter ref kind env sigma typ =
     let eqb b1 b2 = if b1 then b2 else not b2 in
     module_filter mods ref kind env sigma typ &&
+    blacklist_filter ref kind env sigma typ &&
       let rec aux = function
         | GlobSearchLiteral i -> search_filter i ref kind env sigma typ
         | GlobSearchDisjConj l -> List.exists (List.for_all aux') l
       and aux' (b,s) = eqb b (aux s) in
-      List.for_all aux' items && blacklist_filter ref kind env sigma typ
+      List.for_all aux' items
   in
   let iter ref kind env sigma typ =
     if filter ref kind env sigma typ then pr_search ref kind env sigma typ


### PR DESCRIPTION
This saves a lot of time when blacklisted objects have very large types and the query contains a pattern.
Before, searching through all of UniMath took 45 minutes. With this change it can be brought down to under 4,
when combined with blacklisting subproofs generated by `abstract`.
Rocq's prelude does this but UniMath doesn't use the prelude so while testing I added it:
```rocq
From UniMath Require Import All.
Add Search Blacklist "_subproof" "_subterm" "Private_".
Search (?x -> ?x).
```

The downside of this change is that it is slightly slower in cases where types aren't as large. When importing the whole standard library the blacklist checks take about an extra 100ms.

I didn't touch the `SearchPattern` command because it is far less slow since it doesn't check the pattern against subterms of types like `Search` does. I also didn't change `SearchRewrite` because of the same reason and because it doesn't work in UniMath, as it requires `core.eq.type` and UniMath doesn't use the prelude. Let me know if you think I should go ahead and do the same for these anyway for consistency.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
