### PR TITLE
checker: validate every library named on the rocqchk command line

### DIFF
--- a/checker/checkLibrary.ml
+++ b/checker/checkLibrary.ml
@@ -340,8 +340,11 @@ let library_seg : library_disk ObjFile.id = ObjFile.make_id "library"
 let opaques_seg : seg_proofs ObjFile.id = ObjFile.make_id "opaques"
 let vm_seg = Vmlibrary.vm_segment
 
-let intern_from_file ~intern_mode ~enable_VM (dir, f) =
-  let validate = intern_mode <> Dep in
+(* [validated] is the set of libraries which must be validated when read even
+   if they are interned as a dependency, namely those named on the command
+   line and not admitted. *)
+let intern_from_file ~intern_mode ~validated ~enable_VM (dir, f) =
+  let validate = intern_mode <> Dep || LibrarySet.mem dir validated in
   Flags.if_verbose chk_pp (str"[intern "++str f++str" ...");
   let (sd,md,table,vmlib,digest) =
     try
@@ -377,15 +380,15 @@ let intern_from_file ~intern_mode ~enable_VM (dir, f) =
   opaque_tables := LibraryMap.add sd.md_name table !opaque_tables;
   mk_library sd md f table digest (Vmlibrary.inject vmlib)
 
-let intern_from_file ~intern_mode ~enable_VM dirf : library_t =
+let intern_from_file ~intern_mode ~validated ~enable_VM dirf : library_t =
   NewProfile.profile "intern_from_file"
     ~args:(fun () -> [("name", `String (DirPath.to_string (fst dirf)))])
-    (fun () -> intern_from_file ~intern_mode ~enable_VM dirf)
+    (fun () -> intern_from_file ~intern_mode ~validated ~enable_VM dirf)
     ()
 
 (* Read a compiled library and all dependencies, in reverse order.
    Do not include files that are already in the context. *)
-let rec intern_library ~intern_mode ~enable_VM seen (dir, f) needed =
+let rec intern_library ~intern_mode ~validated ~enable_VM seen (dir, f) needed =
   if LibrarySet.mem dir seen then failwith "Recursive dependencies!";
   (* Look if in the current logical environment *)
   try let _ = find_library dir in needed
@@ -394,13 +397,13 @@ let rec intern_library ~intern_mode ~enable_VM seen (dir, f) needed =
   if List.mem_assoc_f DirPath.equal dir needed then needed
   else
     (* [dir] is an absolute name which matches [f] which must be in loadpath *)
-    let m = intern_from_file ~intern_mode ~enable_VM (dir,f) in
+    let m = intern_from_file ~intern_mode ~validated ~enable_VM (dir,f) in
     let seen' = LibrarySet.add dir seen in
     let deps =
       Array.map (fun (d,_) -> try_locate_absolute_library d) m.library_deps
     in
     let intern_mode = match intern_mode with Rec -> Rec | Root | Dep -> Dep in
-    (dir,m) :: Array.fold_right (intern_library ~intern_mode ~enable_VM seen') deps needed
+    (dir,m) :: Array.fold_right (intern_library ~intern_mode ~validated ~enable_VM seen') deps needed
 
 (* Compute the reflexive transitive dependency closure *)
 let rec fold_deps seen ff (dir,f) (s,acc) =
@@ -428,8 +431,17 @@ let recheck_library senv ~norec ~admit ~check =
   let ml = List.map try_locate_qualified_library check in
   let nrl = List.map try_locate_qualified_library norec in
   let al =  List.map try_locate_qualified_library admit in
-  let needed = List.fold_right (intern_library ~intern_mode:Rec ~enable_VM LibrarySet.empty) ml [] in
-  let needed = List.fold_right (intern_library ~intern_mode:Root ~enable_VM LibrarySet.empty) nrl needed in
+  (* A library named on the command line may also be a dependency of another
+     one, in which case it may happen to be interned in [Dep] mode, which does
+     not validate the marshalled data. Force its validation, unless it was
+     admitted. *)
+  let validated =
+    let fold f l s = List.fold_right (fun (dir, _) s -> f dir s) l s in
+    fold LibrarySet.remove al
+      (fold LibrarySet.add nrl (fold LibrarySet.add ml LibrarySet.empty))
+  in
+  let needed = List.fold_right (intern_library ~intern_mode:Rec ~validated ~enable_VM LibrarySet.empty) ml [] in
+  let needed = List.fold_right (intern_library ~intern_mode:Root ~validated ~enable_VM LibrarySet.empty) nrl needed in
   let needed = List.rev needed in
   (* first compute the closure of norec, remove closure of check,
      add closure of admit, and finally remove norec and check *)

--- a/doc/changelog/09-cli-tools/22363-fix-norec-validation-order-Fixed.rst
+++ b/doc/changelog/09-cli-tools/22363-fix-norec-validation-order-Fixed.rst
@@ -1,0 +1,8 @@
+- **Fixed:**
+  ``rocqchk`` now validates the marshalled data of every library named on the
+  command line, whatever the order of the ``-norec`` arguments; a library that
+  happened to be interned first as a dependency of another explicitly named one
+  was read without validation and without checking its recorded checksums
+  (`#22363 <https://github.com/rocq-prover/rocq/pull/22363>`_,
+  fixes `#22362 <https://github.com/rocq-prover/rocq/issues/22362>`_,
+  by Jason Gross).

--- a/test-suite/misc/norec-validation-order.sh
+++ b/test-suite/misc/norec-validation-order.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# A library named explicitly on the rocqchk command line must be validated when
+# it is read, whatever the order of the -norec arguments. See #22362.
+
+set -e
+
+D=misc/norec-validation-order
+
+rm -f "$D"/*.vo "$D"/*.vok "$D"/*.vos "$D"/*.glob "$D"/out.log
+
+$coqc -R "$D" NorecOrder "$D/B.v"
+$coqc -R "$D" NorecOrder "$D/A.v"
+
+# Invalidate the checksum recorded for the "library" segment of B.vo. The
+# marshalled data itself is untouched, so reading B.vo without validation still
+# succeeds; validating it reports a corrupted file.
+ocaml "$D/corrupt.ml" "$D/B.vo" library
+
+# NorecOrder.B is a dependency of NorecOrder.A, so in one of the two orders
+# below it used to be interned as a dependency and read without validation.
+for args in "-norec NorecOrder.A -norec NorecOrder.B" \
+            "-norec NorecOrder.B -norec NorecOrder.A"; do
+  if "$BIN"rocqchk -R "$D" NorecOrder $args > "$D/out.log" 2>&1; then
+    echo "rocqchk succeeded on a corrupted file with: $args"
+    cat "$D/out.log"
+    exit 1
+  fi
+  if ! grep -q "Corrupted file" "$D/out.log"; then
+    echo "unexpected rocqchk failure with: $args"
+    cat "$D/out.log"
+    exit 1
+  fi
+done
+
+# -admit is still the way to ask for a library to be taken on faith.
+"$BIN"rocqchk -R "$D" NorecOrder -norec NorecOrder.B -norec NorecOrder.A -admit NorecOrder.B

--- a/test-suite/misc/norec-validation-order/A.v
+++ b/test-suite/misc/norec-validation-order/A.v
@@ -1,0 +1,2 @@
+Require Import NorecOrder.B.
+Definition a := b.

--- a/test-suite/misc/norec-validation-order/B.v
+++ b/test-suite/misc/norec-validation-order/B.v
@@ -1,0 +1,1 @@
+Definition b := 1.

--- a/test-suite/misc/norec-validation-order/corrupt.ml
+++ b/test-suite/misc/norec-validation-order/corrupt.ml
@@ -1,0 +1,40 @@
+(* Flip one byte of the MD5 checksum stored after the data of a segment of a
+   .vo file. The marshalled data itself is left untouched, so that reading the
+   file without validation still succeeds. See lib/objFile.ml for the format. *)
+
+let input_int64 ch =
+  let rec go i accu =
+    if i = 0 then accu
+    else go (i - 1) (Int64.logor (Int64.shift_left accu 8) (Int64.of_int (input_byte ch)))
+  in
+  go 8 0L
+
+let () =
+  let file = Sys.argv.(1) in
+  let segment = Sys.argv.(2) in
+  let ch = open_in_bin file in
+  let () = seek_in ch 8 in
+  let summary_pos = input_int64 ch in
+  let () = LargeFile.seek_in ch summary_pos in
+  let n = input_binary_int ch in
+  let pos = ref None in
+  for _ = 1 to n do
+    let nlen = input_binary_int ch in
+    let name = really_input_string ch nlen in
+    let p = input_int64 ch in
+    let len = input_int64 ch in
+    let _hash = really_input_string ch 16 in
+    if String.equal name segment then pos := Some (Int64.add p len)
+  done;
+  close_in ch;
+  match !pos with
+  | None -> prerr_endline ("no segment " ^ segment ^ " in " ^ file); exit 1
+  | Some p ->
+    let ch = open_in_bin file in
+    let () = LargeFile.seek_in ch p in
+    let b = input_byte ch in
+    let () = close_in ch in
+    let ch = open_out_gen [Open_wronly; Open_binary] 0o644 file in
+    let () = LargeFile.seek_out ch p in
+    let () = output_byte ch (b lxor 1) in
+    close_out ch


### PR DESCRIPTION
Which modules `rocqchk` validates depended on the order in which the `-norec` arguments were given, and a module named explicitly on the command line could end up read with no validation at all. Reproducer and analysis in #22362.

`intern_from_file` computed `let validate = intern_mode <> Dep in`, and a dependency of a `-norec` root is interned in `Dep` mode. Since the first intern of a library wins (`List.mem_assoc_f DirPath.equal dir needed`) and the `-norec` roots are interned in reverse command line order (`List.fold_right`), a library named with `-norec` could be reached first as a dependency of another `-norec` argument and read by `System.marshal_in`, a bare `Marshal.from_channel` with neither `Validate.validate` nor a comparison of the segment digest against the one recorded in the segment table.

`recheck_library` now computes the set of libraries named on the command line, minus those named with `-admit`, and threads it down to `intern_from_file`, which validates a library if it is in that set even when it is interned as a dependency. Nothing else changes: which libraries get *checked* is untouched, dependencies that were not named on the command line are still read without validation, and `-admit` still means the file is taken on faith.

The test in `test-suite/misc/norec-validation-order.sh` builds two libraries, invalidates the checksum recorded for the `library` segment of the dependency (leaving the marshalled data itself intact, so that an unvalidated read still succeeds), and requires both argument orders to report `Corrupted file`. It fails on `master` in the order that reads the file raw.

Note that the reproducer in the issue rides on #22360, whose fix is pending in #22361; the test here does not depend on it.

Fixes #22362.

---

Opened autonomously by Claude (Opus 5) on behalf of Jason Gross (jason@theorem.dev).
