### PR TITLE
EConstr: add map_with_full_binders (moved from termops)

### DIFF
--- a/doc/changelog/12-infrastructure-and-dependencies/22340-econstr-map-with-full-binders-Added.rst
+++ b/doc/changelog/12-infrastructure-and-dependencies/22340-econstr-map-with-full-binders-Added.rst
@@ -1,0 +1,8 @@
+- **Added:**
+  ``EConstr.map_with_full_binders``, the map counterpart of
+  ``EConstr.iter_with_full_binders``, which pushes the declarations bound by
+  ``Case``, ``Fix`` and ``CoFix`` nodes as well as by ``Prod``, ``Lambda`` and
+  ``LetIn``; ``Termops.map_constr_with_full_binders`` is now an alias for it
+  (ML API change)
+  (`#22340 <https://github.com/rocq-prover/rocq/pull/22340>`_,
+  by Jason Gross).

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -728,6 +728,82 @@ let iter_with_full_binders env sigma g f n c =
     Array.iter (f n') bl
   | Array (_u,t,def,ty) -> Array.Fun1.iter f n t; f n def; f n ty
 
+let map_with_full_binders env sigma g f n c0 =
+  let open Context.Rel.Declaration in
+  match kind sigma c0 with
+  | (Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _
+    | Construct _ | Int _ | Float _ | String _) -> c0
+  | Cast (c,k,t) ->
+    let c' = f n c in
+    let t' = f n t in
+    if c' == c && t' == t then c0
+    else mkCast (c', k, t')
+  | Prod (na,t,c) ->
+    let t' = f n t in
+    let c' = f (g (LocalAssum (na, t)) n) c in
+    if t' == t && c' == c then c0
+    else mkProd (na, t', c')
+  | Lambda (na,t,c) ->
+    let t' = f n t in
+    let c' = f (g (LocalAssum (na, t)) n) c in
+    if t' == t && c' == c then c0
+    else mkLambda (na, t', c')
+  | LetIn (na,b,t,c) ->
+    let b' = f n b in
+    let t' = f n t in
+    let c' = f (g (LocalDef (na, b, t)) n) c in
+    if b' == b && t' == t && c' == c then c0
+    else mkLetIn (na, b', t', c')
+  | App (c,l) ->
+    let c' = f n c in
+    let l' = Array.Fun1.Smart.map f n l in
+    if c' == c && l' == l then c0
+    else mkApp (c', l')
+  | Evar ev ->
+    let ev' = map_existential sigma (fun c -> f n c) ev in
+    if ev' == ev then c0
+    else mkEvar ev'
+  | Case (ci,u,pms,(p,r),iv,c,bl) ->
+    (* The annotated case only serves to compute the contexts bound by the
+       return clause and by the branches; the terms under those contexts are
+       shared with the compact representation, which is the one we rebuild. *)
+    let (_, _, _, (pctx,_), _, _, blctx) =
+      annotate_case env sigma (ci, u, pms, (p,r), iv, c, bl)
+    in
+    let f_ctx (ctx, c) (nas, _ as br) =
+      let c' = f (List.fold_right g ctx n) c in
+      if c' == c then br else (nas, c')
+    in
+    let pms' = Array.Fun1.Smart.map f n pms in
+    let p' = f_ctx pctx p in
+    let iv' = map_invert (f n) iv in
+    let c' = f n c in
+    let bl' = Array.Smart.map2 f_ctx blctx bl in
+    if pms' == pms && p' == p && iv' == iv && c' == c && bl' == bl then c0
+    else mkCase (ci, u, pms', (p',r), iv', c', bl')
+  | Proj (p,r,c) ->
+    let c' = f n c in
+    if c' == c then c0
+    else mkProj (p, r, c')
+  | Fix (ln,(lna,tl,bl)) ->
+    let tl' = Array.Fun1.Smart.map f n tl in
+    let n' = Array.fold_left2_i (fun i n na t -> g (LocalAssum (na, lift i t)) n) n lna tl in
+    let bl' = Array.Fun1.Smart.map f n' bl in
+    if tl' == tl && bl' == bl then c0
+    else mkFix (ln,(lna,tl',bl'))
+  | CoFix (ln,(lna,tl,bl)) ->
+    let tl' = Array.Fun1.Smart.map f n tl in
+    let n' = Array.fold_left2_i (fun i n na t -> g (LocalAssum (na,lift i t)) n) n lna tl in
+    let bl' = Array.Fun1.Smart.map f n' bl in
+    if tl' == tl && bl' == bl then c0
+    else mkCoFix (ln,(lna,tl',bl'))
+  | Array (u,t,def,ty) ->
+    let t' = Array.Fun1.Smart.map f n t in
+    let def' = f n def in
+    let ty' = f n ty in
+    if t' == t && def' == def && ty' == ty then c0
+    else mkArray (u, t', def', ty')
+
 let iter_with_binders sigma g f n c =
   let f l c = f l (of_constr c) in
   let c = unsafe_to_constr @@ whd_evar sigma c in

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -353,6 +353,12 @@ val map_existential : Evd.evar_map -> (t -> t) -> existential -> existential
 val iter : Evd.evar_map -> (t -> unit) -> t -> unit
 val iter_with_binders : Evd.evar_map -> ('a -> 'a) -> ('a -> t -> unit) -> 'a -> t -> unit
 val iter_with_full_binders : Environ.env -> Evd.evar_map -> (rel_declaration -> 'a -> 'a) -> ('a -> t -> unit) -> 'a -> t -> unit
+val map_with_full_binders : Environ.env -> Evd.evar_map -> (rel_declaration -> 'a -> 'a) -> ('a -> t -> t) -> 'a -> t -> t
+(** The map counterpart of {!iter_with_full_binders}: [f] is applied to the
+    immediate subterms of the term, the accumulator being updated by [g] for
+    every declaration bound in the visited subterm, including the ones bound
+    by [Case], [Fix] and [CoFix] nodes. It is not recursive. *)
+
 val fold : Evd.evar_map -> ('a -> t -> 'a) -> 'a -> t -> 'a
 val fold_with_binders : Evd.evar_map -> ('a -> 'a) -> ('a -> 'b -> t -> 'b) -> 'a -> 'b -> t -> 'b
 

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -615,70 +615,7 @@ let map_constr_with_binders_left_to_right env sigma g f l c =
       else mkArray(u,t',def',ty')
 
 (* strong *)
-let map_constr_with_full_binders env sigma g f l cstr =
-  let open EConstr in
-  match EConstr.kind sigma cstr with
-  | (Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _
-    | Construct _ | Int _ | Float _ | String _) -> cstr
-  | Cast (c,k, t) ->
-      let c' = f l c in
-      let t' = f l t in
-      if c==c' && t==t' then cstr else mkCast (c', k, t')
-  | Prod (na,t,c) ->
-      let t' = f l t in
-      let c' = f (g (RelDecl.LocalAssum (na, t)) l) c in
-      if t==t' && c==c' then cstr else mkProd (na, t', c')
-  | Lambda (na,t,c) ->
-      let t' = f l t in
-      let c' = f (g (RelDecl.LocalAssum (na, t)) l) c in
-      if t==t' && c==c' then cstr else  mkLambda (na, t', c')
-  | LetIn (na,b,t,c) ->
-      let b' = f l b in
-      let t' = f l t in
-      let c' = f (g (RelDecl.LocalDef (na, b, t)) l) c in
-      if b==b' && t==t' && c==c' then cstr else mkLetIn (na, b', t', c')
-  | App (c,al) ->
-      let c' = f l c in
-      let al' = Array.map (f l) al in
-      if c==c' && Array.for_all2 (==) al al' then cstr else mkApp (c', al')
-  | Proj (p,r,c) ->
-      let c' = f l c in
-        if c' == c then cstr else mkProj (p, r, c')
-  | Evar ev ->
-    let ev' = EConstr.map_existential sigma (fun c -> f l c) ev in
-    if ev' == ev then cstr else mkEvar ev'
-  | Case (ci, u, pms, (p,r), iv, c, bl) ->
-      let (ci, _, pms, (p0,_), _, c, bl0) = annotate_case env sigma (ci, u, pms, (p,r), iv, c, bl) in
-      let f_ctx (nas, _ as r) (ctx, c) =
-        let c' = f (List.fold_right g ctx l) c in
-        if c' == c then r else (nas, c')
-      in
-      let pms' = Array.Smart.map (f l) pms in
-      let p' = f_ctx p p0 in
-      let iv' = map_invert (f l) iv in
-      let c' = f l c in
-      let bl' = Array.map2 f_ctx bl bl0 in
-      if pms==pms' && p==p' && iv'==iv && c==c' && Array.for_all2 (==) bl bl' then cstr else
-        mkCase (ci, u, pms', (p',r), iv', c', bl')
-  | Fix (ln,(lna,tl,bl as fx)) ->
-      let tl' = Array.map (f l) tl in
-      let l' = fold_rec_types g fx l in
-      let bl' = Array.map (f l') bl in
-      if Array.for_all2 (==) tl tl' && Array.for_all2 (==) bl bl'
-      then cstr
-      else mkFix (ln,(lna,tl',bl'))
-  | CoFix(ln,(lna,tl,bl as fx)) ->
-      let tl' = Array.map (f l) tl in
-      let l' = fold_rec_types g fx l in
-      let bl' = Array.map (f l') bl in
-      if Array.for_all2 (==) tl tl' && Array.for_all2 (==) bl bl'
-      then cstr
-      else mkCoFix (ln,(lna,tl',bl'))
-  | Array(u,t,def,ty) ->
-      let t' = Array.Smart.map (f l) t in
-      let def' = f l def in
-      let ty' = f l ty in
-      if def==def' && t == t' && ty==ty' then cstr else mkArray (u,t', def',ty')
+let map_constr_with_full_binders = EConstr.map_with_full_binders
 
 (* [fold_constr_with_binders g f n acc c] folds [f n] on the immediate
    subterms of [c] starting from [acc] and proceeding from left to


### PR DESCRIPTION
`EConstr` has an environment-aware `iter_with_full_binders` but no corresponding map. This adds:

```ocaml
val map_with_full_binders : Environ.env -> Evd.evar_map ->
  (rel_declaration -> 'a -> 'a) -> ('a -> t -> t) -> 'a -> t -> t
```

The traversal already exists as `Termops.map_constr_with_full_binders`. Its implementation moves beside the iterator in `eConstr.ml`, adapted to local `Array.Fun1.Smart.map` / `Array.Smart.map2` conventions, and the `Termops` function becomes an alias. Its signature and behavior do not change, and physical sharing is preserved at least as well as before.

Keeping the implementation in one place is especially important for `Case`: it recovers return-predicate and branch contexts through `annotate_case` while rebuilding the compact case representation.

Without this API, plugin authors may fall back to plain `EConstr.map` for `Case` / `Fix` / `CoFix`. That does not push their binders, so de Bruijn indices resolve against the ambient context and can silently produce wrong results. LPCIC/coq-elpi#1092 provides a concrete use case: coq-elpi retypes binder types to fix relevance marks, and retyping a fixpoint body without its binders can select an unrelated declaration's sort.

There is no in-tree caller; this is an ML API addition. A changelog entry is included under `doc/changelog/12-infrastructure-and-dependencies/`.

Verification:

- `dune build engine/` and `dune build @check`: both clean.
- `dev/lint-repository.sh`: passes.
- Test suite not run: no user-visible change and no in-tree caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Wordsmithed by Codex.
