### PR TITLE
Fix make dunestrap for upcoming dune

### DIFF
--- a/doc/changelog/12-infrastructure-and-dependencies/22356-janno-dune-deps-Fixed.rst
+++ b/doc/changelog/12-infrastructure-and-dependencies/22356-janno-dune-deps-Fixed.rst
@@ -1,0 +1,4 @@
+- **Fixed:**
+  Fix `dunestrap` rule generation to work with dune 3.25
+  (`#22356 <https://github.com/rocq-prover/rocq/pull/22356>`_,
+  by Jan-Oliver Kaiser).

--- a/dune
+++ b/dune
@@ -44,8 +44,7 @@
  (targets corelib_dune)
  (deps
   (source_tree plugins)
-  (source_tree theories)
-  (package rocq-runtime))
+  (source_tree theories))
  (action
   (with-stdout-to %{targets}
    (run tools/dune_rule_gen/gen_rules.exe Corelib theories/Corelib %{env:COQ_DUNE_EXTRA_OPT=}))))
@@ -54,8 +53,7 @@
  (targets ltac2_dune)
  (deps
   (source_tree plugins)
-  (source_tree theories)
-  (package rocq-runtime))
+  (source_tree theories))
  (action
   (with-stdout-to %{targets}
    (run tools/dune_rule_gen/gen_rules.exe Ltac2 theories/Ltac2 -noinit %{env:COQ_DUNE_EXTRA_OPT=}))))

--- a/dune
+++ b/dune
@@ -45,7 +45,7 @@
  (deps
   (source_tree plugins)
   (source_tree theories)
-  %{workspace_root}/_build/install/%{context_name}/lib/rocq-runtime/META)
+  (package rocq-runtime))
  (action
   (with-stdout-to %{targets}
    (run tools/dune_rule_gen/gen_rules.exe Corelib theories/Corelib %{env:COQ_DUNE_EXTRA_OPT=}))))
@@ -55,7 +55,7 @@
  (deps
   (source_tree plugins)
   (source_tree theories)
-  %{workspace_root}/_build/install/%{context_name}/lib/rocq-runtime/META)
+  (package rocq-runtime))
  (action
   (with-stdout-to %{targets}
    (run tools/dune_rule_gen/gen_rules.exe Ltac2 theories/Ltac2 -noinit %{env:COQ_DUNE_EXTRA_OPT=}))))

--- a/tools/coqdep/lib/common.ml
+++ b/tools/coqdep/lib/common.ml
@@ -151,19 +151,6 @@ module VCache = Set.Make(VData)
     (those loaded by [Require]) from other dependencies, e.g. dependencies
     on ".v" files (for [Load]) or ".cmx", ".cmo", etc... (for [Declare]). *)
 
-(* Transform "Declare ML %DECL" to a pair of (meta, cmxs). Something
-   very similar is in ML top *)
-let declare_ml_to_file file (decl : string) =
-  let legacy_decl = String.split_on_char ':' decl in
-  match legacy_decl with
-  | [package] ->
-    Fl.findlib_deep_resolve ~file ~package
-  | [cmxs; package] ->
-    (* rocq compile will warn *)
-    Fl.findlib_deep_resolve ~file ~package
-  | bad_pkg ->
-    CErrors.user_err Pp.(str "Failed to resolve plugin: " ++ str decl)
-
 let coq_to_stdlib from strl =
   let tr_qualid = function
     | "Coq" :: l -> "Stdlib" :: l
@@ -194,7 +181,7 @@ end
 (* recursive because of Load *)
 let rec find_dependencies ({State.vAccu; separator_hack; loadpath} as st) basename =
   (* Visited marks *)
-  let visited_ml = ref CString.Set.empty in
+  let visited_package = ref CString.Set.empty in
   let visited_v = ref VCache.empty in
   let should_visit_v_and_mark from str =
     if not (VCache.mem (from, str) !visited_v) then begin
@@ -207,9 +194,6 @@ let rec find_dependencies ({State.vAccu; separator_hack; loadpath} as st) basena
   let dependencies = ref DepSet.empty in
   let add_dep dep = dependencies := DepSet.add dep !dependencies in
   let add_dep_other s = add_dep (Dep_info.Dep.Other s) in
-
-  (* worker dep *)
-  let () = add_dep_other (Loadpath.get_worker_path loadpath) in
 
   (* Reading file contents *)
   let f = basename ^ ".v" in
@@ -247,16 +231,11 @@ let rec find_dependencies ({State.vAccu; separator_hack; loadpath} as st) basena
         List.iter decl strl;
         loop ()
       | Declare sl ->
-        (* We resolve "pkg_name" to a .cma file, using the META *)
-        let sl = List.map (declare_ml_to_file f) sl in
-        let decl (meta_file, str) =
-          List.iter add_dep_other meta_file;
-          str |> List.iter (fun str ->
-          let plugin_file = Filename.chop_extension str in
-          if not (CString.Set.mem plugin_file !visited_ml) then begin
-            visited_ml := CString.Set.add plugin_file !visited_ml;
-            add_dep (Dep_info.Dep.Ml plugin_file)
-          end)
+        let decl dep =
+          if not (CString.Set.mem dep !visited_package) then begin
+            visited_package := CString.Set.add dep !visited_package;
+            add_dep (Dep_info.Dep.Ml dep)
+          end
         in
         List.iter decl sl;
         loop ()

--- a/tools/coqdep/lib/dep_info.ml
+++ b/tools/coqdep/lib/dep_info.ml
@@ -11,7 +11,7 @@
 module Dep = struct
   type t =
   | Require of string (* one basename, to which we later append .vo or .vos *)
-  | Ml of string
+  | Ml of string (* the fully qualified findlib package *)
   | Other of string (* filenames of dependencies, separated by spaces *)
 
   let compare a b = match a, b with

--- a/tools/coqdep/lib/dep_info.mli
+++ b/tools/coqdep/lib/dep_info.mli
@@ -13,9 +13,11 @@ module Dep : sig
   | Require of string
   (** module basename, to which we later append .vo or .vos *)
   | Ml of string
-  (** plugin basename and byte extension, resolved from Declare Ml Module *)
+  (** fully qualified findlib package as given in Declare Ml Module *)
   | Other of string
   (** load, meta, and external dependencies *)
+
+  val compare : t -> t -> int
 
   module Set : CSet.ExtS with type elt = t
 end

--- a/tools/coqdep/lib/makefile.ml
+++ b/tools/coqdep/lib/makefile.ml
@@ -88,7 +88,43 @@ let option_write_vos = ref false
 let set_noglob glob = option_noglob := glob
 let set_write_vos vos = option_write_vos := vos
 
+(* Transform "Declare ML %DECL" to a pair of (meta, cmxs). Something
+   very similar is in ML top *)
+let declare_ml_to_file file (decl : string) =
+  let legacy_decl = String.split_on_char ':' decl in
+  match legacy_decl with
+  | [package] ->
+    Fl.findlib_deep_resolve ~file ~package
+  | [cmxs; package] ->
+    (* rocq compile will warn *)
+    Fl.findlib_deep_resolve ~file ~package
+  | bad_pkg ->
+    CErrors.user_err Pp.(str "Failed to resolve plugin: " ++ str decl)
+
 let print_dep fmt { Dep_info.name; deps } =
+  let vfile = name^".v" in
+  let deps =
+    let visited_ml = ref CString.Set.empty in
+    let expand_package_dep package =
+      let meta_file, str = declare_ml_to_file vfile package in
+      List.map (fun f -> Dep_info.Dep.Other f) meta_file @
+      CList.map_filter (fun str ->
+          let plugin_file = Filename.chop_extension str in
+          if not (CString.Set.mem plugin_file !visited_ml) then begin
+            visited_ml := CString.Set.add plugin_file !visited_ml;
+            Some (Dep_info.Dep.Ml plugin_file)
+          end
+          else None)
+        str
+    in
+    let f dep =
+      match dep with
+      | Dep_info.Dep.Ml package -> expand_package_dep package
+      | Dep_info.Dep.Other _ | Dep_info.Dep.Require _ -> [dep]
+    in
+    List.concat_map f deps |> CList.sort_uniq Dep_info.Dep.compare
+  in
+
   let ename = escape name in
     let glob = if !option_noglob then "" else ename^".glob " in
   fprintf fmt "%s.vo %s%s.v.beautified %s.required_vo: %s.v %a\n" ename glob ename ename ename

--- a/tools/coqdep/lib/rocqdep_main.ml
+++ b/tools/coqdep/lib/rocqdep_main.ml
@@ -50,7 +50,14 @@ let coqdep args =
   if args.Args.sort then
     sort st
   else
-    compute_deps st |> Seq.iter (Makefile.print_dep Format.std_formatter)
+    let deps = compute_deps st in
+    let worker = Dep_info.Dep.Other (Loadpath.get_worker_path @@ Common.State.loadpath st) in
+    let add_worker ({Dep_info.deps; _} as dep_info) =
+      let deps = deps @ [worker] in
+      {dep_info with deps}
+    in
+    let deps = Seq.map add_worker deps in
+    deps |> Seq.iter (Makefile.print_dep Format.std_formatter)
 
 let main args =
   try

--- a/tools/dune_rule_gen/coq_rules.ml
+++ b/tools/dune_rule_gen/coq_rules.ml
@@ -137,7 +137,7 @@ module Context = struct
     ; rule : Coq_module.Rule_type.t (* rule kind *)
     ; boot : Boot_type.t        (* type of library *)
     ; dep_info : Dep_info.t
-    ; async_deps : string list  (* whether coqc needs the workers *)
+    ; worker_deps : string list  (* we always need rocqworker and thus rocq-runtime *)
     ; root_lvl : int
     }
 
@@ -154,14 +154,11 @@ module Context = struct
           ; A "-native-compiler"; A native_string
           ]
 
-  (* XXX: we could put the workers here, but they need a complete OCaml runtime so this is better *)
-  let build_async_deps = ["(package rocq-runtime)"]
-
   (* args are for coqdep *)
   let build_dep_info ~coqdep_args dir_info =
     Dep_info.make ~args:coqdep_args ~dir_info
 
-  let make ~root_lvl ~theory ~user_flags ~boot ~rule ~async ~dir_info ~split =
+  let make ~root_lvl ~theory ~user_flags ~boot ~rule ~async:(_) ~dir_info ~split =
 
     let flags =
       let boot_paths = match boot with
@@ -176,12 +173,13 @@ module Context = struct
       { Flags.user = user_flags; common; loadpath; native_common; native_coqc }
     in
 
+    let worker_deps = ["(package rocq-runtime)"] in
+
     (* coqdep and dep info *)
     let coqdep_args = flags.loadpath in
     let dep_info = build_dep_info ~coqdep_args dir_info in
 
-    let async_deps = if async then build_async_deps else [] in
-    { theory; flags; rule; boot; dep_info; async_deps; root_lvl }
+    { theory; flags; rule; boot; dep_info; worker_deps; root_lvl }
 
 end
 
@@ -211,7 +209,12 @@ let module_rule ~(cctx : Context.t) coq_module =
   (* retrieve deps *)
   let vfile = Coq_module.source coq_module in
   let vo_ext = ".vo" in
-  let vfile_deps = Dep_info.lookup ~dep_info:cctx.dep_info vfile |> List.map (path_of_dep ~vo_ext) in
+  let vfile_deps = Dep_info.lookup ~dep_info:cctx.dep_info vfile in
+  let vfile_deps, vfile_packages =
+    let open Coqdeplib.Dep_info in
+    List.partition (function Dep.Ml _ -> false | Dep.Require _ | Dep.Other _ -> true) vfile_deps
+  in
+  let vfile_deps = List.map (path_of_dep ~vo_ext) vfile_deps in
   (* handle -noinit, inject prelude.vo if needed *)
   let boot_flags, boot_deps = boot_module_setup ~cctx coq_module in
   let coqc_flags = cctx.flags.loadpath @ cctx.flags.user @ cctx.flags.common @ cctx.flags.native_coqc in
@@ -225,8 +228,18 @@ let module_rule ~(cctx : Context.t) coq_module =
   let lvl = cctx.root_lvl + (Coq_module.prefix coq_module |> List.length) in
   let flags = (* flags are relative to the root path *) Arg.List.to_string (flags @ timeflags) in
   let deps = List.map (Path.adjust ~lvl) vfile_deps |> List.map Path.to_string in
-  (* Depend on the workers if async *)
-  let deps = cctx.async_deps @ deps in
+  (* Depend on the workers *)
+  let deps = cctx.worker_deps @ deps in
+  let deps =
+    let open Coqdeplib.Dep_info in
+    List.map (
+      function
+      | Dep.Ml package ->
+        let root = List.nth (String.split_on_char '.' package) 0 in
+        "(package "^root^")"
+      | Dep.Other _ | Dep.Require _ -> assert false) vfile_packages
+    @ deps
+  in
   (* Build rule *)
   let updir = Path.(to_string (adjust ~lvl (make "."))) in
   let action = Format.asprintf "(chdir %s (run rocq c %s %%{dep:%s}))" updir flags vfile_base in


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

ocaml/dune#14373 breaks the hacks that were used in generated dune files for Corelib and Ltac2. In particular, depending on the META file of rocq-runtime (or other ML dependencies) is no longer enough. There might be other hacks to take their place but the simpler fix is to depend on `(package rocq-runtime)` for all `.v` files. Does anything actually need the fine-grained dependencies that were emitted before?

The main part of the change is disentangling dependency information from their two consumers: dune and rocq_makefile. rocq_makefile retains its old behavior. Dune rules only mention (root) packages.

Tested with dune 3.23.1 and 3.24.2.

/cc @rlepigre-skylabs-ai 

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
