### PR TITLE
Move print-mod-uid to main rocq exe instead of rocq repl

### DIFF
--- a/doc/changelog/09-cli-tools/22359-printmoduid-Changed.rst
+++ b/doc/changelog/09-cli-tools/22359-printmoduid-Changed.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  moved `print-mod-uid` from `rocq repl` to just `rocq`, removing risk of interaction with other `rocq repl` flags.
+  `print-mod-uid` is an internal command used by `rocq makefile` when installing native compile data
+  (`#22359 <https://github.com/rocq-prover/rocq/pull/22359>`_,
+  by Gaëtan Gilbert).

--- a/ide/rocqide/idetop.ml
+++ b/ide/rocqide/idetop.ml
@@ -587,7 +587,6 @@ let loop ( { Coqtop.run_mode; color_mode },_) ~opts:_ state =
   match run_mode with
   | Coqtop.Batch -> exit 0
   | Coqtop.(Query PrintTags) -> Colors.print_style_tags color_mode; exit 0
-  | Coqtop.(Query _) -> Printf.eprintf "Unknown query"; exit 1
   | Coqtop.Interactive ->
   let open Vernac.State in
   set_doc state.doc;

--- a/lib/objFile.ml
+++ b/lib/objFile.ml
@@ -205,3 +205,17 @@ let close_out { out_channel = ch; out_segments = seg } =
   let () = output_int64 ch pos in
   let () = flush ch in
   close_out ch
+
+type summary_disk = {
+  md_name : string list;
+  md_deps : Obj.t;
+  md_ocaml : Obj.t;
+  md_info : Obj.t;
+} [@@warning "-unused-field"]
+
+let summary_seg : summary_disk id = make_id "summary"
+
+let library_name f =
+  let ch = with_magic_number_check (fun file -> open_in ~file) f in
+  let md, _ = marshal_in_segment ch ~segment: summary_seg in
+  md.md_name

--- a/lib/objFile.ml
+++ b/lib/objFile.ml
@@ -206,16 +206,22 @@ let close_out { out_channel = ch; out_segments = seg } =
   let () = flush ch in
   close_out ch
 
-type summary_disk = {
-  md_name : string list;
-  md_deps : Obj.t;
-  md_ocaml : Obj.t;
-  md_info : Obj.t;
-} [@@warning "-unused-field"]
+(** cf library.ml for real type *)
+type summary_disk
 
 let summary_seg : summary_disk id = make_id "summary"
+
+let rec assert_string_list v =
+  if Obj.is_int v then assert (Int.equal (Obj.magic v) 0)
+  else
+    let () = assert (Obj.tag v = 0 && Obj.size v = 2 && Obj.tag (Obj.field v 0) = Obj.string_tag) in
+    assert_string_list (Obj.field v 1)
 
 let library_name f =
   let ch = with_magic_number_check (fun file -> open_in ~file) f in
   let md, _ = marshal_in_segment ch ~segment: summary_seg in
-  md.md_name
+  let md = Obj.repr md in
+  assert (Obj.tag md = 0 && Obj.size md > 1);
+  let v = Obj.field (Obj.repr md) 0 in
+  assert_string_list v;
+  (Obj.magic v : string list)

--- a/lib/objFile.mli
+++ b/lib/objFile.mli
@@ -40,3 +40,7 @@ val marshal_out_binary : out_handle -> segment:'a id -> out_channel * (unit -> u
     [Stdlib.output_*] APIs should be used on [oc]. [stop ()] must be invoked in
     order to signal that all data was written to [oc] (which should not be used
     afterwards). Only after calling [stop] the other API can be used on [oh]. *)
+
+val library_name : string -> string list
+(** For a given .vo (or .vos) filename return the library name stored in the "summary" segment
+    (a dirpath, but we don't have access to Names.DirPath in this file) *)

--- a/test-suite/misc/coqtop_print-mod-uid.sh
+++ b/test-suite/misc/coqtop_print-mod-uid.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-export COQBIN=$BIN
-export PATH=$COQBIN:$PATH
-
-[ "$(rocq repl -print-mod-uid prerequisite/admit.vo)" = "prerequisite/.coq-native/NTestSuite_admit" ]

--- a/test-suite/misc/print-mod-uid.sh
+++ b/test-suite/misc/print-mod-uid.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+export COQBIN=$BIN
+export PATH=$COQBIN:$PATH
+
+[ "$(rocq print-mod-uid prerequisite/admit.vo)" = "prerequisite/.coq-native/NTestSuite_admit" ]

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -339,7 +339,7 @@ ALLSRCFILES := \
 # helpers
 vo_to_obj = $(addsuffix .o,\
   $(filter-out Warning: Error:,\
-  $(shell $(COQTOP) -q -noinit -batch -quiet -print-mod-uid $(1))))
+  $(shell $(COQBIN)rocq print-mod-uid $(1))))
 strip_dotslash = $(patsubst ./%,%,$(1))
 
 # without this we get undefined variables in the expansion for the

--- a/topbin/rocq.ml
+++ b/topbin/rocq.ml
@@ -26,6 +26,28 @@ let with_sibling_exe opts prog args =
   let argv = Array.of_list (prog :: args) in
   Rocqshim.exec_or_create_process prog argv
 
+let native_lib_name f =
+  let dp = ObjFile.library_name f in
+  let dp = List.rev_map Unicode.ascii_of_ident dp in
+  "N" ^ (String.concat "_" dp)
+
+let fix_windows_dirsep s =
+  if Sys.win32 then Str.(global_replace (regexp "\\(.\\)\\") "\\1/" s)
+  else s
+
+let get_native_name f =
+  (* deliberately ignore even critical errors *)
+  try
+    fix_windows_dirsep @@
+    Filename.(List.fold_left concat (dirname f)
+      [ ".coq-native"
+      ; native_lib_name f
+      ])
+  with _ -> ""
+
+let print_mod_uid args =
+  print_endline (String.concat " " (List.map get_native_name args))
+
 type subcommand =
   | Compile
   | Repl
@@ -42,6 +64,7 @@ type subcommand =
   | Tex
   | Makefile
   | Timelog2Html
+  | PrintModUid
 
 let subcommands = [
   ("compile", "Compile a Rocq source file", Compile);
@@ -63,6 +86,7 @@ let subcommands = [
   ("tex", "Process Rocq code in a Latex document", Tex);
   ("makefile", "Generate a Makefile to compile a Rocq project", Makefile);
   ("timelog2html", "Combine timing information and a Rocq source file", Timelog2Html);
+  ("print-mod-uid", "Print the native-compile name of the library in a .vo file (internal)", PrintModUid);
 ]
 
 let print_usage fmt () =
@@ -103,6 +127,7 @@ let run_subcommand opts args = function
   | Tex -> Rocqtex.main ~prog:(Sys.argv.(0) ^ " tex") args
   | Makefile -> Rocqmakefile.main ~prog:[Sys.argv.(0); "makefile"] args
   | Timelog2Html -> with_worker_gen opts ~package:"rocq-devtools" "timelog2html" args
+  | PrintModUid -> print_mod_uid args
 
 let () =
   if Array.length Sys.argv < 2 then error_usage ();

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -107,7 +107,7 @@ let ltac_debug_parse () =
   | Ok act -> act
   | Error error -> ltac_debug_answer (Answer.Output (str error)); Action.Failed
 
-type query = PrintTags | PrintModUid of string list
+type query = PrintTags
 type run_mode = Interactive | Batch | Query of query
 
 type toplevel_options = {
@@ -152,7 +152,6 @@ let coqtop_parse_extra opts extras =
   let rec parse_extra run_mode  = function
   | "-batch" :: rest -> parse_extra Batch  rest
   | "-list-tags" :: rest -> Query PrintTags, []
-  | "-print-mod-uid" :: rest -> Query (PrintModUid rest), []
   |   x :: rest ->
     let run_mode, rest = parse_extra run_mode rest in run_mode, x :: rest
   | [] -> run_mode, [] in
@@ -161,28 +160,10 @@ let coqtop_parse_extra opts extras =
   let async_opts, extras = Stmargs.parse_args opts extras in
   ({ run_mode; color_mode}, async_opts), extras
 
-let fix_windows_dirsep s =
-  if Sys.win32 then Str.(global_replace (regexp "\\(.\\)\\") "\\1/" s)
-  else s
-
-let get_native_name s =
-  (* We ignore even critical errors because this mode has to be super silent *)
-  try
-    fix_windows_dirsep @@
-    Filename.(List.fold_left concat (dirname s)
-                [ !Nativelib.output_dir
-                ; Library.native_name_from_filename s
-                ])
-  with _ -> ""
-
 let coqtop_run ({ run_mode; color_mode },_) ~opts state =
   match run_mode with
   | Interactive -> Coqloop.run ~opts ~state;
   | Query PrintTags -> Colors.print_style_tags color_mode; exit 0
-  | Query (PrintModUid sl) ->
-      let s = String.concat " " (List.map get_native_name sl) in
-      print_endline s;
-      exit 0
   | Batch -> exit 0
 
 let coqtop_specific_usage = Boot.Usage.{

--- a/toplevel/coqtop.mli
+++ b/toplevel/coqtop.mli
@@ -37,7 +37,7 @@ val init_toploop : Coqargs.t -> Stm.AsyncOpts.stm_opt -> Coqargs.injection_comma
 
 (** The specific characterization of the coqtop_toplevel *)
 
-type query = PrintTags | PrintModUid of string list
+type query = PrintTags
 type run_mode = Interactive | Batch | Query of query
 
 type toplevel_options = {

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -349,11 +349,6 @@ let rec_intern_library ~intern libs (loc, dir) =
   Library_info.warn_library_info m.library_name m.library_info;
   libs
 
-let native_name_from_filename f =
-  let ch = raw_intern_library f in
-  let lmd, digest_lmd = ObjFile.marshal_in_segment ch ~segment:summary_seg in
-  Nativecode.mod_uid_of_dirpath lmd.md_name
-
 (**********************************************************************)
 (*s [require_library] loads and possibly opens a library. This is a
     synchronized operation. It is performed as follows:

--- a/vernac/library.mli
+++ b/vernac/library.mli
@@ -75,9 +75,6 @@ val loaded_libraries : unit -> DirPath.t list
 
 val library_compiled : DirPath.t -> Safe_typing.compiled_library
 
-(** {6 Native compiler. } *)
-val native_name_from_filename : string -> string
-
 (** {6 Opaque accessors} *)
 val indirect_accessor : Global.indirect_accessor
 [@@deprecated


### PR DESCRIPTION
This avoids having to deal with random initializations, needing -q, and whatever else rocq repl involves.

AFAICT -print-mod-uid is an internal flag used only by rocq makefile (for installing native files).

rocq makefile does not support -native-output-dir AFAICT so we hardcode .coq-native.
