### PR TITLE
Make `f (x:=e)%s` parse as `f (x:=e%s)` instead of `(f (x:=e))%s`

### DIFF
--- a/dev/ci/user-overlays/22357-SkySkimmer-arg-scope.sh
+++ b/dev/ci/user-overlays/22357-SkySkimmer-arg-scope.sh
@@ -1,0 +1,1 @@
+overlay rocq_lsp https://github.com/proux01/coq-lsp rocq22357 22357

--- a/doc/changelog/02-specification-language/22357-arg-scope-Fixed.rst
+++ b/doc/changelog/02-specification-language/22357-arg-scope-Fixed.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  ``f (x:=e)%s`` is now parsed as ``f (x:=e%s)`` instead of ``(f (x:=e))%s``
+  (`#22357 <https://github.com/rocq-prover/rocq/pull/22357>`_,
+  fixes `#22324 <https://github.com/rocq-prover/rocq/issues/22324>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/language/core/assumptions.rst
+++ b/doc/sphinx/language/core/assumptions.rst
@@ -120,14 +120,16 @@ products.
 Function application
 --------------------
 
-.. insertprodn term_application arg
+.. insertprodn term_application scope_delimiter
 
 .. prodn::
    term_application ::= @term10 {+ @arg }
    | @ @qualid_annotated {+ @term1 }
-   arg ::= ( @ident := @term )
-   | ( @natural := @term )
+   arg ::= ( @ident := @term ) {* @scope_delimiter }
+   | ( @natural := @term ) {* @scope_delimiter }
    | @term1
+   scope_delimiter ::= % @scope
+   | %_ @scope
 
 :n:`@term1__fun @term1` denotes applying the function :n:`@term1__fun` to :token:`term1`.
 

--- a/doc/sphinx/language/extensions/arguments-command.rst
+++ b/doc/sphinx/language/extensions/arguments-command.rst
@@ -11,10 +11,10 @@ Setting properties of a function's arguments
       arg_specs ::= @argument_spec
       | /
       | &
-      | ( {+ @argument_spec } ) {* {| % @scope | %_ @scope } }
-      | [ {+ @argument_spec } ] {* {| % @scope | %_ @scope } }
-      | %{ {+ @argument_spec } %} {* {| % @scope | %_ @scope } }
-      argument_spec ::= {? ! } @name {* {| % @scope | %_ @scope } }
+      | ( {+ @argument_spec } ) {* @scope_delimiter }
+      | [ {+ @argument_spec } ] {* @scope_delimiter }
+      | %{ {+ @argument_spec } %} {* @scope_delimiter }
+      argument_spec ::= {? ! } @name {* @scope_delimiter }
       implicits_alt ::= @name
       | [ {+ @name } ]
       | %{ {+ @name } %}

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2388,7 +2388,6 @@ SPLICE: [
 | ne_in_or_out_modules
 | search_queries
 | locatable
-| scope_delimiter
 | one_import_filter_name
 | search_where
 | message_token

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -173,9 +173,14 @@ field_def: [
 | global binders ":=" lconstr
 ]
 
+scope_delimiter: [
+| "%" IDENT
+| "%_" IDENT
+]
+
 arg: [
-| test_lpar_id_coloneq "(" identref ":=" lconstr ")"
-| test_lpar_nat_coloneq "(" natural ":=" lconstr ")"
+| test_lpar_id_coloneq "(" identref ":=" lconstr ")" LIST0 scope_delimiter
+| test_lpar_nat_coloneq "(" natural ":=" lconstr ")" LIST0 scope_delimiter
 | term9
 ]
 
@@ -1345,11 +1350,6 @@ args_modifier: [
 | "extra" "scopes"
 | "clear" "scopes" "and" "implicits"
 | "clear" "implicits" "and" "scopes"
-]
-
-scope_delimiter: [
-| "%" IDENT
-| "%_" IDENT
 ]
 
 argument_spec: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -85,9 +85,14 @@ term_application: [
 ]
 
 arg: [
-| "(" ident ":=" term ")"
-| "(" natural ":=" term ")"
+| "(" ident ":=" term ")" LIST0 scope_delimiter
+| "(" natural ":=" term ")" LIST0 scope_delimiter
 | term1
+]
+
+scope_delimiter: [
+| "%" scope
+| "%_" scope
 ]
 
 term_explicit: [
@@ -685,13 +690,13 @@ arg_specs: [
 | argument_spec
 | "/"
 | "&"
-| "(" LIST1 argument_spec ")" LIST0 [ "%" scope | "%_" scope ]
-| "[" LIST1 argument_spec "]" LIST0 [ "%" scope | "%_" scope ]
-| "{" LIST1 argument_spec "}" LIST0 [ "%" scope | "%_" scope ]
+| "(" LIST1 argument_spec ")" LIST0 scope_delimiter
+| "[" LIST1 argument_spec "]" LIST0 scope_delimiter
+| "{" LIST1 argument_spec "}" LIST0 scope_delimiter
 ]
 
 argument_spec: [
-| OPT "!" name LIST0 [ "%" scope | "%_" scope ]
+| OPT "!" name LIST0 scope_delimiter
 ]
 
 implicits_alt: [

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -108,6 +108,8 @@ type explicit_flag = bool (** true = with "@" *)
 type delimiter_depth = DelimOnlyTmpScope | DelimUnboundedScope
 (** shallow (%_) vs. deep (%) scope opening *)
 
+type scope_delimiter = delimiter_depth * string
+
 type prim_token =
   | Number of NumTok.Signed.t
   | String of string

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -126,6 +126,8 @@ let force_quality ?loc = function
    and we can't do [Rocqlib.lib_ref] at parsing time, it's only available in the interp phase. *)
 let sigref loc = Libnames.qualid_of_string ~loc "Corelib.Init.Specif.sig"
 
+let mk_delim ~loc c d = CAst.make ~loc @@ CDelimiters (fst d, snd d, c)
+
 }
 
 GRAMMAR EXTEND Gram
@@ -134,7 +136,7 @@ GRAMMAR EXTEND Gram
   global constr_pattern cpattern Constr.ident
   closed_binder open_binders binder binders binders_fixannot
   record_declaration typeclass_constraint pattern arg type_cstr
-  one_closed_binder one_open_binder;
+  one_closed_binder one_open_binder scope_delimiter;
   Constr.ident:
     [ [ id = Prim.ident -> { id } ] ]
   ;
@@ -270,7 +272,10 @@ GRAMMAR EXTEND Gram
         args = LIST0 (term LEVEL "9"); ")" ->
         { CAst.make ~loc @@ CProj(true, (f,i), List.map (fun a -> (a,None)) args, c) }
       | c = term; "%"; key = IDENT ->
-        { CAst.make ~loc @@ CDelimiters (DelimUnboundedScope,key,c) }
+        { (* we'd like to use `scope_delimiter` here but that would break left factoring
+             with potential user defined notations
+             (e.g., `Reserved Notation "x %" (at level 1).` in CoLoR) *)
+          CAst.make ~loc @@ CDelimiters (DelimUnboundedScope,key,c) }
       | c = term; "%_"; key = IDENT ->
         { CAst.make ~loc @@ CDelimiters (DelimOnlyTmpScope,key,c) } ]
     | "0"
@@ -326,9 +331,16 @@ GRAMMAR EXTEND Gram
     [ [ id = global; bl = binders; ":="; c = lconstr ->
         { (id, mkLambdaCN ~loc bl c) } ] ]
   ;
+  scope_delimiter: [
+    [ "%"; key = IDENT -> { DelimUnboundedScope, key }
+    | "%_"; key = IDENT -> { DelimOnlyTmpScope, key }
+    ] ]
+  ;
   arg:
-    [ [ test_lpar_id_coloneq; "("; id = identref; ":="; c = lconstr; ")" -> { (c,Some (CAst.make ?loc:id.CAst.loc @@ ExplByName id.CAst.v)) }
-      | test_lpar_nat_coloneq; "("; n = natural; ":="; c = lconstr; ")" -> { (c,Some (CAst.make ~loc @@ ExplByPos n)) }
+    [ [ test_lpar_id_coloneq; "("; id = identref; ":="; c = lconstr; ")"; d = LIST0 scope_delimiter ->
+        { (List.fold_left (mk_delim ~loc) c d,Some (CAst.make ?loc:id.CAst.loc @@ ExplByName id.CAst.v)) }
+      | test_lpar_nat_coloneq; "("; n = natural; ":="; c = lconstr; ")"; d = LIST0 scope_delimiter ->
+        { (List.fold_left (mk_delim ~loc) c d,Some (CAst.make ~loc @@ ExplByPos n)) }
       | c=term LEVEL "9" -> { (c,None) } ] ]
   ;
   atomic_constr:
@@ -440,7 +452,10 @@ GRAMMAR EXTEND Gram
         { CAst.make ~loc @@ CPatCstr (r, Some lp, []) } ]
     | "1" LEFTA
       [ c = pattern; "%"; key = IDENT ->
-        { CAst.make ~loc @@ CPatDelimiters (DelimUnboundedScope,key,c) }
+        { (* we'd like to use `scope_delimiter` here but that would break left factoring
+             with potential user defined notations
+             (e.g., `Reserved Notation "x %" (at level 1).` in CoLoR) *)
+          CAst.make ~loc @@ CPatDelimiters (DelimUnboundedScope,key,c) }
       | c = pattern; "%_"; key = IDENT ->
         { CAst.make ~loc @@ CPatDelimiters (DelimOnlyTmpScope,key,c) } ]
     | "0"

--- a/parsing/procq.ml
+++ b/parsing/procq.ml
@@ -370,6 +370,7 @@ module Constr =
     let record_declaration = Entry.make "record_declaration"
     let arg = Entry.make "arg"
     let type_cstr = Entry.make "type_cstr"
+    let scope_delimiter = Entry.make "scope_delimiter"
   end
 
 module Module =

--- a/parsing/procq.mli
+++ b/parsing/procq.mli
@@ -195,6 +195,7 @@ module Constr :
     val record_declaration : (Libnames.qualid * constr_expr) list Entry.t
     val arg : (constr_expr * explicitation CAst.t option) Entry.t
     val type_cstr : constr_expr Entry.t
+    val scope_delimiter : scope_delimiter Entry.t
   end
 
 module Module :

--- a/test-suite/bugs/bug_22324.v
+++ b/test-suite/bugs/bug_22324.v
@@ -1,0 +1,19 @@
+
+Definition fplus f g : nat -> nat := fun x => f x + g x.
+
+Infix "+" := fplus : function_scope.
+
+Check 0 + 0.
+
+Check (S + S)%function 0.
+
+Open Scope function_scope.
+
+Arguments fplus _ _ {x}.
+
+Check (S + S) (x:=(0+0)%nat).
+
+Check (S + S) (x:=0+0)%nat.
+
+(* previous command used to be parsed as the following: *)
+Fail Check ((S + S) (x:=0+0))%nat.

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -56,7 +56,6 @@ let record_field = Entry.make "record_field"
 let of_type = Entry.make "of_type"
 let of_type_inst = Entry.make "of_type_inst"
 let section_subset_expr = Entry.make "section_subset_expr"
-let scope_delimiter = Entry.make "scope_delimiter"
 let syntax_modifiers = Entry.make "syntax_modifiers"
 let goal_selector = Entry.make "goal_selector"
 let toplevel_selector = Entry.make "toplevel_selector"
@@ -869,7 +868,7 @@ END
 
 (* Extensions: implicits, coercions, etc. *)
 GRAMMAR EXTEND Gram
-  GLOBAL: gallina_ext hint_info scope_delimiter;
+  GLOBAL: gallina_ext hint_info;
 
   gallina_ext: TOP
     [ [ (* Transparent and Opaque *)
@@ -971,10 +970,6 @@ GRAMMAR EXTEND Gram
       | IDENT "clear"; IDENT "implicits"; IDENT "and"; IDENT "scopes" ->
           { [`ClearImplicits; `ClearScopes] }
       ] ]
-  ;
-  scope_delimiter:
-    [ [ "%"; key = IDENT -> { DelimUnboundedScope, key }
-      | "%_"; key = IDENT -> { DelimOnlyTmpScope, key } ] ]
   ;
   argument_spec: [
        [ b = OPT "!"; id = name ; s = LIST0 scope_delimiter ->

--- a/vernac/g_vernac.mli
+++ b/vernac/g_vernac.mli
@@ -48,8 +48,6 @@ val of_type_inst :
 
 val section_subset_expr : Vernacexpr.section_subset_expr Procq.Entry.t
 
-val scope_delimiter : Vernacexpr.scope_delimiter Procq.Entry.t
-
 val syntax_modifiers : Vernacexpr.syntax_modifier CAst.t list Procq.Entry.t
 
 val make_bullet : string -> Proof_bullet.t

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -20,8 +20,6 @@ type coercion_class = FunClass | SortClass | RefClass of qualid or_by_notation
 type goal_identifier = string
 type scope_name = string
 
-type scope_delimiter = delimiter_depth * scope_name
-
 type goal_reference =
   | OpenSubgoals
   | NthGoal of int


### PR DESCRIPTION
This also makes it stop relying on level tolerance.

Fix #22324

#### Overlay (to be merged in sync with the current PR)

* https://github.com/rocq-community/rocq-lsp/pull/1110