### PR TITLE
Abstract away the Summary reference type.

### DIFF
--- a/dev/ci/user-overlays/22372-ppedrot-summary-abstract-ref.sh
+++ b/dev/ci/user-overlays/22372-ppedrot-summary-abstract-ref.sh
@@ -1,0 +1,21 @@
+overlay simple_io https://github.com/ppedrot/rocq-simple-io summary-abstract-ref 22372
+
+overlay elpi https://github.com/ppedrot/coq-elpi summary-abstract-ref 22372
+
+overlay equations https://github.com/ppedrot/equations summary-abstract-ref 22372
+
+overlay lean_importer https://github.com/ppedrot/rocq-lean-import summary-abstract-ref 22372
+
+overlay ltac2_compiler https://github.com/ppedrot/rocq-ltac2-compiler summary-abstract-ref 22372
+
+overlay micromega https://github.com/ppedrot/micromega-plugin summary-abstract-ref 22372
+
+overlay paramcoq https://github.com/ppedrot/paramcoq summary-abstract-ref 22372
+
+overlay quickchick https://github.com/ppedrot/QuickChick summary-abstract-ref 22372
+
+overlay smtcoq https://github.com/ppedrot/smtcoq summary-abstract-ref 22372
+
+overlay tactician https://github.com/ppedrot/coq-tactician summary-abstract-ref 22372
+
+overlay waterproof https://github.com/ppedrot/coq-waterproof summary-abstract-ref 22372

--- a/doc/plugin_tutorial/tuto2/src/counter.ml
+++ b/doc/plugin_tutorial/tuto2/src/counter.ml
@@ -13,10 +13,12 @@ let counter = Summary.ref ~name:"counter" 0
  * We can increment our counter:
  *)
 let increment () =
+  let open Summary.Ref in
   counter := succ !counter
 
 (*
  * We can also read the value of our counter:
  *)
 let value () =
+  let open Summary.Ref in
   !counter

--- a/doc/plugin_tutorial/tuto2/src/persistent_counter.ml
+++ b/doc/plugin_tutorial/tuto2/src/persistent_counter.ml
@@ -15,6 +15,7 @@ let counter = Summary.ref ~name:"persistent_counter" 0
  * saves the value that is passed to it into the reference we have just defined:
  *)
 let cache_count v =
+  let open Summary.Ref in
   counter := v
 
 (*
@@ -44,6 +45,7 @@ let declare_counter : int -> Libobject.obj =
  * Incrementing our counter looks almost identical:
  *)
 let increment () =
+  let open Summary.Ref in
   Lib.add_leaf (declare_counter (succ !counter))
 (*
  * except that we must call our declare_counter function to get a persistent
@@ -54,4 +56,5 @@ let increment () =
  * Reading a value does not change at all:
  *)
 let value () =
+  let open Summary.Ref in
   !counter

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -149,7 +149,10 @@ let meta_counter_summary_name = "meta counter"
 let meta_ctr, meta_counter_summary_tag =
   Summary.ref_tag 0 ~name:meta_counter_summary_name
 
-let new_meta () = incr meta_ctr; !meta_ctr
+let new_meta () =
+  let open Summary.Ref in
+  meta_ctr := !meta_ctr + 1;
+  !meta_ctr
 
 (* The list of non-instantiated existential declarations (order is important) *)
 

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -708,7 +708,9 @@ let evar_counter_summary_name = "evar counter"
 
 (* Generator of existential names *)
 let evar_ctr, evar_counter_summary_tag = Summary.ref_tag 0 ~name:evar_counter_summary_name
-let new_untyped_evar () = incr evar_ctr; Evar.unsafe_of_int !evar_ctr
+let new_untyped_evar () =
+  let open Summary.Ref in
+  evar_ctr := !evar_ctr + 1; Evar.unsafe_of_int !evar_ctr
 
 let default_source = Loc.tag @@ Evar_kinds.InternalHole
 

--- a/engine/profile_tactic.ml
+++ b/engine/profile_tactic.ml
@@ -72,7 +72,7 @@ let empty_treenode name = {
 let root = "root"
 
 
-let stack = Summary.ref ~name:"LtacProf-stack" ~local:true [empty_treenode root]
+let stack = Summary.local_ref ~name:"LtacProf-stack" [empty_treenode root]
 
 let reset_profile_tmp () = stack := [empty_treenode root]
 

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -41,6 +41,7 @@ end
 let template_default_univs = Summary.ref ~name:"template default univs" Univ.Level.Set.empty
 
 let cache_template_default_univs us =
+  let open Summary.Ref in
   template_default_univs := Univ.Level.Set.union !template_default_univs us
 
 let template_default_univs_obj =
@@ -59,7 +60,9 @@ let add_template_default_univs env kn =
     let _, us = UVars.Instance.levels template.template_defaults in
     Lib.add_leaf (template_default_univs_obj us)
 
-let template_default_univs () = !template_default_univs
+let template_default_univs () =
+  let open Summary.Ref in
+  !template_default_univs
 
 module UnivFlex = UnivFlex
 

--- a/interp/abbreviation.ml
+++ b/interp/abbreviation.ml
@@ -36,15 +36,19 @@ let abbrev_table =
   Summary.ref (KerName.Map.empty : data KerName.Map.t) ~name:"ABBREVIATIONS"
 
 let add kn fpa =
+  let open Summary.Ref in
   abbrev_table := KerName.Map.add kn fpa !abbrev_table
 
 let fold f acc =
+  let open Summary.Ref in
   KerName.Map.fold f !abbrev_table acc
 
 let find_opt k =
+  let open Summary.Ref in
   KerName.Map.find_opt k !abbrev_table
 
 let toggle_aux ~on ~use k (sp, data) =
+  let open Summary.Ref in
   if data.abbrev_activated != on then begin
     abbrev_table := KerName.Map.add k (sp, {data with abbrev_activated = on}) !abbrev_table;
     match use with
@@ -57,6 +61,7 @@ let toggle_aux ~on ~use k (sp, data) =
   end
 
 let toggle ~on ~use k =
+  let open Summary.Ref in
   toggle_aux ~on ~use k (KerName.Map.find k !abbrev_table)
 
 let toggle_if ~on ~use filter =
@@ -98,6 +103,7 @@ let open_abbreviation i ((sp,kn),abbrev) =
   end
 
 let import i sp kn =
+  let open Summary.Ref in
   let _,abbrev = KerName.Map.get kn !abbrev_table in
   open_abbreviation i ((sp,kn),abbrev)
 
@@ -134,5 +140,6 @@ let declare ~local user_warns id ~onlyparsing pat =
 
 (* Remark: do not check for activation (if not activated, it is already not supposed to be located) *)
 let find_interp kn =
+  let open Summary.Ref in
   let _,abbrev = KerName.Map.find kn !abbrev_table in
   abbrev.abbrev_pattern

--- a/interp/decls.ml
+++ b/interp/decls.ml
@@ -69,8 +69,11 @@ type variable_data = {
 let vartab =
   Summary.ref (Id.Map.empty : (variable_data*DirPath.t) Id.Map.t) ~name:"VARIABLE"
 
+open Summary.Ref
+
 let secpath () = Lib.current_dirpath true
-let add_variable_data id o = vartab := Id.Map.add id (o,secpath()) !vartab
+let add_variable_data id o =
+vartab := Id.Map.add id (o,secpath()) !vartab
 
 let variable_opacity id = let {opaque},_ = Id.Map.find id !vartab in opaque
 let variable_kind id = let {kind},_ = Id.Map.find id !vartab in kind

--- a/interp/dumpglob.ml
+++ b/interp/dumpglob.ml
@@ -133,8 +133,12 @@ let type_of_logical_kind = function
 (** Data associated to global parameters and constants *)
 
 let csttab = Summary.ref (Names.Cmap_env.empty : logical_kind Names.Cmap_env.t) ~name:"CONSTANT"
-let add_constant_kind env kn k = csttab := Names.Cmap_env.add kn k !csttab
-let constant_kind env kn = Names.Cmap_env.find kn !csttab
+let add_constant_kind env kn k =
+  let open Summary.Ref in
+  csttab := Names.Cmap_env.add kn k !csttab
+let constant_kind env kn =
+  let open Summary.Ref in
+  Names.Cmap_env.find kn !csttab
 
 let type_of_global_ref gr =
   if Typeclasses.is_class (Global.env ()) gr then

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -532,6 +532,7 @@ module GlobRefMap = Environ.QGlobRef.Map
 let implicits_table = Summary.ref GlobRefMap.empty ~name:"implicits"
 
 let implicits_of_global ref =
+  let open Summary.Ref in
   try
     let env = Global.env () in
     let l = GlobRefMap.find env ref !implicits_table in
@@ -549,6 +550,7 @@ let implicits_of_global ref =
   with Not_found -> [DefaultImpArgs,[]]
 
 let cache_implicits_decl (ref, imps) =
+  let open Summary.Ref in
   implicits_table := GlobRefMap.add (Global.env ()) ref imps !implicits_table
 
 let load_implicits _ (_,l) = List.iter cache_implicits_decl l
@@ -568,6 +570,7 @@ let sec_implicits =
   Summary.ref Id.Map.empty ~name:"section-implicits"
 
 let impls_of_context vars =
+  let open Summary.Ref in
   let map n id =
     let impl_pos = (Name id, n, None) in
     match Id.Map.get id !sec_implicits with
@@ -679,6 +682,7 @@ let declare_implicits local ref =
 
 let declare_var_implicits id ~impl =
   let flags = !implicit_args in
+  let open Summary.Ref in
   sec_implicits := Id.Map.add id impl !sec_implicits;
   declare_implicits_gen ImplLocal flags (GlobRef.VarRef id)
 

--- a/interp/implicit_quantifiers.ml
+++ b/interp/implicit_quantifiers.ml
@@ -45,9 +45,11 @@ let add_generalizable gen table =
       table l
 
 let cache_generalizable_type (local,cmd) =
+  let open Summary.Ref in
   generalizable_table := add_generalizable cmd !generalizable_table
 
 let load_generalizable_type _ (local,cmd) =
+  let open Summary.Ref in
   generalizable_table := add_generalizable cmd !generalizable_table
 
 let in_generalizable : bool * lident list option -> obj =
@@ -60,7 +62,9 @@ let in_generalizable : bool * lident list option -> obj =
 let declare_generalizable ~local gen =
  Lib.add_leaf (in_generalizable (local, gen))
 
-let find_generalizable_ident id = Id.Pred.mem (root_of_id id) !generalizable_table
+let find_generalizable_ident id =
+  let open Summary.Ref in
+  Id.Pred.mem (root_of_id id) !generalizable_table
 
 let is_global id =
   try ignore (Nametab.locate_extended (qualid_of_ident id)); true

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -268,6 +268,7 @@ let entry_relative_level_le child = function
 let notation_level_map = Summary.ref ~stage:Summary.Stage.Synterp ~name:"notation_level_map" NotationMap.empty
 
 let declare_notation_level ntn level =
+  let open Summary.Ref in
   if NotationMap.mem ntn !notation_level_map then
     anomaly (str "Notation " ++ pr_notation ntn ++ str " is already assigned a level.");
   notation_level_map := NotationMap.add ntn level !notation_level_map
@@ -1222,6 +1223,7 @@ let is_prim_token_constant_in_constr (entry, symbs) =
   | _ -> false
 
 let level_of_notation ntn =
+  let open Summary.Ref in
   if is_prim_token_constant_in_constr (decompose_notation_key ntn) then
     (* A primitive notation *)
     ({ notation_entry = fst ntn; notation_level = 0}, []) (* TODO: string notations*)
@@ -1583,6 +1585,7 @@ let pr_id_infos (id, ((level,(tmp_scopes, scopes)), under_binders, kind)) =
 let notation_gram_locs = Summary.ref ~stage:Synterp ~name:"ntn-gram-locs" NotationMap.empty
 
 let declare_ntn_gram_loc ntn (loc : Loc.t option) =
+  let open Summary.Ref in
   match loc with
   | None -> ()
   | Some loc ->
@@ -1593,6 +1596,7 @@ let declare_ntn_gram_loc ntn (loc : Loc.t option) =
         !notation_gram_locs
 
 let get_ntn_gram_locs ntn decl_loc =
+  let open Summary.Ref in
   let list = NotationMap.find ntn !notation_gram_locs in
   (match decl_loc with
      None -> list

--- a/interp/notationextern.ml
+++ b/interp/notationextern.ml
@@ -274,27 +274,34 @@ let notation_constr_key = function (* Rem: NApp(NRef ref,[]) stands for @ref *)
   | _ -> Oth, NotAppNotation
 
 let uninterp_notations env c =
+  let open Summary.Ref in
   List.map_append (fun key -> keymap_find env key !notations_key_table)
     (glob_constr_keys c)
 
 let uninterp_cases_pattern_notations env c =
+  let open Summary.Ref in
   keymap_find env (cases_pattern_key c) !notations_key_table
 
 let uninterp_ind_pattern_notations env ind =
+  let open Summary.Ref in
   keymap_find env (RefKey (canonical_gr (GlobRef.IndRef ind))) !notations_key_table
 
 let remove_uninterpretation env rule (metas,c as pat) =
+  let open Summary.Ref in
   let (key,n) = notation_constr_key c in
   notations_key_table := keymap_remove env key { not_rule = rule; not_patt = pat; not_status = n } !notations_key_table
 
 let declare_uninterpretation env rule (metas,c as pat) =
+  let open Summary.Ref in
   let (key,n) = notation_constr_key c in
   notations_key_table := keymap_add env key { not_rule = rule; not_patt = pat; not_status = n } !notations_key_table
 
 let freeze () =
+  let open Summary.Ref in
   !notations_key_table
 
 let unfreeze fkm =
+  let open Summary.Ref in
   notations_key_table := fkm
 
 let with_notation_uninterpretation_protection f x =

--- a/interp/reserve.ml
+++ b/interp/reserve.ml
@@ -85,11 +85,13 @@ let notation_constr_key env = function (* Rem: NApp(NRef ref,[]) stands for @ref
   | _ -> Oth, None
 
 let add_reserved_type env (id,t) =
+  let open Summary.Ref in
   let key = fst (notation_constr_key env t) in
   reserve_table := Id.Map.add id t !reserve_table;
   reserve_revtable := keymap_add env key (id, t) !reserve_revtable
 
 let declare_reserved_type_binding env {CAst.loc;v=id} t =
+  let open Summary.Ref in
   if not (Id.equal id (root_of_id id)) then
     user_err ?loc
       ((Id.print id ++ str
@@ -105,13 +107,16 @@ let declare_reserved_type idl t =
   let env = Global.env () in
   List.iter (fun id -> declare_reserved_type_binding env id t) (List.rev idl)
 
-let find_reserved_type id = Id.Map.find (root_of_id id) !reserve_table
+let find_reserved_type id =
+  let open Summary.Ref in
+  Id.Map.find (root_of_id id) !reserve_table
 
 let constr_key env evd c =
   try mkRefKey env (fst @@ EConstr.destRef evd (fst (EConstr.decompose_app evd c)))
   with Constr.DestKO -> Oth
 
 let revert_reserved_type env evd t =
+  let open Summary.Ref in
   try
     let reserved = KeyMap.find (constr_key env evd t) !reserve_revtable in
     let t = Detyping.detype Detyping.Now ~flags:(PrintingFlags.Detype.current()) env evd t in

--- a/library/global.ml
+++ b/library/global.ml
@@ -29,19 +29,19 @@ let global_env, global_env_summary_tag =
   Summary.ref_tag ~name:global_env_summary_name Safe_typing.empty_environment
 
 let is_joined_environment () =
-  Safe_typing.is_joined_environment !global_env
+  Safe_typing.is_joined_environment (Summary.Ref.get global_env)
 
 let is_curmod_library () =
-  Safe_typing.is_curmod_library !global_env
+  Safe_typing.is_curmod_library (Summary.Ref.get global_env)
 
 let assert_not_synterp () =
   if !Flags.in_synterp_phase = Some true then
     CErrors.anomaly (
       Pp.strbrk"The global environment cannot be accessed during the syntactic interpretation phase.")
 
-let safe_env () = assert_not_synterp(); !global_env
+let safe_env () = assert_not_synterp(); Summary.Ref.get global_env
 
-let set_safe_env e = global_env := e
+let set_safe_env e = Summary.Ref.set global_env e
 
 end
 

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -125,6 +125,7 @@ module MakeTable =
             ++ strbrk ") is already used.")
 
     module MySet = A.Set
+    open Summary.Ref
 
     let t = Summary.ref ~stage:Interp MySet.empty ~name:nick
 
@@ -169,7 +170,9 @@ module MakeTable =
        print = (fun () -> print_table A.title A.printer !t);
      }
 
-    let () = tables := (nick, table_of_A)::!tables
+    let () =
+      let open Stdlib in
+      tables := (nick, table_of_A)::!tables
 
     let v () = !t
     let active x = A.Set.mem x !t

--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -581,6 +581,8 @@ module MakeImperative (Tab:Functional_NAMETAB) (SI:StateInfo) ()
 = struct
   type elt = Tab.elt
 
+  open Summary.Ref
+
   let the_tab = Summary.ref ~stage:SI.stage ~name:SI.summary_name Tab.empty
 
   let push vis sp v = the_tab := Tab.push vis sp v !the_tab
@@ -625,6 +627,8 @@ module MakeWarned (M:NAMETAB)
     : WarnedTab with type elt = M.elt and type warning_data := W.data
 = struct
   include M
+
+  open Summary.Ref
 
   let warntab = Summary.ref ~stage:W.stage ~name:W.summary_name W.Map.empty
 
@@ -947,8 +951,9 @@ let exists_universe = Univs.exists
 (* Source locations *)
 
 open Globnames
+open Summary.Ref
 
-let cci_loc_table : Loc.t ExtRefMap.t ref = Summary.ref ~name:"constant-loc-table" ExtRefMap.empty
+let cci_loc_table : Loc.t ExtRefMap.t Summary.Ref.t = Summary.ref ~name:"constant-loc-table" ExtRefMap.empty
 
 let set_cci_src_loc kn loc = cci_loc_table := ExtRefMap.add kn loc !cci_loc_table
 

--- a/library/rocqlib.ml
+++ b/library/rocqlib.ml
@@ -10,6 +10,7 @@
 
 open Util
 open Names
+open Summary.Ref
 
 let make_dir l = DirPath.make (List.rev_map Id.of_string l)
 
@@ -22,7 +23,7 @@ let init_dir = [ rocq; "Init"]
 
 let jmeq_module_name = ["Stdlib";"Logic";"JMeq"]
 
-let table : GlobRef.t CString.Map.t ref =
+let table : GlobRef.t CString.Map.t Summary.Ref.t =
   Summary.ref ~name:"rocqlib_registered" CString.Map.empty
 
 let get_lib_refs () =

--- a/library/summary.ml
+++ b/library/summary.ml
@@ -199,6 +199,15 @@ let nop () = ()
 
 (** All-in-one reference declaration + registration *)
 
+module Ref =
+struct
+  type 'a t = 'a ref
+  let get = (!)
+  let set = (:=)
+  let (!) = get
+  let (:=) = set
+end
+
 let ref_tag ?(stage=Stage.Interp) ~name x =
   let r = ref x in
   let tag = declare_summary_tag name
@@ -208,18 +217,19 @@ let ref_tag ?(stage=Stage.Interp) ~name x =
       init_function = (fun () -> r := x) } in
   r, tag
 
-let ref ?(stage=Stage.Interp) ?(local=false) ~name x =
-  if not local then fst @@ ref_tag ~stage ~name x
-  else
-    let r = ref x in
-    let () = declare_summary name
-        ~make_marshallable:(fun _ -> None)
-        { stage;
-          freeze_function = (fun () -> Some !r);
-          unfreeze_function = (function Some v -> r := v | None -> r := x);
-          init_function = (fun () -> r := x); }
-    in
-    r
+let local_ref ?(stage=Stage.Interp) ~name x =
+  let r = ref x in
+  let () = declare_summary name
+      ~make_marshallable:(fun _ -> None)
+      { stage;
+        freeze_function = (fun () -> Some !r);
+        unfreeze_function = (function Some v -> r := v | None -> r := x);
+        init_function = (fun () -> r := x); }
+  in
+  r
+
+let ref ?(stage=Stage.Interp) ~name x =
+  fst @@ ref_tag ~stage ~name x
 
 (** Observables *)
 module type OBSERVABLE =
@@ -252,9 +262,12 @@ module MakeObservable
 struct
   type token = string
   type value = Obs.value
+  type observer = Normal of token list Ref.t | Local of token list ref
 
   let observers = Stdlib.ref CString.Map.empty
-  let active_observers : token list ref = ref ~stage:Obs.stage ~local:Obs.local ~name:Obs.name []
+  let active_observers : observer =
+    if Obs.local then Local (local_ref ~stage:Obs.stage ~name:Obs.name [])
+    else Normal (ref ~stage:Obs.stage ~name:Obs.name [])
 
   let register ~name ?(override=false) value : token =
     if not override && CString.Map.mem name !observers then
@@ -264,21 +277,27 @@ struct
       observers := CString.Map.add name value !observers ;
     name
 
-  let remove name = Util.List.remove String.equal name !active_observers
+  let get_active_observers () = match active_observers with
+  | Local active_observers -> !active_observers
+  | Normal active_observers -> Ref.get active_observers
+
+  let remove name =
+    Util.List.remove String.equal name (get_active_observers ())
 
   let activate name : unit =
     assert (CString.Map.mem name !observers);
-    active_observers := name :: remove name;
-    ()
+    match active_observers with
+    | Local active_observers -> active_observers := name :: remove name
+    | Normal active_observers -> Ref.set active_observers (name :: remove name)
 
-  let deactivate name : unit =
-    active_observers := remove name;
-    ()
+  let deactivate name : unit = match active_observers with
+  | Local active_observers -> active_observers := remove name
+  | Normal active_observers -> Ref.set active_observers (remove name)
 
-  let is_active tkn = List.mem tkn !active_observers
+  let is_active tkn = List.mem tkn (get_active_observers ())
 
   let all_active () : (token * value) list =
-    List.map (fun k -> k, CString.Map.get k !observers) !active_observers
+    List.map (fun k -> k, CString.Map.get k !observers) (get_active_observers ())
 end
 
 

--- a/library/summary.mli
+++ b/library/summary.mli
@@ -64,8 +64,18 @@ val declare_summary_tag : string -> ?make_marshallable:('a -> 'a) -> 'a summary_
     [ref_tag] is never local.
 *)
 
-val ref : ?stage:Stage.t -> ?local:bool -> name:string -> 'a -> 'a ref
-val ref_tag : ?stage:Stage.t -> name:string -> 'a -> 'a ref * 'a Dyn.tag
+module Ref :
+sig
+  type 'a t
+  val get : 'a t -> 'a
+  val set : 'a t -> 'a -> unit
+  val (!) : 'a t -> 'a
+  val (:=) : 'a t -> 'a -> unit
+end
+
+val ref : ?stage:Stage.t -> name:string -> 'a -> 'a Ref.t
+val local_ref : ?stage:Stage.t -> name:string -> 'a -> 'a ref
+val ref_tag : ?stage:Stage.t -> name:string -> 'a -> 'a Ref.t * 'a Dyn.tag
 
 (** Special summary for ML modules.  This summary entry is special
     because its unfreeze may load ML code and hence add summary

--- a/parsing/notgram_ops.ml
+++ b/parsing/notgram_ops.ml
@@ -18,6 +18,7 @@ open Notation
 let notation_grammar_map = Summary.ref ~stage:Summary.Stage.Synterp ~name:"notation_grammar_map" NotationMap.empty
 
 let declare_notation_grammar ntn rule =
+  let open Summary.Ref in
   try
     let _ = NotationMap.find ntn !notation_grammar_map in
     anomaly (str "Notation " ++ pr_notation ntn ++ str " is already assigned a grammar.")
@@ -25,6 +26,7 @@ let declare_notation_grammar ntn rule =
   notation_grammar_map := NotationMap.add ntn rule !notation_grammar_map
 
 let grammar_of_notation ntn =
+  let open Summary.Ref in
   NotationMap.find ntn !notation_grammar_map
 
 let list_prefixes ntn =
@@ -54,6 +56,7 @@ let list_prefixes ntn =
 let prefixes_map = Summary.ref ~stage:Summary.Stage.Synterp ~name:"notation_prefixes_map" NotationMap.empty
 
 let declare_prefixes ntn =
+  let open Summary.Ref in
   let register_prefix (pref, _) =
     if not (NotationMap.mem pref !prefixes_map) then
       prefixes_map := NotationMap.add pref ntn !prefixes_map in
@@ -62,6 +65,7 @@ let declare_prefixes ntn =
 let notation_non_terminals_map = Summary.ref ~stage:Summary.Stage.Synterp ~name:"notation_non_terminals_map" NotationMap.empty
 
 let declare_notation_non_terminals ntn entries =
+  let open Summary.Ref in
   try
     let _ = NotationMap.find ntn !notation_grammar_map in
     anomaly (str "Notation " ++ pr_notation ntn ++ str " is already assigned a grammar.")
@@ -70,9 +74,11 @@ let declare_notation_non_terminals ntn entries =
   declare_prefixes ntn
 
 let non_terminals_of_notation ntn =
+  let open Summary.Ref in
   NotationMap.find ntn !notation_non_terminals_map
 
 let longest_common_prefix ntn =
+  let open Summary.Ref in
   CList.find_map
     (fun (pref, k) ->
       NotationMap.find_opt pref !prefixes_map
@@ -80,4 +86,5 @@ let longest_common_prefix ntn =
     (List.rev (list_prefixes ntn))
 
 let get_defined_notations () =
+  let open Summary.Ref in
   NotationSet.elements @@ NotationMap.domain !notation_grammar_map

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -156,7 +156,7 @@ let empty_table = {
   modfile_mps = DirPath.Map.empty;
 }
 
-let make_table () = ref { empty_table with modfile_ids = !blacklist_table }
+let make_table () = ref { empty_table with modfile_ids = Summary.Ref.get blacklist_table }
 
 let add_typedef table kn inst cb t =
   let upd = function
@@ -690,9 +690,12 @@ type lang = Ocaml | Haskell | Scheme | JSON
 
 let lang_ref = Summary.ref Ocaml ~name:"ExtrLang"
 
-let lang () = !lang_ref
+let lang () =
+  let open Summary.Ref in
+  !lang_ref
 
 let extr_lang : lang -> obj =
+  let open Summary.Ref in
   declare_object @@ superglobal_object_nodischarge "Extraction Lang"
     ~cache:(fun l -> lang_ref := l)
     ~subst:None
@@ -705,7 +708,9 @@ let empty_inline_table = (Refset'.empty,Refset'.empty)
 
 let inline_table = Summary.ref empty_inline_table ~name:"ExtrInline"
 
-let to_inline r = Refset'.mem r (fst !inline_table)
+let to_inline r =
+  let open Summary.Ref in
+  Refset'.mem r (fst !inline_table)
 
 (* Extension for supporting foreign function call extraction. *)
 
@@ -713,7 +718,9 @@ let empty_foreign_set = Refset'.empty
 
 let foreign_set = Summary.ref empty_foreign_set ~name:"ExtrForeign"
 
-let to_foreign r = Refset'.mem r !foreign_set
+let to_foreign r =
+  let open Summary.Ref in
+  Refset'.mem r !foreign_set
 
 (* End of Extension for supporting foreign function call extraction. *)
 
@@ -726,9 +733,12 @@ let callback_map = Summary.ref empty_callback_map ~name:"ExtrCallback"
 
 (* End of Extension for supporting callback registration extraction. *)
 
-let to_keep r = Refset'.mem r (snd !inline_table)
+let to_keep r =
+  let open Summary.Ref in
+  Refset'.mem r (snd !inline_table)
 
 let add_inline_entries b l =
+  let open Summary.Ref in
   let f b = if b then Refset'.add else Refset'.remove in
   let i,k = !inline_table in
   inline_table :=
@@ -736,10 +746,12 @@ let add_inline_entries b l =
   (List.fold_right (f (not b)) l k)
 
 let add_foreign_entries l =
+  let open Summary.Ref in
   foreign_set := List.fold_right (Refset'.add) l !foreign_set
 
 (* Adds the qualid_ref and alias opt to the callback_map. *)
 let add_callback_entry alias_opt qualid_ref =
+  let open Summary.Ref in
   callback_map := Refmap'.add qualid_ref alias_opt !callback_map
 
 (* Registration of operations for rollback. *)
@@ -784,6 +796,7 @@ let extraction_inline b l =
 (* Printing part *)
 
 let print_extraction_inline () =
+  let open Summary.Ref in
   let (i,n)= !inline_table in
   let i'= Refset'.filter (function { glob = GlobRef.ConstRef _ } -> true | _ -> false) i in
     (str "Extraction Inline:" ++ fnl () ++
@@ -798,16 +811,19 @@ let print_extraction_inline () =
 (* Reset part *)
 
 let reset_inline : unit -> obj =
+  let open Summary.Ref in
   declare_object @@ superglobal_object_nodischarge "Reset Extraction Inline"
     ~cache:(fun () -> inline_table := empty_inline_table)
     ~subst:None
 
 let reset_foreign : unit -> obj =
+  let open Summary.Ref in
   declare_object @@ superglobal_object_nodischarge "Reset Extraction Foreign"
     ~cache:(fun () -> foreign_set := empty_foreign_set)
     ~subst:None
 
 let reset_callback : unit -> obj =
+  let open Summary.Ref in
   declare_object @@ superglobal_object_nodischarge "Reset Extraction Callback"
     ~cache:(fun () -> callback_map := empty_callback_map)
     ~subst:None
@@ -833,9 +849,11 @@ type int_or_id = ArgInt of int | ArgId of Id.t
 let implicits_table = Summary.ref Refmap'.empty ~name:"ExtrImplicit"
 
 let implicits_of_global r =
- try Refmap'.find r !implicits_table with Not_found -> Int.Set.empty
+  let open Summary.Ref in
+  try Refmap'.find r !implicits_table with Not_found -> Int.Set.empty
 
 let add_implicits r l =
+  let open Summary.Ref in
   let names = argnames_of_global r in
   let n = List.length names in
   let add_arg s = function
@@ -887,6 +905,7 @@ let file_of_modfile table dp =
   String.mapi (fun i c -> if i = 0 then s0.[0] else c) (string_of_modfile table dp)
 
 let add_blacklist_entries l =
+  let open Summary.Ref in
   blacklist_table :=
     List.fold_right (fun s -> Id.Set.add (Id.of_string (String.capitalize_ascii s)))
       l !blacklist_table
@@ -907,11 +926,13 @@ let extraction_blacklist l =
 (* Printing part *)
 
 let print_extraction_blacklist () =
+  let open Summary.Ref in
   prlist_with_sep fnl Id.print (Id.Set.elements !blacklist_table)
 
 (* Reset part *)
 
 let reset_blacklist : unit -> obj =
+  let open Summary.Ref in
   declare_object @@ superglobal_object_nodischarge "Reset Extraction Blacklist"
     ~cache:(fun ()-> blacklist_table := Id.Set.empty)
     ~subst:None
@@ -925,23 +946,34 @@ let (use_type_scheme_nb_args, type_scheme_nb_args_hook) = Hook.make ()
 
 let customs = Summary.ref Refmap'.empty ~name:"ExtrCustom"
 
-let add_custom r ids s = customs := Refmap'.add r (ids,s) !customs
+let add_custom r ids s =
+  let open Summary.Ref in
+  customs := Refmap'.add r (ids,s) !customs
 
-let is_custom r = Refmap'.mem r !customs
+let is_custom r =
+  let open Summary.Ref in
+  Refmap'.mem r !customs
 
 let is_inline_custom r = (is_custom r) && (to_inline r)
 
 let is_foreign_custom r = (is_custom r) && (to_foreign r)
 
-let find_callback r = Refmap'.find r !callback_map
+let find_callback r =
+  let open Summary.Ref in
+  Refmap'.find r !callback_map
 
-let find_custom r = snd (Refmap'.find r !customs)
+let find_custom r =
+  let open Summary.Ref in
+  snd (Refmap'.find r !customs)
 
-let find_type_custom r = Refmap'.find r !customs
+let find_type_custom r =
+  let open Summary.Ref in
+  Refmap'.find r !customs
 
 let custom_matchs = Summary.ref Refmap'.empty ~name:"ExtrCustomMatchs"
 
 let add_custom_match r s =
+  let open Summary.Ref in
   custom_matchs := Refmap'.add r s !custom_matchs
 
 let indref_of_match pv =
@@ -953,10 +985,12 @@ let indref_of_match pv =
     | _ -> raise Not_found
 
 let is_custom_match pv =
+  let open Summary.Ref in
   try Refmap'.mem (indref_of_match pv) !custom_matchs
   with Not_found -> false
 
 let find_custom_match pv =
+  let open Summary.Ref in
   Refmap'.find (indref_of_match pv) !custom_matchs
 
 (* Printing entries *)
@@ -970,9 +1004,11 @@ let print_constref_extractions ref_set val_lookup_f section_str =
        )
 
 let print_extraction_foreign () =
+  let open Summary.Ref in
   print_constref_extractions !foreign_set (find_custom) "Extraction Foreign Constant:"
 
 let print_extraction_callback () =
+  let open Summary.Ref in
   let keys = Refmap'.domain !callback_map in
   print_constref_extractions keys (fun r ->
     match find_callback r with

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -157,6 +157,7 @@ let cache_Function (_,(finfos)) =
 *)
 
 let cache_Function finfos =
+  let open Summary.Ref in
   from_function := Cmap_env.add finfos.function_constant finfos !from_function;
   from_graph := Indmap_env.add finfos.graph_ind finfos !from_graph
 
@@ -253,8 +254,12 @@ let find_or_none id =
       | _ -> CErrors.anomaly (Pp.str "Not a constant.") )
   with Not_found -> None
 
-let find_Function_infos f = Cmap_env.find_opt f !from_function
-let find_Function_of_graph ind = Indmap_env.find_opt ind !from_graph
+let find_Function_infos f =
+  let open Summary.Ref in
+  Cmap_env.find_opt f !from_function
+let find_Function_of_graph ind =
+  let open Summary.Ref in
+  Indmap_env.find_opt ind !from_graph
 
 let update_Function finfo =
   (* Pp.msgnl (pr_info finfo); *)
@@ -288,7 +293,9 @@ let add_Function is_general f =
   in
   update_Function finfos
 
-let pr_table env sigma = pr_table env sigma !from_function
+let pr_table env sigma =
+  let open Summary.Ref in
+  pr_table env sigma !from_function
 
 (*********************************)
 (* Debugging *)

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -381,6 +381,7 @@ let transitivity_left_table = Summary.ref [] ~name:"transitivity-steps-l"
    complete to proof of the last hypothesis (assumed to state an equality) *)
 
 let step left x tac =
+  let open Summary.Ref in
   let l =
     List.map (fun lem ->
       let lem = EConstr.of_constr lem in
@@ -394,6 +395,7 @@ let step left x tac =
 (* Main function to push lemmas in persistent environment *)
 
 let cache_transitivity_lemma (left,lem) =
+  let open Summary.Ref in
   if left then
     transitivity_left_table  := lem :: !transitivity_left_table
   else

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -71,6 +71,7 @@ type pp_tactic = {
 let prnotation_tab = Summary.ref ~name:"pptactic-notation" KerName.Map.empty
 
 let declare_notation_tactic_pprule kn pt =
+  let open Summary.Ref in
   prnotation_tab := KerName.Map.add kn pt !prnotation_tab
 
 type 'a raw_extra_genarg_printer =
@@ -250,6 +251,7 @@ let string_of_genarg_arg (ArgumentType arg) =
   | Extend.Uentryl (_, lvl) -> "tactic" ^ string_of_int lvl
 
   let pr_alias_key key =
+    let open Summary.Ref in
     try
       let prods = (KerName.Map.find key !prnotation_tab).pptac_prods in
       let pr = function
@@ -267,6 +269,7 @@ let string_of_genarg_arg (ArgumentType arg) =
     argument_type_eq (ArgumentType (ExtraArg tag)) wit
 
   let pr_alias_gen pr_gen lev key l =
+    let open Summary.Ref in
     try
       let pp = KerName.Map.find key !prnotation_tab in
       let rec pack prods args = match prods, args with

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -228,9 +228,10 @@ let interp_prod_item = function
     TacNonTerm (loc, (symbol, ido))
 
 let make_fresh_key =
+  let open Summary.Ref in
   let id = Summary.ref ~stage:Summary.Stage.Synterp ~name:"TACTIC-NOTATION-COUNTER" 0 in
   fun prods ->
-    let cur = incr id; !id in
+    let cur = id := !id + 1; !id in
     let map = function
     | TacTerm s -> s
     | TacNonTerm _ -> "#"

--- a/plugins/ltac/tacenv.ml
+++ b/plugins/ltac/tacenv.ml
@@ -50,13 +50,17 @@ let alias_map = Summary.ref ~name:"tactic-alias"
   (KerName.Map.empty : alias_tactic KerName.Map.t)
 
 let register_alias key tac =
+  let open Summary.Ref in
   alias_map := KerName.Map.add key tac !alias_map
 
 let interp_alias key =
+  let open Summary.Ref in
   try KerName.Map.find key !alias_map
   with Not_found -> CErrors.anomaly (str "Unknown tactic alias: " ++ KerName.print key ++ str ".")
 
-let check_alias key = KerName.Map.mem key !alias_map
+let check_alias key =
+  let open Summary.Ref in
+  KerName.Map.mem key !alias_map
 
 (** ML tactic extensions (TacML) *)
 
@@ -131,13 +135,20 @@ let mactab =
   Summary.ref (KerName.Map.empty : ltac_entry KerName.Map.t)
     ~name:"tactic-definition"
 
-let ltac_entries () = !mactab
+let ltac_entries () =
+  let open Summary.Ref in
+  !mactab
 
-let interp_ltac r = (KerName.Map.find r !mactab).tac_body
+let interp_ltac r =
+  let open Summary.Ref in
+  (KerName.Map.find r !mactab).tac_body
 
-let is_ltac_for_ml_tactic r = (KerName.Map.find r !mactab).tac_for_ml
+let is_ltac_for_ml_tactic r =
+  let open Summary.Ref in
+  (KerName.Map.find r !mactab).tac_for_ml
 
 let add ~depr kn b t =
+  let open Summary.Ref in
   let entry = {
     tac_for_ml = b;
     tac_body = t;
@@ -148,10 +159,12 @@ let add ~depr kn b t =
   mactab := KerName.Map.add kn entry !mactab
 
 let replace kn path t =
+  let open Summary.Ref in
   let entry _ e = { e with tac_body = t; tac_redef = path :: e.tac_redef } in
   mactab := KerName.Map.modify kn entry !mactab
 
 let tac_deprecation kn =
+  let open Summary.Ref in
   try (KerName.Map.find kn !mactab).tac_deprecation with Not_found -> None
 
 type tacdef = {

--- a/plugins/ltac2/tac2env.ml
+++ b/plugins/ltac2/tac2env.ml
@@ -66,53 +66,71 @@ type compile_info = {
 
 let ltac_state = Summary.ref empty_state ~name:"ltac2-state"
 
-let compiled_tacs = Summary.ref ~local:true ~name:"ltac2-compiled-state" KerName.Map.empty
+let compiled_tacs = Summary.local_ref ~name:"ltac2-compiled-state" KerName.Map.empty
 
 let define_global kn e =
+  let open Summary.Ref in
   let state = !ltac_state in
   ltac_state := { state with ltac_tactics = KerName.Map.add kn e state.ltac_tactics }
 
 let interp_global kn =
-  let data = KerName.Map.find kn ltac_state.contents.ltac_tactics in
+  let open Summary.Ref in
+  let data = KerName.Map.find kn (!ltac_state).ltac_tactics in
   data
 
 let set_compiled_global kn info v =
   assert (not (interp_global kn).gdata_mutable);
   compiled_tacs := KerName.Map.add kn (info,v) !compiled_tacs
 
-let get_compiled_global kn = KerName.Map.find_opt kn !compiled_tacs
+let get_compiled_global kn =
+  KerName.Map.find_opt kn !compiled_tacs
 
-let globals () = (!ltac_state).ltac_tactics
+let globals () =
+  let open Summary.Ref in
+  (!ltac_state).ltac_tactics
 
 let define_constructor kn t =
+  let open Summary.Ref in
   let state = !ltac_state in
   ltac_state := {
     state with
     ltac_constructors = KerName.Map.add kn t state.ltac_constructors;
   }
 
-let interp_constructor kn = KerName.Map.find kn ltac_state.contents.ltac_constructors
+let interp_constructor kn =
+  let open Summary.Ref in
+  KerName.Map.find kn (!ltac_state).ltac_constructors
 
 let find_all_constructors_in_type kn =
+  let open Summary.Ref in
   KerName.Map.filter (fun _ data -> KerName.equal kn data.cdata_type) (!ltac_state).ltac_constructors
 
 let define_projection kn t =
+  let open Summary.Ref in
   let state = !ltac_state in
   ltac_state := { state with ltac_projections = KerName.Map.add kn t state.ltac_projections }
 
-let interp_projection kn = KerName.Map.find kn ltac_state.contents.ltac_projections
+let interp_projection kn =
+  let open Summary.Ref in
+  KerName.Map.find kn (!ltac_state).ltac_projections
 
 let define_type kn e =
+  let open Summary.Ref in
   let state = !ltac_state in
   ltac_state := { state with ltac_types = KerName.Map.add kn e state.ltac_types }
 
-let interp_type kn = KerName.Map.find kn ltac_state.contents.ltac_types
+let interp_type kn =
+  let open Summary.Ref in
+  KerName.Map.find kn (!ltac_state).ltac_types
 
 let define_abbrev kn data =
+  let open Summary.Ref in
   let state = !ltac_state in
   ltac_state := { state with ltac_abbrevs = KerName.Map.add kn data state.ltac_abbrevs }
 
-let interp_abbrev kn = KerName.Map.find kn ltac_state.contents.ltac_abbrevs
+let interp_abbrev kn =
+  let open Summary.Ref in
+  KerName.Map.find kn (!ltac_state).ltac_abbrevs
 
 module ML =
 struct

--- a/plugins/ltac2/tac2syn.ml
+++ b/plugins/ltac2/tac2syn.ml
@@ -69,6 +69,7 @@ let current_scopes = Summary.ref ~name:"ltac2-current-scopes" []
 type open_close_scope = Open | Close
 
 let cache_open_close_scope (sc,openclose) =
+  let open Summary.Ref in
   match openclose with
   | Open -> current_scopes := sc :: (List.remove Tac2Scope.equal sc !current_scopes)
   | Close -> current_scopes := List.remove Tac2Scope.equal sc !current_scopes
@@ -90,6 +91,7 @@ let close_scope local sc = open_close_scope local sc Close
 let default_scope = Summary.ref ~name:"ltac2-default-scope" None
 
 let cache_default_scope sc =
+  let open Summary.Ref in
   let () = if Option.has_some !default_scope then
       CErrors.user_err Pp.(str "Declare ML Module for the Ltac2 plugin in multiple Rocq modules is not supported.")
   in
@@ -111,11 +113,15 @@ let declare_default_scope () =
 let () =
   Mltop.(declare_cache_obj_full (interp_only_obj declare_default_scope) "rocq-runtime.plugins.ltac2")
 
-let default_scope () = match !default_scope with
+let default_scope () =
+  let open Summary.Ref in
+  match !default_scope with
   | Some v -> v
   | None -> assert false
 
-let current_scopes () = !current_scopes
+let current_scopes () =
+  let open Summary.Ref in
+  !current_scopes
 
 module Tac2Custom = KerName
 
@@ -765,7 +771,7 @@ type ('scope,'body) notation_interpretation = {
   nota_body : 'body;
 }
 
-let notation_data : (Tac2Scope.t, notation_data) notation_interpretation Tac2Scope.Map.t ParsedNota.AnyMap.t ref =
+let notation_data : (Tac2Scope.t, notation_data) notation_interpretation Tac2Scope.Map.t ParsedNota.AnyMap.t Summary.Ref.t =
   Summary.ref ~name:"tac2notation-data" ParsedNota.AnyMap.empty
 
 let rec interp_notation_args : type a. a Syntax.seq -> _ -> a -> _ = fun parsing toks args ->
@@ -789,6 +795,7 @@ let rec interp_notation_args : type a. a Syntax.seq -> _ -> a -> _ = fun parsing
    scopes *)
 let interp_notation ?loc scopes syn
   : notation_data * (lname * raw_tacexpr) list =
+  let open Summary.Ref in
   let WithArgs ((rule, _ as parsing), args) = TacSyn.get syn in
   let data =
     (* NB no Reserve Notation for ltac2 so can't have a notation without interp data *)
@@ -811,6 +818,7 @@ let interp_notation ?loc scopes syn
   data.nota_body, args
 
 let cache_synext_interp data =
+  let open Summary.Ref in
   let add_data m =
     let m = Option.default Tac2Scope.Map.empty m in
     let m = Tac2Scope.Map.add data.nota_scope data m in

--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -378,7 +378,7 @@ module type Elt = sig
   val name : string
 
   val gref : unit -> GlobRef.t
-  val table : (term_kind * decl_kind) ConstrMap.t ref
+  val table : (term_kind * decl_kind) ConstrMap.t Summary.Ref.t
   val cast : elt decl -> decl_kind
   val dest : decl_kind -> elt decl option
 
@@ -647,6 +647,7 @@ module MakeTable (E : Elt) : S = struct
                                           gl_pr_constr c ++ str " should be a global reference")
 
   let register_hint env evd t elt =
+    let open Summary.Ref in
     match EConstr.kind evd t with
     | App (c, _) ->
        let gr = safe_ref evd c in
@@ -702,6 +703,7 @@ module MakeTable (E : Elt) : S = struct
         (CErrors.user_err Pp.(Libnames.pr_qualid c ++ str " does not exist."))
 
   let pp_keys () =
+    let open Summary.Ref in
     let env = Global.env () in
     let evd = Evd.from_env env in
     ConstrMap.fold
@@ -770,9 +772,9 @@ module UnOpSpec = MakeTable (EUnopSpec)
 module BinOpSpec = MakeTable (EBinOpSpec)
 
 let init_cache () =
-  table_cache := !table;
-  saturate_cache := !saturate;
-  specs_cache := !specs
+  table_cache := Summary.Ref.get table;
+  saturate_cache := Summary.Ref.get saturate;
+  specs_cache := Summary.Ref.get specs
 
 open EInjT
 

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -334,6 +334,7 @@ module Cmap = Map.Make(Termops.ConstrData)
 let from_carrier = Summary.ref Cmap.empty ~name:"ring-tac-carrier-table"
 
 let print_rings () =
+  let open Summary.Ref in
   Feedback.msg_notice (strbrk "The following ring structures have been declared:");
   Cmap.iter (fun _carrier ring ->
       let env = Global.env () in
@@ -345,7 +346,9 @@ let print_rings () =
             str"and equivalence relation "++ pr_constr_env env sigma ring.ring_req))
     ) !from_carrier
 
-let ring_for_carrier r = Cmap.find r !from_carrier
+let ring_for_carrier r =
+  let open Summary.Ref in
+  Cmap.find r !from_carrier
 
 let find_ring_structure env sigma l =
   match l with
@@ -366,6 +369,7 @@ let find_ring_structure env sigma l =
     | [] -> assert false
 
 let add_entry e =
+  let open Summary.Ref in
   from_carrier := Cmap.add e.ring_carrier e !from_carrier
 
 let subst_th (subst,th) =
@@ -767,6 +771,7 @@ let dest_field env sigma th_spec =
 let field_from_carrier = Summary.ref Cmap.empty ~name:"field-tac-carrier-table"
 
 let print_fields () =
+  let open Summary.Ref in
   Feedback.msg_notice (strbrk "The following field structures have been declared:");
   Cmap.iter (fun _carrier fi ->
       let env = Global.env () in
@@ -778,7 +783,9 @@ let print_fields () =
             str"and equivalence relation "++ pr_constr_env env sigma fi.field_req))
     ) !field_from_carrier
 
-let field_for_carrier r = Cmap.find r !field_from_carrier
+let field_for_carrier r =
+  let open Summary.Ref in
+  Cmap.find r !field_from_carrier
 
 let find_field_structure env sigma l =
   check_required_library (cdir@["Field_tac"]);
@@ -800,6 +807,7 @@ let find_field_structure env sigma l =
     | [] -> assert false
 
 let add_field_entry e =
+  let open Summary.Ref in
   field_from_carrier := Cmap.add e.field_carrier e !field_from_carrier
 
 let subst_th (subst,th) =

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -32,6 +32,7 @@ module ERelevance = EConstr.ERelevance
 
 let ssroldreworder = Summary.ref ~name:"SSR:oldreworder" false
 let () =
+  let open Summary.Ref in
   Goptions.(declare_bool_option
     { optstage = Summary.Stage.Interp;
       optkey   = ["SsrOldRewriteGoalsOrder"];
@@ -428,7 +429,7 @@ let pirrel_rewrite ?(under=false) ?(map_redex=id_map_redex) pred rdx rdx_ty c_so
   let proof = EConstr.mkApp (elim, [| rdx_ty; new_rdx; pred; p; rdx; c |]) in
   debug_ssr (fun () -> Pp.(str"pirrel_rewrite: proof term: " ++ pr_econstr_env env sigma proof));
   Proofview.tclORELSE (refine_with
-                         ~first_goes_last:(not !ssroldreworder || under) ~with_evars:under (sigma, proof))
+                         ~first_goes_last:(not @@ Summary.Ref.get ssroldreworder || under) ~with_evars:under (sigma, proof))
     (fun (e, i) ->
        (* we generate a msg like: "Unable to find an instance for the variable" *)
        match EConstr.kind sigma c with
@@ -504,7 +505,7 @@ let rwcltac ?under ?map_redex cl rdx dir (sigma, r) =
       let rwtacs = [
         Tacticals.tclTHENLIST [
           rewritetac ?under dir (EConstr.mkVar rule_id);
-          if !ssroldreworder || Option.default false under then
+          if Summary.Ref.get ssroldreworder || Option.default false under then
             Proofview.tclUNIT ()
           else
             Proofview.cycle 1

--- a/plugins/ssr/ssrfwd.ml
+++ b/plugins/ssr/ssrfwd.ml
@@ -86,6 +86,7 @@ open Ssripats
 let ssrhaveNOtcresolution = Summary.ref ~name:"SSR:havenotcresolution" false
 
 let () =
+  let open Summary.Ref in
   Goptions.(declare_bool_option
     { optstage = Summary.Stage.Interp;
       optkey   = ["SsrHave";"NoTCResolution"];
@@ -251,6 +252,7 @@ let havetac ist
      (introstac binders) in
  let simpltac = introstac simpl in
  let fixtc =
+   let open Summary.Ref in
    not !ssrhaveNOtcresolution &&
    match fk with FwdHint(_,true) -> false | _ -> true in
  let hint = hinttac ist true hint in

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -375,12 +375,13 @@ let mk_abstract_id =
   let open Rocqlib in
   let ssr_abstract_id = Summary.ref ~name:"SSR:abstractid" 0 in
 begin fun env sigma ->
+  let open Summary.Ref in
   let sigma, zero = EConstr.fresh_global env sigma (lib_ref "num.nat.O") in
   let sigma, succ = EConstr.fresh_global env sigma (lib_ref "num.nat.S") in
   let rec nat_of_n n =
     if n = 0 then zero
     else EConstr.mkApp (succ, [|nat_of_n (n-1)|]) in
-  incr ssr_abstract_id;
+  ssr_abstract_id := !ssr_abstract_id + 1;
   sigma, nat_of_n !ssr_abstract_id
 end
 

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -30,6 +30,8 @@ module AdaptorDb = struct
   end
   module AdaptorMap = Map.Make(AdaptorKind)
 
+  open Summary.Ref
+
   let term_view_adaptor_db =
     Summary.ref ~name:"view_adaptor_db" AdaptorMap.empty
 

--- a/plugins/ssrrewrite/ssrrewrite.mlg
+++ b/plugins/ssrrewrite/ssrrewrite.mlg
@@ -47,6 +47,7 @@ END
 let ssr_rewrite_syntax = Summary.ref ~name:"SSR:rewrite" true
 
 let () =
+  let open Summary.Ref in
   Goptions.(declare_bool_option
     { optstage = Summary.Stage.Synterp;
       optkey   = ["SsrRewrite"];
@@ -58,6 +59,7 @@ let lbrace = Char.chr 123
 (** Workaround to a limitation of coqpp *)
 
 let test_ssr_rewrite_syntax =
+  let open Summary.Ref in
   let test kwstate strm =
     if not !ssr_rewrite_syntax then Error () else
     if Pptactic.ssr_rewrite_loaded () then Ok () else

--- a/pretyping/arguments_renaming.ml
+++ b/pretyping/arguments_renaming.ml
@@ -30,6 +30,7 @@ type req =
   | ReqGlobal
 
 let load_rename_args _ (_, (r, names)) =
+  let open Summary.Ref in
   name_table := GlobRefMap.add (Global.env ()) r names !name_table
 
 let cache_rename_args o = load_rename_args 1 o
@@ -72,7 +73,9 @@ let rename_arguments local r names =
   let req = if local then ReqLocal else ReqGlobal in
   Lib.add_leaf (inRenameArgs (req, (r, names)))
 
-let arguments_names env r = GlobRefMap.find env r !name_table
+let arguments_names env r =
+  let open Summary.Ref in
+  GlobRefMap.find env r !name_table
 
 let rename_type env ty ref =
   let name_override old_name override =

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -555,15 +555,17 @@ let register_hook ~name ?(override=false) h =
 let active_hooks = Summary.ref ~name:"coercion_hooks" ([] : string list)
 
 let deactivate_hook ~name =
+  let open Summary.Ref in
   active_hooks := List.filter (fun s -> not (String.equal s name)) !active_hooks
 
 let activate_hook ~name =
   assert (CString.Map.mem name !all_hooks);
   deactivate_hook ~name;
+  let open Summary.Ref in
   active_hooks := name :: !active_hooks
 
 let apply_hooks env sigma ~flags body ~inferred ~expected =
-  List.find_map (fun name -> CString.Map.get name !all_hooks env sigma ~flags body ~inferred ~expected) !active_hooks
+  List.find_map (fun name -> CString.Map.get name !all_hooks env sigma ~flags body ~inferred ~expected) (Summary.Ref.get active_hooks)
 
 let default_flags_of env =
   default_flags_of TransparentState.full

--- a/pretyping/coercionops.ml
+++ b/pretyping/coercionops.ml
@@ -93,6 +93,7 @@ let coercion_tab =
   Summary.ref ~name:"coercion_tab" (CoeTypMap.empty : coe_info_typ CoeTypMap.t)
 
 let reachable_from cl =
+  let open Summary.Ref in
   try (ClTypMap.find cl !class_tab).cl_reachable_from
   with Not_found -> ClTypSet.empty
 
@@ -133,28 +134,39 @@ let inheritance_graph =
 (* ajout de nouveaux "objets" *)
 
 let add_new_class cl s =
+  let open Summary.Ref in
   class_tab := ClTypMap.add cl s !class_tab
 
 let add_coercion coe s =
+  let open Summary.Ref in
   coercion_tab := CoeTypMap.add coe s !coercion_tab
 
 let add_path (x, y) p =
+  let open Summary.Ref in
   inheritance_graph := ClGraph.add x y p !inheritance_graph
 
 (* class_info : cl_typ -> int * cl_info_typ *)
 
-let class_info cl = ClTypMap.find cl !class_tab
+let class_info cl =
+  let open Summary.Ref in
+  ClTypMap.find cl !class_tab
 
 let class_nparams cl = (class_info cl).cl_param
 
-let class_exists cl = ClTypMap.mem cl !class_tab
+let class_exists cl =
+  let open Summary.Ref in
+  ClTypMap.mem cl !class_tab
 
-let coercion_info coe = CoeTypMap.find coe !coercion_tab
+let coercion_info coe =
+  let open Summary.Ref in
+  CoeTypMap.find coe !coercion_tab
 
 let coercion_type env sigma (coe,u) =
   Retyping.get_type_of env sigma (EConstr.mkRef (coe.coe_value,u))
 
-let coercion_exists coe = CoeTypMap.mem coe !coercion_tab
+let coercion_exists coe =
+  let open Summary.Ref in
+  CoeTypMap.mem coe !coercion_tab
 
 (* find_class_type : evar_map -> constr -> cl_typ * universe_list * constr list *)
 
@@ -247,6 +259,7 @@ let pr_class x = str (string_of_class x)
 (* lookup paths *)
 
 let lookup_path_between_class (s,t) =
+  let open Summary.Ref in
   ClGraph.find s t !inheritance_graph
 
 let lookup_path_to_fun_from_class s =
@@ -293,6 +306,7 @@ let get_coercion_constructor env coe =
   | _ -> raise Not_found
 
 let lookup_pattern_path_between env (s,t) =
+  let open Summary.Ref in
   List.map (get_coercion_constructor env)
     (ClGraph.find (CL_IND s) (CL_IND t) !inheritance_graph)
 
@@ -339,6 +353,7 @@ let different_class_params env ci =
     | _ -> false
 
 let add_coercion_in_graph env sigma ?(update=false) ic =
+  let open Summary.Ref in
   let source = ic.coe_source in
   let target = ic.coe_target in
   let source_info = class_info source in
@@ -371,7 +386,7 @@ let add_coercion_in_graph env sigma ?(update=false) ic =
             j_info.cl_reachable_from) &&
        not (compare_path env sigma i p q)
     then
-      ambig_paths := (ij, p, q) :: !ambig_paths
+      Stdlib.(ambig_paths := (ij, p, q) :: !ambig_paths)
   in
   let try_add_new_path (i,j as ij) p =
     let () = if cl_typ_eq i j then check_coherence ij p [] in
@@ -423,7 +438,7 @@ let add_coercion_in_graph env sigma ?(update=false) ic =
           else
             k_info.cl_repr
       }) !class_tab;
-  match !ambig_paths with [] -> () | _ -> warn_ambiguous_path !ambig_paths
+  Stdlib.(match !ambig_paths with [] -> () | _ -> warn_ambiguous_path !ambig_paths)
 
 let subst_coercion subst c =
   let env = Global.env () in
@@ -472,11 +487,14 @@ let declare_coercion env sigma ?update c =
 
 (* For printing purpose *)
 let classes () =
+  let open Summary.Ref in
   List.rev (ClTypMap.fold (fun x _ acc -> x :: acc) !class_tab [])
 let coercions () =
+  let open Summary.Ref in
   List.rev (CoeTypMap.fold (fun _ y acc -> y::acc) !coercion_tab [])
 
 let inheritance_graph () =
+  let open Summary.Ref in
   ClGraph.bindings !inheritance_graph
 
 let coercion_of_reference env r =

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -285,17 +285,19 @@ let register_hook ~name ?(override=false) h =
 let active_hooks = Summary.ref ~name:"canonical_solution_hooks_hacked" ([] : string list)
 
 let deactivate_hook ~name =
+  let open Summary.Ref in
   active_hooks := List.filter (fun s -> not (String.equal s name)) !active_hooks
 
 let activate_hook ~name =
   assert (CString.Map.mem name !all_hooks);
   deactivate_hook ~name;
+  let open Summary.Ref in
   active_hooks := name :: !active_hooks
 
 let apply_hooks env sigma proj pat =
   List.find_map (fun name ->
     try CString.Map.get name !all_hooks env sigma proj pat
-    with e when CErrors.noncritical e -> anomaly Pp.(str "CS hook " ++ str name ++ str " exploded")) !active_hooks
+    with e when CErrors.noncritical e -> anomaly Pp.(str "CS hook " ++ str name ++ str " exploded")) (Summary.Ref.get active_hooks)
 
 let decompose_proj ?metas env sigma (t1, sk1) =
    (* I only recognize ConstRef projections since these are the only ones for which

--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -82,7 +82,7 @@ val all_hooks : hook CString.Map.t ref
 
 val register_hook : name:CString.Map.key -> ?override:bool -> hook -> unit
 
-val active_hooks : string list ref
+val active_hooks : string list Summary.Ref.t
 
 val deactivate_hook : name:Util.String.t -> unit
 

--- a/pretyping/keys.ml
+++ b/pretyping/keys.ml
@@ -76,9 +76,11 @@ let add_kv k v m =
   with Not_found -> Keymap.add k (Keyset.singleton v) m
 
 let add_keys k v =
+  let open Summary.Ref in
   keys := add_kv k v (add_kv v k !keys)
 
 let equiv_keys k k' =
+  let open Summary.Ref in
   k == k' || KeyOrdered.equal k k' ||
     try Keyset.mem k' (Keymap.find k !keys)
     with Not_found -> false
@@ -173,4 +175,5 @@ let pr_mapping pr_global k v =
   pr_key pr_global k ++ str" <-> " ++ pr_keyset pr_global v
 
 let pr_keys pr_global =
+  let open Summary.Ref in
   Keymap.fold (fun k v acc -> pr_mapping pr_global k v ++ fnl () ++ acc) !keys (mt())

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -57,12 +57,15 @@ let bidi_hints =
   Summary.ref (GlobRefMap.empty : int GlobRefMap.t) ~name:"bidirectionalityhints"
 
 let add_bidirectionality_hint env gr n =
+  let open Summary.Ref in
   bidi_hints := GlobRefMap.add env gr n !bidi_hints
 
 let get_bidirectionality_hint env gr =
+  let open Summary.Ref in
   GlobRefMap.find_opt env gr !bidi_hints
 
 let clear_bidirectionality_hint env gr =
+  let open Summary.Ref in
   bidi_hints := GlobRefMap.remove env gr !bidi_hints
 
 (************************************************************************)

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -43,12 +43,13 @@ let effect_table = ref String.Map.empty
 (** a test to know whether a constant is actually the effect function *)
 let reduction_effect_hook env sigma con c =
   try
-    let funkey = Cmap_env.find con !constant_effect_table in
+    let funkey = Cmap_env.find con (Summary.Ref.get @@ constant_effect_table) in
     let effect_function = String.Map.find funkey !effect_table in
     effect_function env sigma (Lazy.force c)
   with Not_found -> ()
 
 let cache_reduction_effect (con,funkey) =
+  let open Summary.Ref in
   constant_effect_table := Cmap_env.add con funkey !constant_effect_table
 
 let subst_reduction_effect (subst,(con,funkey)) =
@@ -97,6 +98,7 @@ module ReductionBehaviour = struct
     Summary.ref ((Cpred.empty, QConstant.Map.empty)) ~name:"reductionbehaviour"
 
   let load _ (_,(r, b)) =
+    let open Summary.Ref in
     let env = Global.env () in
     table := (match b with
                 | None -> Cpred.remove r (fst !table), QConstant.Map.remove env r (snd !table)
@@ -177,6 +179,7 @@ module ReductionBehaviour = struct
        hov 2 (str "The reduction tactics " ++ pp_behavior b)
 
   module Db = struct
+    open Summary.Ref
     type t = table
     let get () = !table
     let empty = (Cpred.empty, QConstant.Map.empty)

--- a/pretyping/structures.ml
+++ b/pretyping/structures.ml
@@ -62,6 +62,7 @@ let projection_table =
   Summary.ref (Environ.QConstant.Map.empty : t Environ.QConstant.Map.t) ~name:"record-projs"
 
 let register ({ name; projections; nparams } as s) =
+  let open Summary.Ref in
   let env = Global.env () in
   structure_table := Environ.QInd.Map.add env name s !structure_table;
   projection_table :=
@@ -86,21 +87,28 @@ let rebuild env s =
   let nparams = mib.Declarations.mind_nparams in
   { s with nparams }
 
-let mem env ind = Environ.QInd.Map.mem env ind !structure_table
+let mem env ind =
+  let open Summary.Ref in
+  Environ.QInd.Map.mem env ind !structure_table
 
-let find env indsp = Environ.QInd.Map.find env indsp !structure_table
+let find env indsp =
+  let open Summary.Ref in
+  Environ.QInd.Map.find env indsp !structure_table
 
 let find_projections env indsp =
   (find env indsp).projections |>
   List.map (fun { proj_body } -> proj_body)
 
 let find_from_projection env cst =
+  let open Summary.Ref in
   Environ.QConstant.Map.find env cst !projection_table
 
 let projection_nparams env cst =
+  let open Summary.Ref in
   (Environ.QConstant.Map.find env cst !projection_table).nparams
 
 let is_projection cst =
+  let open Summary.Ref in
   let env = Global.env () in
   Environ.QConstant.Map.mem env cst !projection_table
 
@@ -330,6 +338,7 @@ let make env sigma ref =
   (ref,indsp)
 
 let register ~warn env sigma o =
+    let open Summary.Ref in
     compute_canonical_projections env sigma ~warn o |>
     List.iter (fun ((proj, (cs_pat, t)), s) ->
       let l = try GlobRefMap.find env proj !object_table with Not_found -> PatMap.empty in
@@ -369,6 +378,7 @@ type t = {
 }
 
 let find env sigma (proj,pat) =
+  let open Summary.Ref in
   let t', { o_DEF = c; o_CTX = ctx; o_INJ=n; o_TABS = bs;
         o_TPARAMS = params; o_NPARAMS = nparams; o_TCOMPS = us } = PatMap.find env pat (GlobRefMap.find env proj !object_table) in
   let us = List.map EConstr.of_constr us in
@@ -394,6 +404,7 @@ let rec get_nth n = function
   else get_nth (n - len) args
 
 let rec decompose_projection ?metas env sigma c args =
+  let open Summary.Ref in
   match EConstr.kind sigma c with
   | Meta mv ->
     begin match metas with
@@ -452,11 +463,13 @@ let canonical_entry_of_object projection value (_, { o_ORIGIN = solution }) =
   { projection; value; solution }
 
 let entries () =
+  let open Summary.Ref in
   GlobRefMap.fold (fun p ol acc ->
     PatMap.fold (fun pat o acc -> canonical_entry_of_object p pat o :: acc) ol acc)
     !object_table []
 
 let entries_for env ~projection:p =
+  let open Summary.Ref in
   try
     GlobRefMap.find env p !object_table |>
     (fun m -> PatMap.fold (fun pat o accu -> canonical_entry_of_object p pat o :: accu) m []) |>
@@ -473,11 +486,15 @@ let prim_table =
   Summary.ref (Cmap_env.empty : data Cmap_env.t) ~name:"record-prim-projs"
 
 let register p c =
+  let open Summary.Ref in
   prim_table := Cmap_env.add c p !prim_table
 
-let mem c = Cmap_env.mem c !prim_table
+let mem c =
+  let open Summary.Ref in
+  Cmap_env.mem c !prim_table
 
 let find_opt c =
+  let open Summary.Ref in
   try Some (Cmap_env.find c !prim_table) with Not_found -> None
 
 let find_opt_with_relevance (c,u) =

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -77,10 +77,12 @@ let hint_priority is = is.is_info.hint_priority
  * states management
  *)
 
-let classes : typeclasses ref = Summary.ref GlobRefMap.empty ~name:"classes"
-let instances : instances ref = Summary.ref GlobRefMap.empty ~name:"instances"
+let classes : typeclasses Summary.Ref.t = Summary.ref GlobRefMap.empty ~name:"classes"
+let instances : instances Summary.Ref.t = Summary.ref GlobRefMap.empty ~name:"instances"
 
-let class_info env c = GlobRefMap.find_opt env c !classes
+let class_info env c =
+  let open Summary.Ref in
+  GlobRefMap.find_opt env c !classes
 
 let class_info_exn env sigma r =
   match class_info env r with
@@ -90,6 +92,7 @@ let class_info_exn env sigma r =
     not_a_class env sigma c
 
 let global_class_of_constr env sigma c =
+  let open Summary.Ref in
   try let gr, u = EConstr.destRef sigma c in
     GlobRefMap.find env gr !classes, u
   with DestKO | Not_found -> not_a_class env sigma c
@@ -116,11 +119,13 @@ let class_of_constr env sigma c =
   with e when CErrors.noncritical e -> None
 
 let is_class_constr env sigma c =
+  let open Summary.Ref in
   try let gr, u = EConstr.destRef sigma c in
     GlobRefMap.mem env gr !classes
   with DestKO | Not_found -> false
 
 let rec is_class_type env evd c =
+  let open Summary.Ref in
   let c, _ = EConstr.decompose_app evd c in
     match EConstr.kind evd c with
     | Prod (_, _, t) -> is_class_type env evd t
@@ -132,6 +137,7 @@ let is_class_evar env evd evi =
   is_class_type env evd (Evd.evar_concl evi)
 
 let rec is_maybe_class_type env evd c =
+  let open Summary.Ref in
   let c, _ = EConstr.decompose_app evd c in
     match EConstr.kind evd c with
     | Prod (_, _, t) -> is_maybe_class_type env evd t
@@ -141,6 +147,7 @@ let rec is_maybe_class_type env evd c =
     | _ -> is_class_constr env evd c
 
 let load_class env cl =
+  let open Summary.Ref in
   classes := GlobRefMap.add env cl.cl_impl cl !classes
 
 (** Build the subinstances hints. *)
@@ -150,6 +157,7 @@ let load_class env cl =
  *)
 
 let load_instance env inst =
+  let open Summary.Ref in
   let insts =
     try GlobRefMap.find env inst.is_class !instances
     with Not_found -> GlobRefMap.empty in
@@ -157,20 +165,25 @@ let load_instance env inst =
   instances := GlobRefMap.add env inst.is_class insts !instances
 
 let remove_instance env inst =
+  let open Summary.Ref in
   let insts =
     try GlobRefMap.find env inst.is_class !instances
     with Not_found -> assert false in
   let insts = GlobRefMap.remove env inst.is_impl insts in
   instances := GlobRefMap.add env inst.is_class insts !instances
 
-let typeclasses () = GlobRefMap.fold (fun _ l c -> l :: c) !classes []
+let typeclasses () =
+  let open Summary.Ref in
+  GlobRefMap.fold (fun _ l c -> l :: c) !classes []
 
 let cmap_elements c = GlobRefMap.fold (fun k v acc -> v :: acc) c []
 
 let instances_of env c =
+  let open Summary.Ref in
   try cmap_elements (GlobRefMap.find env c.cl_impl !instances) with Not_found -> []
 
 let all_instances () =
+  let open Summary.Ref in
   GlobRefMap.fold (fun k v acc ->
     GlobRefMap.fold (fun k v acc -> v :: acc) v acc)
     !instances []
@@ -186,6 +199,7 @@ let instances_exn env sigma r =
     not_a_class env sigma c
 
 let is_class env gr =
+  let open Summary.Ref in
   GlobRefMap.mem env gr !classes
 
 open Evar_kinds

--- a/printing/ppextend.ml
+++ b/printing/ppextend.ml
@@ -82,18 +82,23 @@ let specific_notation_printing_rules =
   Summary.ref ~name:"specific-notation-printing-rules" (SpecificNotationMap.empty : notation_printing_rules SpecificNotationMap.t)
 
 let declare_generic_notation_printing_rules ntn rules =
+  let open Summary.Ref in
   generic_notation_printing_rules := NotationMap.add ntn rules !generic_notation_printing_rules
 let declare_specific_notation_printing_rules specific_ntn rules =
+  let open Summary.Ref in
   specific_notation_printing_rules := SpecificNotationMap.add specific_ntn rules !specific_notation_printing_rules
 
 let has_generic_notation_printing_rule ntn =
+  let open Summary.Ref in
   try (NotationMap.find ntn !generic_notation_printing_rules).notation_printing_reserved
   with Not_found -> false
 
 let find_generic_notation_printing_rule ntn =
+  let open Summary.Ref in
   NotationMap.find ntn !generic_notation_printing_rules
 
 let find_specific_notation_printing_rule specific_ntn =
+  let open Summary.Ref in
   SpecificNotationMap.find specific_ntn !specific_notation_printing_rules
 
 let find_notation_printing_rule which ntn =

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -328,7 +328,9 @@ let empty_rewrite_db = {
 let rewtab =
   Summary.ref (String.Map.empty : rewrite_db String.Map.t) ~name:"autorewrite"
 
-let raw_find_base bas = String.Map.find bas !rewtab
+let raw_find_base bas =
+  let open Summary.Ref in
+  String.Map.find bas !rewtab
 
 let find_base bas =
   try raw_find_base bas
@@ -439,7 +441,8 @@ let auto_multi_rewrite ?(conds=Naive) ?(forward=true) lems cl =
 let fresh_key =
   let id = Summary.ref ~name:"REWHINT-COUNTER" 0 in
   fun () ->
-    let cur = incr id; !id in
+    let open Summary.Ref in
+    let cur = id := !id + 1; !id in
     let lbl = Id.of_string ("_" ^ string_of_int cur) in
     let kn = Lib.make_kn lbl in
     let (mp, _) = KerName.repr kn in
@@ -477,10 +480,12 @@ let warn_implicit_create_hint_db =
   CWarnings.create ~name:"implicit-create-rewrite-hint-db" ~category:Deprecation.Version.v9_2
     (fun db -> strbrk "Implicitly declaring Rewrite hint databases is deprecated. Please explicitly create " ++ quote (str db))
 
-let cache_db db = match String.Map.find_opt db.db_name !rewtab with
-| None ->
-  rewtab := String.Map.add db.db_name empty_rewrite_db !rewtab
-| Some _ -> warn_create_hintdb db
+let cache_db db =
+  let open Summary.Ref in
+  match String.Map.find_opt db.db_name !rewtab with
+  | None ->
+    rewtab := String.Map.add db.db_name empty_rewrite_db !rewtab
+  | Some _ -> warn_create_hintdb db
 
 let load_db _ x = cache_db x
 
@@ -501,6 +506,7 @@ let create_rewrite_hint_db ~local ~name =
 
 (* Functions necessary to the library object declaration *)
 let cache_hintrewrite (rbase,lrl) =
+  let open Summary.Ref in
   let base = try raw_find_base rbase with Not_found -> empty_rewrite_db in
   let fold accu r = {
     rdb_hintdn = HintDN.add (Global.env ()) r.rew_pat r accu.rdb_hintdn;
@@ -594,6 +600,7 @@ let add_rew_rules ~locality base (lrul:raw_rew_rule list) =
 
 
 let check_declared db =
+  let open Summary.Ref in
   if not (String.Map.mem db !rewtab) then warn_implicit_create_hint_db db
 
 let add_rewrite_hint ~locality ~poly bases ort t lcsr =

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -488,6 +488,7 @@ module Search = struct
        Hint_db.empty TransparentState.full true, QGraph.initial_graph)
 
   let make_autogoal_hints env sigma only_classes (modes,st as mst) =
+    let open Summary.Ref in
     let sign = EConstr.named_context env in
     let qvars = Evd.elim_graph sigma in
     let (dir, onlyc, sign', cached_modes, cached_hints, qvars') = !autogoal_cache in
@@ -1215,10 +1216,12 @@ let register_solver ~name ?(override=false) h =
 let active_solvers = Summary.ref ~name:"typeclass_solvers" ([] : string list)
 
 let deactivate_solver ~name =
+  let open Summary.Ref in
   active_solvers := List.filter (fun s -> not (String.equal s name)) !active_solvers
 
 let activate_solver ~name =
   assert (CString.Map.mem name !class_solvers);
+  let open Summary.Ref in
   deactivate_solver ~name;
   active_solvers := name :: !active_solvers
 
@@ -1230,6 +1233,7 @@ let find_solver env evd (s : Intpart.set) =
         let (solver,cond) = CString.Map.find hd !class_solvers in
         if cond env evd s then solver else find_solver tl
       with Not_found ->  find_solver tl in
+  let open Summary.Ref in
   find_solver !active_solvers
 
 (** If [do_split] is [true], we try to separate the problem in

--- a/tactics/declareScheme.ml
+++ b/tactics/declareScheme.ml
@@ -13,6 +13,7 @@ open Names
 let scheme_map = Summary.ref GlobRef.Map_env.empty ~name:"Schemes"
 
 let cache_one_scheme kind (gr,const) =
+  let open Summary.Ref in
   scheme_map := GlobRef.Map_env.update gr (function
       | None -> Some (CString.Map.singleton kind const)
       | Some map -> Some (CString.Map.add kind const map))
@@ -46,9 +47,13 @@ let declare_scheme local kind (gr, _ as grcl) =
   in
   Lib.add_leaf (inScheme (local,(kind,grcl)))
 
-let lookup_scheme kind gr = CString.Map.find kind (GlobRef.Map_env.find gr !scheme_map)
+let lookup_scheme kind gr =
+  let open Summary.Ref in
+  CString.Map.find kind (GlobRef.Map_env.find gr !scheme_map)
 
 let lookup_scheme_opt kind gr =
   try Some (lookup_scheme kind gr) with Not_found -> None
 
-let all_schemes () = !scheme_map
+let all_schemes () =
+  let open Summary.Ref in
+  !scheme_map

--- a/tactics/elimschemes.ml
+++ b/tactics/elimschemes.ml
@@ -25,6 +25,7 @@ let prop_but_default_dependent_elim =
   Summary.ref ~name:"PROP-BUT-DEFAULT-DEPENDENT-ELIM" Indset_env.empty
 
 let inPropButDefaultDepElim : inductive -> Libobject.obj =
+  let open Summary.Ref in
   Libobject.declare_object @@
   Libobject.superglobal_object "prop_but_default_dependent_elim"
     ~cache:(fun i ->
@@ -35,7 +36,9 @@ let inPropButDefaultDepElim : inductive -> Libobject.obj =
 let declare_prop_but_default_dependent_elim i =
   Lib.add_leaf (inPropButDefaultDepElim i)
 
-let is_prop_but_default_dependent_elim i = Indset_env.mem i !prop_but_default_dependent_elim
+let is_prop_but_default_dependent_elim i =
+  let open Summary.Ref in
+  Indset_env.mem i !prop_but_default_dependent_elim
 
 let pseudo_sort_quality_for_elim ind mip =
   let s = mip.mind_sort in

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -145,7 +145,8 @@ include KerName
 let fresh_key =
   let id = Summary.ref ~name:"HINT-COUNTER" 0 in
   fun () ->
-    let cur = incr id; !id in
+    let open Summary.Ref in
+    let cur = id := !id + 1; !id in
     let lbl = Id.of_string ("_" ^ string_of_int cur) in
     let kn = Lib.make_kn lbl in
     let (mp, _) = KerName.repr kn in
@@ -919,16 +920,23 @@ type hint_db = Hint_db.t
 let searchtable = Summary.ref ~name:"searchtable" Hintdbmap.empty
 
 let searchtable_map name =
+  let open Summary.Ref in
   Hintdbmap.find name !searchtable
 let searchtable_add (name, db) =
+  let open Summary.Ref in
   (* XXX see #21114 *)
 (*   let () = assert (Hintdbmap.mem name !searchtable) in *)
   searchtable := Hintdbmap.add name db !searchtable
 let searchtable_create (name, db) =
+  let open Summary.Ref in
 (*   let () = assert (not @@ Hintdbmap.mem name !searchtable) in *)
   searchtable := Hintdbmap.add name db !searchtable
-let current_db_names () = Hintdbmap.domain !searchtable
-let current_db () = Hintdbmap.bindings !searchtable
+let current_db_names () =
+  let open Summary.Ref in
+  Hintdbmap.domain !searchtable
+let current_db () =
+  let open Summary.Ref in
+  Hintdbmap.bindings !searchtable
 
 let current_pure_db () = List.map snd (current_db ())
 
@@ -1806,6 +1814,7 @@ let pr_hint_db_by_name env sigma dbname =
 
 (* displays all the hints of all databases *)
 let pr_searchtable env sigma =
+  let open Summary.Ref in
   let fold name db accu =
     accu ++ str "In the database " ++ str name ++ str ":" ++ fnl () ++
     pr_hint_db_env env sigma db ++ fnl ()

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -244,23 +244,24 @@ let reduction_tab = ref String.Map.empty
 let red_expr_tab = Summary.ref String.Map.empty ~name:"Declare Reduction"
 
 let declare_reduction s f =
-  if String.Map.mem s !reduction_tab || String.Map.mem s !red_expr_tab
+  if String.Map.mem s !reduction_tab || String.Map.mem s (Summary.Ref.get red_expr_tab)
   then user_err
     (str "There is already a reduction expression of name " ++ str s ++ str ".")
   else reduction_tab := String.Map.add s f !reduction_tab
 
 let check_custom = function
   | ExtraRedExpr s ->
-      if not (String.Map.mem s !reduction_tab || String.Map.mem s !red_expr_tab)
+      if not (String.Map.mem s !reduction_tab || String.Map.mem s (Summary.Ref.get red_expr_tab))
       then user_err (str "Reference to undefined reduction expression " ++ str s ++ str ".")
   |_ -> ()
 
 let decl_red_expr s e =
-  if String.Map.mem s !reduction_tab || String.Map.mem s !red_expr_tab
+  if String.Map.mem s !reduction_tab || String.Map.mem s (Summary.Ref.get red_expr_tab)
   then user_err
     (str "There is already a reduction expression of name " ++ str s ++ str ".")
   else begin
     check_custom e;
+    let open Summary.Ref in
     red_expr_tab := String.Map.add s e !red_expr_tab
   end
 
@@ -312,6 +313,7 @@ let rec eval_red_expr env = function
 | Cbn f -> Cbn (make_flag env f)
 | Lazy f -> Lazy (make_flag env f)
 | ExtraRedExpr s ->
+  let open Summary.Ref in
   begin match String.Map.find s !red_expr_tab with
   | e -> eval_red_expr env e
   | exception Not_found -> ExtraRedExpr s (* delay to runtime interpretation *)

--- a/test-suite/misc/non-marshalable-state/src/evil.mlg
+++ b/test-suite/misc/non-marshalable-state/src/evil.mlg
@@ -10,6 +10,6 @@ let state = Summary.ref
 
 VERNAC COMMAND EXTEND magic CLASSIFIED AS SIDEFF
 | [ "magic" ] -> {
-    state := Some (fun () -> ())
+    Summary.Ref.set state (Some (fun () -> ()))
 }
 END

--- a/test-suite/misc/non-marshalable-state/src/good.mlg
+++ b/test-suite/misc/non-marshalable-state/src/good.mlg
@@ -2,7 +2,7 @@ DECLARE PLUGIN "coq-test-suite.good"
 
 {
 
-let state = Summary.ref ~local:true
+let state = Summary.local_ref
   ~name:"elpi-compiler-cache"
   None
 

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -147,15 +147,17 @@ let register_observer ~name ?(override=false) o =
   name
 
 let deactivate_observer name =
+  let open Summary.Ref in
   active_observers := List.remove String.equal name !active_observers
 
 let activate_observer name =
   assert (CString.Map.mem name !observers);
   deactivate_observer name;
+  let open Summary.Ref in
   active_observers := name :: !active_observers
 
 let observe event =
-  List.iter (fun name -> (CString.Map.get name !observers) event) !active_observers
+  List.iter (fun name -> (CString.Map.get name !observers) event) (Summary.Ref.get active_observers)
 
 let add_instance cl info global impl =
   let () = match global with

--- a/vernac/comExtraDeps.ml
+++ b/vernac/comExtraDeps.ml
@@ -14,6 +14,7 @@ open CErrors
 let extra_deps = Summary.ref ~name:"extra_deps" ~stage:Summary.Stage.Synterp Id.Map.empty
 
 let bind_extra_dep ?loc path id =
+  let open Summary.Ref in
   match Id.Map.find_opt id !extra_deps with
   | Some (other,loc) ->
       user_err Pp.(str "Extra dependency " ++ Id.print id ++
@@ -25,4 +26,6 @@ let declare_extra_dep ?loc ~from ~file id =
   let file_path = Loadpath.find_extra_dep_with_logical_path ?loc ~from ~file () in
   Option.iter (bind_extra_dep ?loc file_path) id
 
-let query_extra_dep id = fst @@ Id.Map.find id !extra_deps
+let query_extra_dep id =
+  let open Summary.Ref in
+  fst @@ Id.Map.find id !extra_deps

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -401,7 +401,9 @@ end
 
 let local_csts = Summary.ref ~name:"local-csts" Cset_env.empty
 
-let is_local_constant c = Cset_env.mem c !local_csts
+let is_local_constant c =
+  let open Summary.Ref in
+  Cset_env.mem c !local_csts
 
 type constant_obj = {
   cst_kind : Decls.logical_kind;
@@ -411,6 +413,7 @@ type constant_obj = {
 }
 
 let load_constant i ((sp,kn), obj) =
+  let open Summary.Ref in
   if Nametab.exists_cci sp then
     raise (DeclareUniv.AlreadyDeclared (None, Libnames.basename sp));
   let con = Global.constant_of_delta_kn kn in

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -282,9 +282,13 @@ let do_constraint ~poly l =
 
 let constraint_sources = Summary.ref ~name:"univ constraint sources" []
 
-let cache_constraint_source x = constraint_sources := x :: !constraint_sources
+let cache_constraint_source x =
+  let open Summary.Ref in
+  constraint_sources := x :: !constraint_sources
 
-let constraint_sources () = !constraint_sources
+let constraint_sources () =
+  let open Summary.Ref in
+  !constraint_sources
 
 let constraint_obj =
   Libobject.declare_object {

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -317,9 +317,12 @@ module ModSubstObjs :
      Summary.ref ~stage:Actions.stage (ModPath.Map.empty : substitutive_objects ModPath.Map.t)
        ~name:Actions.substobjs_table_name
 
-   let set mp objs = (table := ModPath.Map.add mp objs !table)
+   let set mp objs =
+    let open Summary.Ref in
+    (table := ModPath.Map.add mp objs !table)
 
    let rec get mp =
+     let open Summary.Ref in
      try ModPath.Map.find mp !table with Not_found ->
        handle_missing_substobjs mp
 
@@ -428,6 +431,7 @@ module ModObjs :
    val all : unit -> module_objects ModPath.Map.t
  end =
  struct
+   open Summary.Ref
    let table =
      Summary.ref ~stage:Actions.stage (ModPath.Map.empty : module_objects ModPath.Map.t)
        ~name:Actions.modobjs_table_name
@@ -799,16 +803,21 @@ let default_module_info = { cur_typ = None; cur_typs = [] }
 let openmod_info = Summary.ref default_module_info ~name:"MODULE-INFO"
 
 let start_library dir =
+  let open Summary.Ref in
   let mp = Global.start_library dir in
   openmod_info := default_module_info;
   openmod_syntax_info := Some (default_module_syntax_info mp);
   Lib.start_compilation dir mp
 
-let set_openmod_syntax_info info = match !openmod_syntax_info with
+let set_openmod_syntax_info info =
+  let open Summary.Ref in
+  match !openmod_syntax_info with
   | None -> anomaly Pp.(str "bad init of openmod_syntax_info")
   | Some _ -> openmod_syntax_info := Some info
 
-let openmod_syntax_info () = match !openmod_syntax_info with
+let openmod_syntax_info () =
+  let open Summary.Ref in
+  match !openmod_syntax_info with
   | None -> anomaly Pp.(str "missing init of openmod_syntax_info")
   | Some v -> v
 
@@ -1085,6 +1094,7 @@ let start_module_core id args res =
   mp, res_entry_o, subtyps, params, Univ.ContextSet.union ctx ctx'
 
 let start_module export id args res =
+  let open Summary.Ref in
   let fs = Summary.Interp.freeze_summaries () in
   let mp, res_entry_o, subtyps, _, _ = start_module_core id args res in
   openmod_info := { cur_typ = res_entry_o; cur_typs = subtyps };
@@ -1132,6 +1142,7 @@ let end_module_core id m_info objects fs =
   mp, objects
 
 let end_module () =
+  let open Summary.Ref in
   let oldprefix,fs,objects = Lib.Interp.end_module () in
   let m_info = !openmod_info in
   let _olddp, id = pop_path oldprefix.obj_path in
@@ -1271,6 +1282,7 @@ let start_modtype_core id args mtys =
   mp, params, sub_mty_l, Univ.ContextSet.union params_ctx sub_mty_ctx
 
 let start_modtype id args mtys =
+  let open Summary.Ref in
   let fs = Summary.Interp.freeze_summaries () in
   let mp, _, sub_mty_l, _ = start_modtype_core id args mtys in
   openmodtype_info := sub_mty_l;
@@ -1287,6 +1299,7 @@ let end_modtype_core id sub_mty_l objects fs =
   mp, objects
 
 let end_modtype () =
+  let open Summary.Ref in
   let oldprefix,fs,objects = Lib.Interp.end_modtype () in
   let olddp, id = pop_path oldprefix.obj_path in
   let sub_mty_l = !openmodtype_info in

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -106,7 +106,7 @@ type library_t = {
 }
 
 (* This is a map from names to loaded libraries *)
-let libraries_table : library_t DirPath.Map.t ref =
+let libraries_table : library_t DirPath.Map.t Summary.Ref.t =
   Summary.ref DirPath.Map.empty ~stage:Summary.Stage.Synterp ~name:"LIBRARY"
 
 (* This is the map of loaded libraries filename *)
@@ -123,6 +123,7 @@ let loaded_native_libraries = Summary.ref DirPath.Set.empty ~stage:Summary.Stage
 (* various requests to the tables *)
 
 let find_library dir =
+  let open Summary.Ref in
   DirPath.Map.find_opt dir !libraries_table
 
 let try_find_library dir =
@@ -154,6 +155,7 @@ let library_is_loaded dir =
      be performed first, thus the libraries_loaded_list ... *)
 
 let register_loaded_library ~root m =
+  let open Summary.Ref in
   let libname = m.library_name in
   let rec aux = function
     | [] -> [root, libname]
@@ -163,6 +165,7 @@ let register_loaded_library ~root m =
   libraries_table := DirPath.Map.add libname m !libraries_table
 
 let register_native_library libname =
+  let open Summary.Ref in
   if (Global.typing_flags ()).enable_native_compiler
     && not (DirPath.Set.mem libname !loaded_native_libraries) then begin
       let dirname = Filename.dirname (library_full_filename libname) in
@@ -170,7 +173,9 @@ let register_native_library libname =
       Nativelib.enable_library dirname libname
   end
 
-let loaded_libraries () = List.map snd !libraries_loaded_list
+let loaded_libraries () =
+  let open Summary.Ref in
+  List.map snd !libraries_loaded_list
 
 (** Delayed / available tables of opaque terms *)
 
@@ -454,6 +459,7 @@ let require_library_syntax_from_dirpath ~intern modrefl =
 (*s [save_library dir] ends library [dir] and save it to the disk. *)
 
 let current_deps () =
+  let open Summary.Ref in
   (* Only keep the roots of the dependency DAG *)
   let map (root, m) =
     if root then
@@ -552,6 +558,7 @@ let save_library_to todo_proofs ~output_native_objects dir f =
     Nativelib.compile_library ast fn
 
 let get_used_load_paths () =
+  let open Summary.Ref in
   String.Set.elements
     (List.fold_left (fun acc (root, m) -> String.Set.add
       (Filename.dirname (library_full_filename m)) acc)

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -33,12 +33,15 @@ let pp p =
   let path = Pp.str (CUnix.escaped_string_of_physical_path p.path_physical) in
   Pp.(h (installed ++ spc () ++ dir ++ spc () ++ path))
 
-let get_load_paths () = !load_paths
+let get_load_paths () =
+  let open Summary.Ref in
+  !load_paths
 
 let anomaly_too_many_paths path =
   CErrors.anomaly Pp.(str "Several logical paths are associated with" ++ spc () ++ str path ++ str ".")
 
 let find_load_path phys_dir =
+  let open Summary.Ref in
   let phys_dir = CUnix.canonical_path_name phys_dir in
   let filter p = String.equal p.path_physical phys_dir in
   let paths = List.filter filter !load_paths in
@@ -49,6 +52,7 @@ let find_load_path phys_dir =
 
 (* get the list of load paths that correspond to a given logical path *)
 let find_with_logical_path dirpath =
+  let open Summary.Ref in
   List.filter (fun p -> Names.DirPath.equal p.path_logical dirpath) !load_paths
 
 let warn_file_found_multiple_times =
@@ -87,6 +91,7 @@ let find_extra_dep_with_logical_path ?loc ~from ~file () =
 
 
 let remove_load_path dir =
+  let open Summary.Ref in
   let filter p = not (String.equal p.path_physical dir) in
   load_paths := List.filter filter !load_paths
 
@@ -98,6 +103,7 @@ let warn_overriding_logical_loadpath =
                ; DP.print rocq_path]))
 
 let add_load_path ~installed phys_path rocq_path ~implicit =
+  let open Summary.Ref in
   let phys_path = CUnix.canonical_path_name phys_path in
   let filter p = String.equal p.path_physical phys_path in
   let binding = {
@@ -128,6 +134,7 @@ let add_load_path ~installed phys_path rocq_path ~implicit =
   | _ -> anomaly_too_many_paths phys_path
 
 let filter_path f =
+  let open Summary.Ref in
   let rec aux = function
   | [] -> []
   | p :: l ->
@@ -163,13 +170,14 @@ let expand_path ?root dir =
       full, add_path ~is_installed:path_installed (ph, lg) others
     else
       full, others in
+  let open Summary.Ref in
   let full, others = List.fold_right aux !load_paths (([],[]), ([], [])) in
   (* Returns the dirpath matching exactly and the ordered list of
      -R/-Q blocks with subdirectories that matches *)
   full, others
 
 let locate_file fname =
-  let paths = List.map physical !load_paths in
+  let paths = List.map physical @@ Summary.Ref.get load_paths in
   let _,longfname =
     System.find_file_in_path ~warn:(not !Flags.quiet) paths fname in
   longfname

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -38,6 +38,7 @@ let () = CErrors.register_handler @@ function
 let compat_custom_names = Summary.ref ~stage:Synterp ~name:"compat-custom-names" Id.Map.empty
 
 let add_custom_compat kn =
+  let open Summary.Ref in
   let id = CustomName.label kn in
   compat_custom_names :=
     Id.Map.update id (fun existing -> Some (kn :: Option.default [] existing))
@@ -51,6 +52,7 @@ let warn_compat_custom = CWarnings.create ~name:"deprecated-unqualified-custom-e
         str " by its unqualified name is deprecated.")
 
 let intern_custom_name qid =
+  let open Summary.Ref in
   match Nametab.CustomEntries.locate qid with
   | v -> v
   | exception Not_found ->
@@ -1548,7 +1550,9 @@ let find_subentry_types from n assoc etyps symbols =
 let custom_entry_locality = Summary.ref ~name:"LOCAL-CUSTOM-ENTRY" CustomName.Set.empty
 (** If the entry is present then local *)
 
-let locality_of_custom_entry s = CustomName.Set.mem s !custom_entry_locality
+let locality_of_custom_entry s =
+  let open Summary.Ref in
+  CustomName.Set.mem s !custom_entry_locality
 
 let check_locality_compatibility local custom i_typs =
   if not local then
@@ -2206,6 +2210,7 @@ let load_custom_entry i ((sp,kn),local) =
   Nametab.CustomEntries.push (Until i) sp kn;
   add_custom_compat kn;
   Egramrocq.create_custom_entry kn;
+  let open Summary.Ref in
   let () = if local then
       custom_entry_locality := CustomName.Set.add kn !custom_entry_locality
   in

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -241,7 +241,7 @@ let plugin_init_functions : (unit -> unit) list PluginSpec.Map.t ref = ref Plugi
 
 let add_init_function name f =
   let name = PluginSpec.of_package name in
-  if PluginSpec.Set.mem name !initialized_plugins
+  if PluginSpec.Set.mem name (Summary.Ref.get initialized_plugins)
   then CErrors.anomaly Pp.(str "Not allowed to add init function for already initialized plugin " ++ str (PluginSpec.pp name));
   plugin_init_functions := PluginSpec.Map.update name (function
       | None -> Some [f]
@@ -286,7 +286,7 @@ let perform_cache_obj name =
 let dinit = CDebug.create ~name:"mltop-init" ()
 
 let init_ml_object mname =
-  if PluginSpec.Set.mem mname !initialized_plugins
+  if PluginSpec.Set.mem mname (Summary.Ref.get initialized_plugins)
   then dinit Pp.(fun () -> str "already initialized " ++ str (PluginSpec.pp mname))
   else  begin
     dinit Pp.(fun () -> str "initing " ++ str (PluginSpec.pp mname));
@@ -294,6 +294,7 @@ let init_ml_object mname =
       | l -> List.iter (fun f -> f()) (List.rev l); List.length l
       | exception Not_found -> 0
     in
+    let open Summary.Ref in
     initialized_plugins := PluginSpec.Set.add mname !initialized_plugins;
     dinit Pp.(fun () -> str "finished initing " ++ str (PluginSpec.pp mname) ++ str " (" ++ int n ++ str " init functions)")
   end

--- a/vernac/proof_using.ml
+++ b/vernac/proof_using.ml
@@ -19,7 +19,9 @@ module NamedDecl = Context.Named.Declaration
 let all_collection_id = Id.of_string "All"
 let known_names = Summary.ref [] ~name:"proofusing-nameset"
 
-let is_known_name id = CList.mem_assoc_f Id.equal id !known_names
+let is_known_name id =
+  let open Summary.Ref in
+  CList.mem_assoc_f Id.equal id !known_names
 
 let rec close_fwd env sigma s =
   let s' =
@@ -59,6 +61,7 @@ let err_redefine_all_collection () =
   CErrors.user_err Pp.(str "\"" ++ Id.print all_collection_id ++ str "\" is a predefined collection containing all variables. It can't be redefined.")
 
 let process_expr env sigma e v_ty =
+  let open Summary.Ref in
   let variable_exists id = Termops.is_section_variable_env ~check:false env id in
   let rec aux = function
     | SsEmpty -> Id.Set.empty
@@ -103,6 +106,7 @@ let definition_using env evd ~using ~terms =
   Names.Id.Set.(CList.fold_right add l empty)
 
 let name_set id expr =
+  let open Summary.Ref in
   if Id.equal id all_collection_id then err_redefine_all_collection ();
   if is_known_name id then warn_redefine_collection id;
   (* but we won't warn if id gets declared as a section variable later *)

--- a/vernac/tactic_option.ml
+++ b/vernac/tactic_option.ml
@@ -49,9 +49,10 @@ let warn_default_locality =
          are fine with the change of semantics, disable this warning.")
 
 let declare_tactic_option ?default name =
-  let current_tactic : Gentactic.glob_generic_tactic option ref =
+  let current_tactic : Gentactic.glob_generic_tactic option Summary.Ref.t =
     Summary.ref default ~name:(name^"-default-tactic")
   in
+  let open Summary.Ref in
   let set_current_tactic t =
     current_tactic := t
   in


### PR DESCRIPTION
There is no reason to expose this type as the usual OCaml reference type, and doing so prevents experimenting with more clever implementations where the liboject internals can track the references in a different way.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/1098
- https://github.com/rocq-prover/equations/pull/740
- https://github.com/rocq-community/micromega-plugin/pull/8
- https://github.com/rocq-community/paramcoq/pull/158
- https://github.com/QuickChick/QuickChick/pull/434
- https://github.com/rocq-community/rocq-lean-import/pull/71
- https://github.com/SkySkimmer/rocq-ltac2-compiler/pull/36
- https://github.com/Lysxia/rocq-simple-io/pull/91
- https://github.com/smtcoq/smtcoq/pull/187
- https://github.com/coq-tactician/coq-tactician/pull/142
- https://github.com/impermeable/rocq-waterproof/pull/246