### PR TITLE
checker: accept all 12 caml_prim constructors in VM data validation

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -367,7 +367,8 @@ let v_vm_reloc_table = v_array (v_pair v_int v_int)
 
 let v_vm_annot_switch = v_tuple "vm_annot_switch" [|v_vm_reloc_table; v_bool; v_int|]
 
-let v_vm_caml_prim = v_enum "vm_caml_prim" 6
+let v_vm_caml_prim = v_enum "vm_caml_prim" 12
+(* Number of constructors of the caml_prim type in "kernel/vmbytecodes.ml" *)
 
 let v_non_subst_reloc = v_sum "vm_non_subst_reloc" 0 [|
   [|v_sort|];

--- a/doc/changelog/09-cli-tools/22361-fix-vm-caml-prim-arity-Fixed.rst
+++ b/doc/changelog/09-cli-tools/22361-fix-vm-caml-prim-arity-Fixed.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  ``rocqchk -bytecode-compiler yes`` no longer refuses to load files that use
+  primitive strings; the VM data validator accepted only the six array
+  primitives, so the bytecode of any string primitive failed to intern
+  (`#22361 <https://github.com/rocq-prover/rocq/pull/22361>`_,
+  fixes `#22360 <https://github.com/rocq-prover/rocq/issues/22360>`_,
+  by Jason Gross).

--- a/test-suite/coqchk/bug_22360.v
+++ b/test-suite/coqchk/bug_22360.v
@@ -1,0 +1,12 @@
+(* -*- coqchk-prog-args: ("-bytecode-compiler" "yes") -*- *)
+
+Require Import PrimString.
+
+Open Scope pstring_scope.
+
+(* The VM data validator capped caml_prim at its 6 array primitives, so the
+   bytecode of any string primitive failed to intern. A string literal alone
+   does not exercise this; the primitives have to be applied. *)
+Definition greeting := PrimString.cat "hello, " "world".
+Definition len := PrimString.length greeting.
+Definition cmp := PrimString.compare greeting "".


### PR DESCRIPTION
`checker/values.ml` capped `vm_caml_prim` at 6, the number of `caml_prim` constructors when the VM data validator was added in 09336f2ac0. 15c0443676 ("Add a primitive string type") grew the type to 12 by appending the six string primitives; it updated `v_primitive` (55 → 63), `v_prim_type` (3 → 4) and the `String` cases of `v_constr`/`v_hpattern`, but left `v_vm_caml_prim` alone.

The result is that `rocqchk -bytecode-compiler yes` fails to intern any `.vo` whose VM data references a string primitive — including `Corelib.Strings.PrimString` itself:

```
Fatal Error: Failure: Validation failed: bad constant constructor 11 (in vm_caml_prim).
```

With the arity corrected, all 67 Corelib libraries check with `-bytecode-compiler yes`.

`test-suite/coqchk/bug_22360.v` applies `PrimString.cat`, `length` and `compare`; that file fails to intern before the fix (`bad constant constructor 10`) and checks cleanly after. A string literal alone does not reach this path, which is why the existing `bugs/bug_19455.v` did not catch it.

Fixes #22360.

---

Opened autonomously by Claude (Opus 5) on behalf of Jason Gross (jason@theorem.dev).

