### PR TITLE
Apply warning flags before computing load paths (#20743)

### DIFF
--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -149,6 +149,20 @@ let init_profile ~file =
       NewProfile.finish ();
       close_out ch)
 
+(* Warning flags given on the command line are turned into injections, which
+   are only applied once the initial state is built. Some warnings are emitted
+   before that, while computing load paths, and could not be silenced at all
+   (e.g. deprecated-coq-env-var). Apply the flags early so that -w is taken
+   into account from the start; the injection is still applied later, which is
+   harmless since it sets the same value. *)
+let init_warnings opts =
+  let open Coqargs in
+  List.iter (function
+      | OptionInjection (["Warnings"], OptionSet (Some flags)) ->
+        CWarnings.set_flags (CWarnings.normalize_flags_string flags)
+      | _ -> ())
+    (List.rev opts.pre.injections)
+
 let init_runtime ~usage opts =
   let open Coqargs in
   Vernacextend.static_linking_done ();
@@ -158,6 +172,8 @@ let init_runtime ~usage opts =
 
   (* excluded directories *)
   List.iter System.exclude_directory opts.config.exclude_dirs;
+
+  init_warnings opts;
 
   let coqenv = boot_env usage opts in
 

--- a/test-suite/misc/silence_deprecated_env_var.sh
+++ b/test-suite/misc/silence_deprecated_env_var.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# The deprecated-coq-env-var warning is emitted while computing load paths,
+# before the initial state is built, so -w had no effect on it. Check that it
+# can be silenced, and that it is still emitted when it is not.
+
+export COQBIN=$BIN
+export PATH=$COQBIN:$PATH
+
+set -e
+
+TMP=`mktemp -d`
+cd $TMP
+
+cat > silence.v <<EOT
+Definition x := 1.
+EOT
+
+export COQPATH="$TMP"
+
+set +e
+
+N=`rocq c -q silence.v 2>&1 | grep -c "Deprecated environment variable"`
+if [ $N -ne 1 ]; then
+  echo "the deprecated-coq-env-var warning is not emitted without -w"
+  rocq c -q silence.v
+  rm -rf $TMP
+  exit 1
+fi
+
+N=`rocq c -q -w -deprecated-coq-env-var silence.v 2>&1 | grep -c "Deprecated environment variable"`
+if [ $N -ne 0 ]; then
+  echo "the deprecated-coq-env-var warning is not silenced by -w"
+  rocq c -q -w -deprecated-coq-env-var silence.v
+  rm -rf $TMP
+  exit 1
+fi
+
+rm -rf $TMP
+exit 0


### PR DESCRIPTION
Fixes #20743.

`-w` is turned into an injection (`add_set_warnings`, `sysinit/coqargs.ml:194`), and injections are applied when the initial state is built. The `deprecated-coq-env-var` warning is emitted before that, while computing load paths (`init_runtime` → `init_load_paths` → `Envars.coqpath`, `lib/envars.ml:111`), so the flag could not affect it:

```
$ COQPATH=$PWD rocq repl -q -w -deprecated-coq-env-var
Warning: Deprecated environment variable COQPATH, use ROCQPATH instead.
[deprecated-coq-env-var,deprecated-since-9.0,deprecated,default]
```

`Set Warnings "-deprecated-coq-env-var".` inside a `.v` did not help either, for the same reason: the message is printed before the file is read.

The patch applies the warning flags at the start of `init_runtime`, before load paths are computed. The injection is still applied later as before, which is harmless since it sets the same value. With it:

```
$ COQPATH=$PWD rocq repl -q -w -deprecated-coq-env-var
Welcome to Rocq ...
```

and without the flag the warning is still emitted.

**Testing.** Added `test-suite/misc/silence_deprecated_env_var.sh`, checking both directions (silenced with the flag, still emitted without it). I verified it fails on an unpatched tree, so it does catch a regression. Also checked by hand that unrelated warnings are unaffected, that `-w` still silences them, and that `-w -all` still silences everything.

Three tests in the `misc` subsystem fail in my environment (`quotation_token`, `side-eff-leak-univs`, `tc_declaration_observer`), but they fail the same way on an unpatched tree: they build plugins and hit "not a compiled interface for this version of OCaml" here. Unrelated to this change.

Built from `6df5ae33` with OCaml 4.14.2.

Disclosure: I use an AI assistant in my work.
