### PR TITLE
Print elimination constraints in incompatible binders (#21813)

### DIFF
--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -283,14 +283,22 @@ let pr_universes sigma ?variance ?priv = function
 let pr_global_env = Nametab.pr_global_env
 let pr_global = pr_global_env Id.Set.empty
 
-let pr_universe_instance_binder evd inst csts =
+let pr_universe_instance_binder evd ?(elim_csts=Sorts.ElimConstraints.empty) inst csts =
   let open Univ in
   let prlev = Termops.pr_evd_level evd in
-  let pcsts = if UnivConstraints.is_empty csts then mt()
-    else strbrk " | " ++
-         prlist_with_sep pr_comma
+  let pucsts = if UnivConstraints.is_empty csts then mt()
+    else prlist_with_sep pr_comma
            (fun (u,d,v) -> hov 0 (prlev u ++ UnivConstraint.pr_kind d ++ prlev v))
            (UnivConstraints.elements csts)
+  in
+  let pecsts = if Sorts.ElimConstraints.is_empty elim_csts then mt()
+    else Sorts.ElimConstraints.pr (Evd.quality_printer evd) elim_csts
+  in
+  let pcsts =
+    if UnivConstraints.is_empty csts && Sorts.ElimConstraints.is_empty elim_csts then mt()
+    else if UnivConstraints.is_empty csts then strbrk " | " ++ pecsts
+    else if Sorts.ElimConstraints.is_empty elim_csts then strbrk " | " ++ pucsts
+    else strbrk " | " ++ pecsts ++ pr_comma () ++ pucsts
   in
   str"@{" ++ UVars.Instance.pr (Evd.sort_printer evd) inst ++ pcsts ++ str"}"
 

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -143,7 +143,8 @@ val pr_sort : ?universes:bool -> ?qualities:bool -> evar_map -> Sorts.t -> Pp.t
 (** Universe constraints *)
 
 val pr_universe_instance   : evar_map -> UVars.Instance.t -> Pp.t
-val pr_universe_instance_binder : evar_map -> UVars.Instance.t -> Univ.UnivConstraints.t -> Pp.t
+val pr_universe_instance_binder : evar_map -> ?elim_csts:Sorts.ElimConstraints.t ->
+  UVars.Instance.t -> Univ.UnivConstraints.t -> Pp.t
 val pr_universe_ctx        : evar_map -> ?variance:UVars.Variance.t array ->
   UVars.UContext.t -> Pp.t
 val pr_abstract_universe_ctx : evar_map -> ?variance:UVars.Variance.t array ->

--- a/test-suite/output/elim_constraints_binder.out
+++ b/test-suite/output/elim_constraints_binder.out
@@ -1,0 +1,6 @@
+File "./output/elim_constraints_binder.v", line 15, characters 0-27:
+The command has indeed failed with message:
+Signature components for field T do not match:
+incompatible polymorphic binders: got @{s ; u | s -> Type, Set < u}
+but expected @{s ; u | Set < u}
+(incompatible constraints).

--- a/test-suite/output/elim_constraints_binder.v
+++ b/test-suite/output/elim_constraints_binder.v
@@ -1,0 +1,15 @@
+(* Elimination constraints should show up when polymorphic binders are
+   reported as incompatible, otherwise both sides of the message print
+   the same thing. *)
+
+Set Universe Polymorphism.
+
+Module Type M.
+  Parameter T@{s; u|Set < u} : unit.
+End M.
+
+Module Impl.
+  Definition T@{s; u|s -> Type, Set < u} := tt.
+End Impl.
+
+Fail Module M2 : M := Impl.

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1312,6 +1312,7 @@ let explain_not_match_error = function
       let uctx = UVars.AbstractContext.repr auctx in
       let sigma = Evd.from_auctx env (Printer.fill_names auctx) in
       Printer.pr_universe_instance_binder sigma
+        ~elim_csts:(UContext.elim_constraints uctx)
         (UContext.instance uctx)
         (UContext.univ_constraints uctx)
     in


### PR DESCRIPTION
Fixes #21813.

The message printed both sides identically, since elimination constraints could not reach the printer:

```
Error: Signature components for field T do not match:
incompatible polymorphic binders: got @{s ; u | Set < u} but expected
@{s ; u | Set < u}
(incompatible constraints).
```

`pr_universe_instance_binder` only accepted `Univ.UnivConstraints.t`, so `himsg.ml` passed `UContext.univ_constraints uctx` and the `s -> Type` was dropped on the way. It now takes an optional `?elim_csts`, printed with the existing `Sorts.ElimConstraints.pr` (already used in `himsg.ml` for unsatisfied constraints and in `vernacentries.ml`), and the same example prints:

```
incompatible polymorphic binders: got @{s ; u | s -> Type, Set < u}
but expected @{s ; u | Set < u}
(incompatible constraints).
```

This also covers the second half of the report. Of the four call sites, three pass `UnivConstraints.empty` (`prettyp.ml:77`, `prettyp.ml:571`, `printmod.ml:136`); since the new argument is optional they are untouched, and only `himsg.ml` gained one line.

Two questions I would rather ask than decide:

- **Order.** I print elimination constraints first, then universe ones, matching `PConstraints.pr` in `kernel/pConstraints.ml`. Say the word if you prefer the other way round.
- **Shape.** An optional argument keeps the diff minimal, but if you would rather have the printer take `PConstraints.t` and drop the two-argument form entirely, that is a slightly larger change I am happy to make instead.

**Testing.** Added `test-suite/output/elim_constraints_binder.v` with the example from the report. The full `output` subsystem passes: 366 tests passed over 366, i.e. 100 %. Built from `6df5ae33` with OCaml 4.14.2, on a tree containing only this change.

Disclosure: I use an AI assistant in my work.
