### PR TITLE
Use Grammar Extend for ltac2 constr grammar extensions

### DIFF
--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -3374,6 +3374,13 @@ q_assert: [
 | assertion      (* ltac2 plugin *)
 ]
 
+Procq.Constr.term0: [
+| "ltac2" ":" "(" ltac2_expr6 ")"      (* ltac2 plugin *)
+| test_ampersand_ident "&" Prim.ident      (* ltac2 plugin *)
+| test_dollar_ident_colon_ident "$" Prim.identref ":" Prim.identref      (* ltac2 plugin *)
+| test_dollar_ident "$" Prim.ident      (* ltac2 plugin *)
+]
+
 ltac2_entry: [
 | tac2def_val      (* ltac2 plugin *)
 | tac2def_typ      (* ltac2 plugin *)

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -2044,6 +2044,13 @@ q_assert: [
 | assertion      (* ltac2 plugin *)
 ]
 
+Procq.Constr.term0: [
+| "ltac2" ":" "(" ltac2_expr ")"      (* ltac2 plugin *)
+| test_ampersand_ident "&" ident      (* ltac2 plugin *)
+| test_dollar_ident_colon_ident "$" ident ":" ident      (* ltac2 plugin *)
+| test_dollar_ident "$" ident      (* ltac2 plugin *)
+]
+
 assertion: [
 | "(" ident_or_anti ":=" term ")"      (* ltac2 plugin *)
 | "(" ident_or_anti ":" term ")" OPT ltac2_by_tactic      (* ltac2 plugin *)

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -916,74 +916,21 @@ END
 
 (** Extension of constr syntax *)
 
-(*
 GRAMMAR EXTEND Gram
   Procq.Constr.term: LEVEL "0"
     [ [ IDENT "ltac2"; ":"; "("; tac = ltac2_expr; ")" ->
-      { let arg = Genarg.in_gen (Genarg.rawwit Tac2env.wit_ltac2_constr) tac in
-        CAst.make ~loc (CGenarg arg) }
+      { CAst.make ~loc (CGenarg (Raw (Tac2env.wit_ltac2_constr, tac))) }
       | test_ampersand_ident; "&"; id = Prim.ident ->
       { let tac = Tac2quote.of_exact_hyp ~loc (CAst.make ~loc id) in
-        let arg = Genarg.in_gen (Genarg.rawwit Tac2env.wit_ltac2_constr) tac in
-        CAst.make ~loc (CGenarg arg) }
+        CAst.make ~loc (CGenarg (Raw (Tac2env.wit_ltac2_constr, tac))) }
+      | test_dollar_ident_colon_ident; "$"; kind = Prim.identref; ":"; id = Prim.identref ->
+      { CAst.make ~loc (CGenarg (Raw (Tac2env.wit_ltac2_var_quotation, (Some kind, id)))) }
       | test_dollar_ident; "$"; id = Prim.ident ->
-      { let id = Loc.tag ~loc id in
-        let arg = Genarg.in_gen (Genarg.rawwit Tac2env.wit_ltac2_quotation) id in
-        CAst.make ~loc (CGenarg arg) }
+      { let id = CAst.make ~loc id in
+        CAst.make ~loc (CGenarg (Raw (Tac2env.wit_ltac2_var_quotation, (None, id)))) }
     ] ]
   ;
 END
-*)
-{
-
-let () =
-
-let open Tok in
-let (++) r s = Procq.Rule.next r s in
-let rules = [
-  Procq.(
-    Production.make
-      (Rule.stop ++ Symbol.nterm test_dollar_ident ++ Symbol.token (PKEYWORD "$") ++ Symbol.nterm Prim.ident)
-    begin fun id _ _ loc ->
-      let id = CAst.make ~loc id in
-      CAst.make ~loc (CGenarg (Raw (Tac2env.wit_ltac2_var_quotation, (None, id))))
-    end
-  );
-
-  Procq.(
-    Production.make
-      (Rule.stop ++ Symbol.nterm test_dollar_ident_colon_ident ++
-       Symbol.token (PKEYWORD "$") ++ Symbol.nterm Prim.identref ++
-       Symbol.token (PKEYWORD ":") ++ Symbol.nterm Prim.identref)
-    begin fun id _ kind _ _ loc ->
-      CAst.make ~loc (CGenarg (Raw (Tac2env.wit_ltac2_var_quotation, (Some kind, id))))
-    end
-  );
-
-  Procq.(
-    Production.make
-      (Rule.stop ++ Symbol.nterm test_ampersand_ident ++ Symbol.token (PKEYWORD "&") ++ Symbol.nterm Prim.ident)
-    begin fun id _ _ loc ->
-      let tac = Tac2quote.of_exact_hyp ~loc (CAst.make ~loc id) in
-      CAst.make ~loc (CGenarg (Raw (Tac2env.wit_ltac2_constr, tac)))
-    end
-  );
-
-  Procq.(
-    Production.make
-      (Rule.stop ++ Symbol.token (PIDENT (Exact "ltac2")) ++ Symbol.token (PKEYWORD ":") ++
-       Symbol.token (PKEYWORD "(") ++ Symbol.nterm ltac2_expr ++ Symbol.token (PKEYWORD ")"))
-    begin fun _ tac _ _ _ loc ->
-      CAst.make ~loc (CGenarg (Raw (Tac2env.wit_ltac2_constr, tac)))
-    end
-  )
-] in
-
-  Egramml.grammar_extend ~ignore_kw:false ~plugin_uid:("rocq-runtime.plugins.ltac2", "g_ltac2.mlg:adhoc1")
-    Procq.Constr.term (Procq.Reuse (Some"0", rules))
-
-
-}
 
 {
 


### PR DESCRIPTION
Looking at b06ed5af083e66ab33fbb8f77c8cce5e6b6ed2d3 "port to coqpp" which did the change, I think we stopped using the preprocessor because coqpp didn't support being used in the middle of a ocaml function
~~~
let () = Hook.set Tac2entries.register_constr_quotations begin fun () ->
GEXTEND Gram ...
~~~

However now coqpp handles delaying the grammar extension to make it backtrackable so we don't need any special handling.
