### PR TITLE
document further details of 'rocq makefile' -arg flag handling, improve single quote handling

### DIFF
--- a/doc/changelog/09-cli-tools/22369-makefile-arg-Changed.rst
+++ b/doc/changelog/09-cli-tools/22369-makefile-arg-Changed.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  Unpaired single quotes in ``-arg`` values are an error rather than
+  being silently closed as-if a matching quote was present at the end
+  (`#22369 <https://github.com/rocq-prover/rocq/pull/22369>`_,
+  by Ralf Jung).

--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -642,11 +642,19 @@ two arguments ``-w`` and ``all`` to `rocq compile`. If the argument to `rocq com
 use single-quotes inside the double-quotes. For example ``-arg "-set 'Default
 Goal Selector=!'"`` gets passed to `rocq compile` as the two arguments ``-set`` and ``Default Goal Selector=!``.
 
-But note, that single-quotes in a ``_RocqProject`` file are only special
-characters if they appear in the string following ``-arg``. And on their own
-they don't quote spaces. For example ``-arg 'foo bar'`` in ``_RocqProject`` is
-equivalent to ``-arg foo "bar'"`` (in ``_RocqProject`` notation). ``-arg "'foo
-bar'"`` behaves differently and passes the single argument ``foo bar`` to `rocq compile`.
+Unpaired single quotes are implicitly closed at the end of the string.
+There is currently no way to escape ``"`` or ``'``, so arguments with those characters cannot
+be passed to `rocq compile`.
+
+Note that single-quotes in a ``_RocqProject`` file are only special characters
+if they appear in the string following ``-arg``. And on their own they don't
+quote spaces. For example ``-arg 'foo bar'`` in ``_RocqProject`` is first split
+into ``-arg``, ``'foo``, ``bar'``. Then ``'foo`` is interpreted as the value for
+``-arg``. The unpaired single quote is implicitly closed at the end, so this
+ends up passing ``foo`` to `rocq compile`. Finally, ``bar'`` is the next token,
+and it is interpreted as a filename (like all strings in ``_RocqProject`` that
+are not flags). ``-arg "'foo bar'"`` behaves differently and passes the single
+argument ``foo bar`` to `rocq compile`.
 
 Forbidden filenames
 +++++++++++++++++++

--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -650,11 +650,11 @@ Note that single-quotes in a ``_RocqProject`` file are only special characters
 if they appear in the string following ``-arg``. And on their own they don't
 quote spaces. For example ``-arg 'foo bar'`` in ``_RocqProject`` is first split
 into ``-arg``, ``'foo``, ``bar'``. Then ``'foo`` is interpreted as the value for
-``-arg``. The unpaired single quote is implicitly closed at the end, so this
-ends up passing ``foo`` to `rocq compile`. Finally, ``bar'`` is the next token,
-and it is interpreted as a filename (like all strings in ``_RocqProject`` that
-are not flags). ``-arg "'foo bar'"`` behaves differently and passes the single
-argument ``foo bar`` to `rocq compile`.
+``-arg``. This leads to an error due to the unpaired single quote. If we could
+ignore the error, the next token ``bar'`` would be interpreted as a filename
+(like all strings in ``_RocqProject`` that are not flags). ``-arg "'foo bar'"``
+behaves differently and passes the single argument ``foo bar`` to `rocq
+compile`.
 
 Forbidden filenames
 +++++++++++++++++++

--- a/lib/coqProject_file.ml
+++ b/lib/coqProject_file.ml
@@ -194,6 +194,8 @@ let process_extra_args arg =
   String.iter process_char arg;
   if !has_leftovers then
     out_list := buffer buf :: !out_list;
+  if !inside_quotes then
+    raise (Parsing_error ("Invalid value for -arg, unpaired single quote: \"" ^ String.escaped arg ^ "\""));
   List.rev !out_list
 
 let expand_paths project =


### PR DESCRIPTION
Documents some of the things we discovered in #22322. Also adjusts unpaired handling of single quotes to emit an error rather than implicitly adding a closing single quote at the end.
Cc @SkySkimmer 