### PR TITLE
Report which terms are not convertible (#20944)

### DIFF
--- a/doc/changelog/04-tactics/22335-not-convertible-terms-Changed.rst
+++ b/doc/changelog/04-tactics/22335-not-convertible-terms-Changed.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  The :tacn:`change` tactic and other conversion tactics now report which terms are not convertible, instead of a bare "Not convertible" message.
+  (`#22335 <https://github.com/rocq-prover/rocq/pull/22335>`_,
+  fixes `#20944 <https://github.com/rocq-prover/rocq/issues/20944>`_,
+  by Aleksei Rybnikov).

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -485,7 +485,7 @@ let cc_tactic depth additional_terms b =
         | HeqnH (ida,idb) ->
           convert_to_hyp_tac ida ta idb tb p)
       begin function (e, info) -> match e with
-        | TacticErrors.NotConvertible ->
+        | TacticErrors.NotConvertible _ ->
           Tacticals.tclFAIL
             (str (if b then "simple congruence failed" else "congruence failed") ++
              str " (cannot build a well-typed proof)")

--- a/tactics/tacticErrors.ml
+++ b/tactics/tacticErrors.ml
@@ -28,7 +28,7 @@ exception UsedTwice of Id.t
 exception VariableHasNoValue of Id.t
 exception ConvertIncompatibleTypes of env * evar_map * constr * constr
 exception ConvertNotAType
-exception NotConvertible
+exception NotConvertible of (env * evar_map * constr * constr) option
 exception NotUnfoldable
 exception NoQuantifiedHypothesis of quantified_hypothesis * bool
 exception CannotFindInstance of Id.t
@@ -146,8 +146,13 @@ let tactic_interp_error_handler = function
       quote (Termops.Internal.print_constr_env env sigma t2) ++ str "."
   | ConvertNotAType ->
       str "Not a type."
-  | NotConvertible ->
+  | NotConvertible None ->
       str "Not convertible."
+  | NotConvertible (Some (env, sigma, t1, t2)) ->
+      str "Not convertible:" ++ spc () ++
+      quote (Termops.Internal.print_constr_env env sigma t1) ++ spc () ++
+      str "with" ++ spc () ++
+      quote (Termops.Internal.print_constr_env env sigma t2) ++ str "."
   | NotUnfoldable ->
      str "Cannot unfold a non-constant."
   | NoQuantifiedHypothesis (id,red) ->
@@ -242,7 +247,10 @@ let convert_not_a_type ?loc () =
   Loc.raise ?loc ConvertNotAType
 
 let not_convertible ?loc () =
-  Loc.raise ?loc NotConvertible
+  Loc.raise ?loc (NotConvertible None)
+
+let not_convertible_terms ?loc env sigma x y =
+  Loc.raise ?loc (NotConvertible (Some (env, sigma, x, y)))
 
 let not_unfoldable ?loc () =
   Loc.raise ?loc NotUnfoldable

--- a/tactics/tacticErrors.mli
+++ b/tactics/tacticErrors.mli
@@ -39,6 +39,10 @@ val convert_not_a_type : ?loc:Loc.t -> unit -> 'a
 
 val not_convertible : ?loc:Loc.t -> unit -> 'a
 
+(** Same as [not_convertible], but reports the two terms that failed to
+    convert. *)
+val not_convertible_terms : ?loc:Loc.t -> env -> evar_map -> constr -> constr -> 'a
+
 val not_unfoldable : ?loc:Loc.t -> unit -> 'a
 
 val no_quantified_hypothesis : ?loc:Loc.t -> quantified_hypothesis -> bool -> 'a
@@ -87,5 +91,5 @@ val need_dependent_product : ?loc:Loc.t -> unit -> 'a
 val clear_dependency_msg : env -> evar_map -> Names.Id.t option ->
     Evarutil.clear_dependency_error -> GlobRef.t option -> Pp.t
 
-exception NotConvertible
+exception NotConvertible of (env * evar_map * constr * constr) option
 exception DependsOnBody of Names.Id.t list * Names.Id.Set.t * Names.Id.t option

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -117,7 +117,7 @@ let convert_concl ~cast ~check ty k =
         if check then begin
           let sigma, _ = Typing.type_of env sigma ty in
           match Reductionops.infer_conv env sigma ty conclty with
-          | None -> TacticErrors.not_convertible ()
+          | None -> TacticErrors.not_convertible_terms env sigma ty conclty
           | Some sigma -> sigma
         end else sigma
       in
@@ -146,11 +146,11 @@ let convert_gen pb x y =
     let sigma = Proofview.Goal.sigma gl in
     match Reductionops.infer_conv ~pb env sigma x y with
     | Some sigma -> Proofview.Unsafe.tclEVARS sigma
-    | None -> TacticErrors.not_convertible ()
+    | None -> TacticErrors.not_convertible_terms env sigma x y
     | exception e when CErrors.noncritical e ->
       let _, info = Exninfo.capture e in
       (* FIXME: Sometimes an anomaly is raised from conversion *)
-      TacticErrors.not_convertible ?loc:(Loc.get_loc info) ()
+      TacticErrors.not_convertible_terms ?loc:(Loc.get_loc info) env sigma x y
 end
 
 let convert x y = convert_gen Conversion.CONV x y
@@ -720,7 +720,7 @@ let change_and_check cv_pb mayneedglobalcheck deep t env sigma c = match t env s
 | Changed (sigma, t') ->
   let sigma = check_types env sigma mayneedglobalcheck deep t' c in
   match infer_conv ~pb:cv_pb env sigma t' c with
-  | None -> TacticErrors.not_convertible ()
+  | None -> TacticErrors.not_convertible_terms env sigma c t'
   | Some sigma -> Changed (sigma, t')
 
 (* Use cumulativity only if changing the conclusion not a subterm *)

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -732,7 +732,7 @@ end
     for backwards compatibility. Don't use in new code. *)
 
 (** Deprecated since 9.2, use [TacticErrors.not_convertible ()] instead. *)
-exception NotConvertible
+exception NotConvertible of (Environ.env * Evd.evar_map * EConstr.constr * EConstr.constr) option
 
 val fix : Id.t -> int -> unit Proofview.tactic
 [@@ocaml.deprecated "(since 9.2) Use [FixTactics.fix]"]

--- a/test-suite/output/change_not_convertible.out
+++ b/test-suite/output/change_not_convertible.out
@@ -1,0 +1,9 @@
+File "./output/change_not_convertible.v", line 5, characters 5-17:
+The command has indeed failed with message:
+Not convertible: "True" with "False".
+File "./output/change_not_convertible.v", line 6, characters 5-19:
+The command has indeed failed with message:
+Not convertible: "True" with "1 = 1".
+File "./output/change_not_convertible.v", line 7, characters 5-28:
+The command has indeed failed with message:
+Not convertible: "True" with "True -> True".

--- a/test-suite/output/change_not_convertible.v
+++ b/test-suite/output/change_not_convertible.v
@@ -1,0 +1,8 @@
+(* The "Not convertible" error should say which terms are not convertible. *)
+
+Goal True.
+Proof.
+Fail change False.
+Fail change (1 = 1).
+Fail change ?x with (x -> x).
+Abort.


### PR DESCRIPTION
Fixes #20944.

`change False` answered with a bare `Not convertible.`, although both terms are available where the error is raised:

```coq
Goal True.
  change False.        (* Error: Not convertible. *)
  change ?x with (x -> x).   (* Error: Not convertible. *)
```

`NotConvertible` now carries optional data, the same pattern already used for similar errors in `vernac/himsg.ml` (e.g. `NotConvertibleInductiveField (id, Some (env, typ1, typ2))`). A new `not_convertible_terms` sits next to the existing `convert_incompatible_types`, and the four call sites pass what they already have:

- `tactics.ml:120` in `convert_concl`
- `tactics.ml:149` and `:153` in `convert_gen`
- `tactics.ml:723` in `change_and_check`

The message now reads:

```
Error: Not convertible: "True" with "False".
Error: Not convertible: "True" with "True -> True".
```

I used the wording suggested in the issue rather than the longer style of `ConvertIncompatibleTypes`, but I am happy to switch if you prefer the latter, since this message is shared by several tactics.

When no terms are supplied, the previous message is printed unchanged, so `not_convertible ()` keeps working as before.

**Compatibility.** The constructor gained an argument, so handlers matching on `TacticErrors.NotConvertible`, or on the deprecated re-export `Tactics.NotConvertible`, need `NotConvertible _`. There is exactly one such handler in the tree, in `plugins/cc/cctac.ml`, updated here. The `doc/changelog` entry is added. I did not touch `dev/doc/changes.md`: its most recent section is still "Changes between Coq 8.17 and Coq 8.18", so there is no section for the current cycle and I did not want to invent one. Say the word and I will add an entry there.

**Testing.** Added `test-suite/output/change_not_convertible.v` with the two examples from the issue plus one more; the expected output was generated with the test suite's own invocation. The full `output` subsystem passes: 364 tests passed over 364, i.e. 100 %. Built from `6df5ae33` with OCaml 4.14.2.

Disclosure: I use an AI assistant in my work.

