### PR TITLE
Record the checks a module operation skipped

### DIFF
--- a/checker/checkFlags.ml
+++ b/checker/checkFlags.ml
@@ -14,11 +14,13 @@ let set_local_flags flags env =
   (* Explicitly ignored flags are set to not change *)
   let envflags = Environ.typing_flags env in
   let flags = {
-    (* These flags may be overridden *)
-    check_guarded = flags.check_guarded;
-    check_positive = flags.check_positive;
-    check_universes = flags.check_universes;
-    check_eliminations = flags.check_eliminations;
+    (* These flags may be overridden, but only downwards: the env may already
+       be recording checks that the enclosing module operation skipped, and a
+       declaration cannot ask for those back. *)
+    check_guarded = flags.check_guarded && envflags.check_guarded;
+    check_positive = flags.check_positive && envflags.check_positive;
+    check_universes = flags.check_universes && envflags.check_universes;
+    check_eliminations = flags.check_eliminations && envflags.check_eliminations;
     conv_oracle = flags.conv_oracle;
     share_reduction = flags.share_reduction;
     unfold_dep_heuristic = flags.unfold_dep_heuristic;
@@ -37,3 +39,10 @@ let set_local_flags flags env =
    this rather than the environment's flag when deciding whether to recompile
    the VM bytecode of a library. *)
 let enable_vm = ref false
+
+(* Modules record the checks their own operation performed, not the flags some
+   declaration was written under, so only the checks are taken from them: the
+   oracle, sharing and allow_uip belong to the declarations. *)
+let weaken_checks flags env =
+  let envflags = Environ.typing_flags env in
+  Environ.set_typing_flags (Declareops.weaken_checks ~weak:flags envflags) env

--- a/checker/checkFlags.mli
+++ b/checker/checkFlags.mli
@@ -13,3 +13,8 @@ val set_local_flags : Declarations.typing_flags -> Environ.env -> Environ.env
 
 (** Whether the user asked for the VM, i.e. the value of -bytecode-compiler. *)
 val enable_vm : bool ref
+
+(** Turn off in [env] every check that the given flags turn off, leaving the
+    other typing flags of [env] alone. Used for the flags recorded on a module
+    by the operation that built it. *)
+val weaken_checks : Declarations.typing_flags -> Environ.env -> Environ.env

--- a/checker/check_stat.ml
+++ b/checker/check_stat.ml
@@ -40,18 +40,61 @@ let pr_axioms env opac =
   let csts = List.map Constant.to_string opac in
   pr_assumptions "Axioms" csts
 
+(* A module operation records the checks it skipped on the module it produced,
+   because they belong to no declaration: the constant an inlined body came
+   from is gone, and a subtyping check is not a declaration at all. So the
+   flags a declaration is subject to are its own, weakened by those of every
+   module it sits in (#12155, #16646). *)
+let effective_flags env =
+  let cache = ref ModPath.Map.empty in
+  let rec modpath_flags mp =
+    match ModPath.Map.find_opt mp !cache with
+    | Some flags -> flags
+    | None ->
+      let flags = match mp with
+      | MPfile _ | MPbound _ -> Declareops.safe_flags Conv_oracle.empty
+      | MPdot (mp', _) ->
+        let outer = modpath_flags mp' in
+        match Environ.lookup_module mp env with
+        | mb -> Declareops.weaken_checks ~weak:(Mod_declarations.mod_typing_flags mb) outer
+        | exception Not_found -> outer
+      in
+      let () = cache := ModPath.Map.add mp flags !cache in
+      flags
+  in
+  fun mp flags -> Declareops.weaken_checks ~weak:(modpath_flags mp) flags
+
+let fold_flagged env f acc =
+  let eff = effective_flags env in
+  let acc =
+    fold_constants (fun c cb acc ->
+        f (Constant.to_string c) (eff (Constant.modpath c) cb.const_typing_flags) acc)
+      env acc
+  in
+  fold_inductives (fun c cb acc ->
+      f (MutInd.to_string c) (eff (MutInd.modpath c) cb.mind_typing_flags) acc)
+    env acc
+
+let pr_flagged env name test =
+  pr_assumptions name
+    (fold_flagged env (fun s flags acc -> if test flags then s :: acc else acc) [])
+
 let pr_type_in_type env =
-  let csts = fold_constants (fun c cb acc -> if not cb.const_typing_flags.check_universes then Constant.to_string c :: acc else acc) env [] in
-  let csts = fold_inductives (fun c cb acc -> if not cb.mind_typing_flags.check_universes then MutInd.to_string c :: acc else acc) env csts in
-  pr_assumptions "Constants/Inductives relying on type-in-type" csts
+  pr_flagged env "Constants/Inductives relying on type-in-type"
+    (fun flags -> not flags.check_universes)
 
 let pr_unguarded env =
-  let csts = fold_constants (fun c cb acc -> if not cb.const_typing_flags.check_guarded then Constant.to_string c :: acc else acc) env [] in
-  let csts = fold_inductives (fun c cb acc -> if not cb.mind_typing_flags.check_guarded then MutInd.to_string c :: acc else acc) env csts in
-  pr_assumptions "Constants/Inductives relying on unsafe (co)fixpoints" csts
+  pr_flagged env "Constants/Inductives relying on unsafe (co)fixpoints"
+    (fun flags -> not flags.check_guarded)
 
 let pr_nonpositive env =
-  let inds = fold_inductives (fun c cb acc -> if not cb.mind_typing_flags.check_positive then MutInd.to_string c :: acc else acc) env [] in
+  let eff = effective_flags env in
+  let inds =
+    fold_inductives (fun c cb acc ->
+        if not (eff (MutInd.modpath c) cb.mind_typing_flags).check_positive
+        then MutInd.to_string c :: acc else acc)
+      env []
+  in
   pr_assumptions "Inductives whose positivity is assumed" inds
 
 let pr_indices_matter env =

--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -283,6 +283,9 @@ let rec check_mexpression env sign mbtyp mp_mse res = match sign with
 
 let rec check_module env opac mp (mb : Mod_declarations.module_body) opacify =
   Flags.if_verbose Feedback.msg_notice (str "  checking module: " ++ str (ModPath.to_string mp));
+  (* The operation that built this module may have skipped checks; we are
+     redoing that operation, so we skip the same ones (#12155, #16646). *)
+  let env = CheckFlags.weaken_checks (mod_typing_flags mb) env in
   let delta_mb = mod_delta mb in
   let opac =
     check_signature env opac (mod_type mb) mp delta_mb opacify
@@ -321,6 +324,7 @@ let rec check_module env opac mp (mb : Mod_declarations.module_body) opacify =
 
 and check_module_type env mp (mty : Mod_declarations.module_type_body) =
   Flags.if_verbose Feedback.msg_notice (str "  checking module type: " ++ str (ModPath.to_string @@ mp));
+  let env = CheckFlags.weaken_checks (mod_typing_flags mty) env in
   let _ : check_state =
     check_signature env empty_state (mod_type mty) mp (mod_delta mty) empty_cset in
   ()

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -611,10 +611,11 @@ let [_v_sfb;_v_struc;_v_sign;_v_mexpr;_v_impl;v_module;_v_modtype] : _ Vector.t 
            [|v_modbody_resolver; v_struc|]|])  (* Struct *)
   and v_module =
     v_tuple_c ("module_body",
-           [|v_sum_c ("when_mod_body", 0, [|[|v_impl|]|]);v_sign;v_opt v_mexpr;v_modbody_resolver|])
+           [|v_sum_c ("when_mod_body", 0, [|[|v_impl|]|]);v_sign;v_opt v_mexpr;v_modbody_resolver;
+             v_typing_flags|])
   and v_modtype =
     v_tuple_c ("module_type_body",
-           [|v_noimpl;v_sign;v_opt v_mexpr;v_modtype_resolver|])
+           [|v_noimpl;v_sign;v_opt v_mexpr;v_modtype_resolver;v_typing_flags|])
   in
   [v_sfb;v_struc;v_sign;v_mexpr;v_impl;v_module;v_modtype])
 

--- a/dev/doc/critical-bugs.md
+++ b/dev/doc/critical-bugs.md
@@ -11,8 +11,6 @@ This file recollects knowledge about critical bugs found in Coq since version 8.
       - [buffer overflow on large records and closures (infinite loop with OCaml 5)](#buffer-overflow-on-large-records-and-closures-infinite-loop-with-ocaml-5)
       - [memory corruption by evaluating on ill-typed terms (obtained from unsafe tactics)](#memory-corruption-by-evaluating-on-ill-typed-terms-obtained-from-unsafe-tactics)
       - [coqchk checks too little about primitive declarations](#coqchk-checks-too-little-about-primitive-declarations)
-      - [Print Assumptions + Parameter Inline fails to report some inconsistent flags](#print-assumptions-parameter-inline-fails-to-report-some-inconsistent-flags)
-      - [Print Assumptions does not report Unset Universe Checking used during functor application](#print-assumptions-does-not-report-unset-universe-checking-used-during-functor-application)
   - [Fixed bugs](#fixed-bugs)
     - [Typing constructions](#typing-constructions)
       - [substitution missing in the body of a let](#substitution-missing-in-the-body-of-a-let)
@@ -88,6 +86,8 @@ This file recollects knowledge about critical bugs found in Coq since version 8.
       - [Section variables used in side effects not checked by Proof using](#section-variables-used-in-side-effects-not-checked-by-proof-using)
     - [Forgetting unsafe flags](#forgetting-unsafe-flags)
       - [unsafe typing flags used inside a section would not be reported by Print Assumptions after closing the section](#unsafe-typing-flags-used-inside-a-section-would-not-be-reported-by-print-assumptions-after-closing-the-section)
+      - [Print Assumptions + Parameter Inline fails to report some inconsistent flags](#print-assumptions-parameter-inline-fails-to-report-some-inconsistent-flags)
+      - [Print Assumptions does not report Unset Universe Checking used during functor application](#print-assumptions-does-not-report-unset-universe-checking-used-during-functor-application)
     - [Conflicts with axioms in library](#conflicts-with-axioms-in-library)
       - [axiom of description and decidability of equality on real numbers in library Reals was inconsistent with impredicative Set](#axiom-of-description-and-decidability-of-equality-on-real-numbers-in-library-reals-was-inconsistent-with-impredicative-set)
       - [guard condition was unknown to be inconsistent with propositional extensionality in library Sets](#guard-condition-was-unknown-to-be-inconsistent-with-propositional-extensionality-in-library-sets)
@@ -140,28 +140,6 @@ This file recollects knowledge about critical bugs found in Coq since version 8.
 - GH issue number: rocq-prover/rocq#12439
 - exploit: not fully worked out, requires crafted .vo file
 - risk: none (requires crafted .vo file)
-
-#### Print Assumptions + Parameter Inline fails to report some inconsistent flags
-
-- component: module functors
-- introduced: rocq-prover/rocq#79
-- impacted versions: V8.6-NOW
-- impacted coqchk versions: none
-- found by: Jason Gross
-- GH issue number: rocq-prover/rocq#12155
-- exploit: see issue
-- risk: moderate if not using coqchk, none if using coqchk (coqchk rejects the produced file)
-
-#### Print Assumptions does not report Unset Universe Checking used during functor application
-
-- component: module functors
-- introduced: v8.11 (#10291) or earlier
-- impacted versions: V8.11-NOW
-- impacted coqchk versions: none
-- found by: Gaëtan Gilbert
-- GH issue number: rocq-prover/rocq#16646
-- exploit: see issue
-- risk: moderate if not using coqchk, none if using coqchk (coqchk rejects the produced file)
 
 ## Fixed bugs
 
@@ -1093,6 +1071,30 @@ For instance `α` and `__U03b1_` were the same in the native compiler.
 - found by: Anton Trunov
 - GH issue number: rocq-prover/rocq#14317
 - risk: low as it needs the use of explicit unsafe flags
+
+#### Print Assumptions + Parameter Inline fails to report some inconsistent flags
+
+- component: module functors
+- introduced: rocq-prover/rocq#79
+- impacted released versions: V8.6-V9.3
+- impacted coqchk versions: none
+- fixed in: rocq-prover/rocq#XXXXX
+- found by: Jason Gross
+- GH issue number: rocq-prover/rocq#12155
+- exploit: see issue
+- risk: moderate if not using coqchk, none if using coqchk (coqchk rejects the produced file)
+
+#### Print Assumptions does not report Unset Universe Checking used during functor application
+
+- component: module functors
+- introduced: v8.11 (#10291) or earlier
+- impacted released versions: V8.11-V9.3
+- impacted coqchk versions: none
+- fixed in: rocq-prover/rocq#XXXXX
+- found by: Gaëtan Gilbert
+- GH issue number: rocq-prover/rocq#16646
+- exploit: see issue
+- risk: moderate if not using coqchk, none if using coqchk (coqchk rejects the produced file)
 
 ### Conflicts with axioms in library
 

--- a/dev/doc/critical-bugs.md
+++ b/dev/doc/critical-bugs.md
@@ -1078,7 +1078,7 @@ For instance `α` and `__U03b1_` were the same in the native compiler.
 - introduced: rocq-prover/rocq#79
 - impacted released versions: V8.6-V9.3
 - impacted coqchk versions: none
-- fixed in: rocq-prover/rocq#XXXXX
+- fixed in: rocq-prover/rocq#22374
 - found by: Jason Gross
 - GH issue number: rocq-prover/rocq#12155
 - exploit: see issue
@@ -1090,7 +1090,7 @@ For instance `α` and `__U03b1_` were the same in the native compiler.
 - introduced: v8.11 (#10291) or earlier
 - impacted released versions: V8.11-V9.3
 - impacted coqchk versions: none
-- fixed in: rocq-prover/rocq#XXXXX
+- fixed in: rocq-prover/rocq#22374
 - found by: Gaëtan Gilbert
 - GH issue number: rocq-prover/rocq#16646
 - exploit: see issue

--- a/doc/changelog/01-kernel/22374-module-ops-record-unsafe-flags.rst
+++ b/doc/changelog/01-kernel/22374-module-ops-record-unsafe-flags.rst
@@ -6,7 +6,7 @@
   signature, were both lost, so a definition obtained that way was reported as
   closed under the global context; :cmd:`rocqchk` rejected some of these files
   outright instead of reporting them
-  (`#XXXXX <https://github.com/rocq-prover/rocq/pull/XXXXX>`_,
+  (`#22374 <https://github.com/rocq-prover/rocq/pull/22374>`_,
   fixes `#12155 <https://github.com/rocq-prover/rocq/issues/12155>`_
   and `#16646 <https://github.com/rocq-prover/rocq/issues/16646>`_,
   by Jason Gross).

--- a/doc/changelog/01-kernel/22374-module-ops-record-unsafe-flags.rst
+++ b/doc/changelog/01-kernel/22374-module-ops-record-unsafe-flags.rst
@@ -1,10 +1,10 @@
 - **Fixed:**
-  :cmd:`Print Assumptions` and :cmd:`rocqchk`'s context summary now report the
+  :cmd:`Print Assumptions` and ``rocqchk``'s context summary now report the
   checks that were disabled while a module operation ran. Previously the flags
   of a body inlined for ``Parameter Inline``, and the flags in force during a
   functor application, an :cmd:`Include` or the sealing of a module by a
   signature, were both lost, so a definition obtained that way was reported as
-  closed under the global context; :cmd:`rocqchk` rejected some of these files
+  closed under the global context; ``rocqchk`` rejected some of these files
   outright instead of reporting them
   (`#22374 <https://github.com/rocq-prover/rocq/pull/22374>`_,
   fixes `#12155 <https://github.com/rocq-prover/rocq/issues/12155>`_

--- a/doc/changelog/01-kernel/XXXXX-module-ops-record-unsafe-flags.rst
+++ b/doc/changelog/01-kernel/XXXXX-module-ops-record-unsafe-flags.rst
@@ -1,0 +1,12 @@
+- **Fixed:**
+  :cmd:`Print Assumptions` and :cmd:`rocqchk`'s context summary now report the
+  checks that were disabled while a module operation ran. Previously the flags
+  of a body inlined for ``Parameter Inline``, and the flags in force during a
+  functor application, an :cmd:`Include` or the sealing of a module by a
+  signature, were both lost, so a definition obtained that way was reported as
+  closed under the global context; :cmd:`rocqchk` rejected some of these files
+  outright instead of reporting them
+  (`#XXXXX <https://github.com/rocq-prover/rocq/pull/XXXXX>`_,
+  fixes `#12155 <https://github.com/rocq-prover/rocq/issues/12155>`_
+  and `#16646 <https://github.com/rocq-prover/rocq/issues/16646>`_,
+  by Jason Gross).

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -39,6 +39,30 @@ let safe_flags oracle = {
   allow_uip = false;
 }
 
+(* The four checks that are recorded and reported. The remaining fields of
+   [typing_flags] are either not checks at all (the oracle, sharing) or are
+   properties of the theory rather than of a particular check. *)
+
+let same_checks f1 f2 =
+  f1.check_guarded == f2.check_guarded
+  && f1.check_positive == f2.check_positive
+  && f1.check_universes == f2.check_universes
+  && f1.check_eliminations == f2.check_eliminations
+
+let full_checking flags =
+  flags.check_guarded && flags.check_positive
+  && flags.check_universes && flags.check_eliminations
+
+let weaken_checks ~weak flags =
+  if full_checking weak then flags
+  else
+    { flags with
+      check_guarded = flags.check_guarded && weak.check_guarded;
+      check_positive = flags.check_positive && weak.check_positive;
+      check_universes = flags.check_universes && weak.check_universes;
+      check_eliminations = flags.check_eliminations && weak.check_eliminations;
+    }
+
 (** {6 Arities } *)
 
 let hcons_template_universe ar =

--- a/kernel/declareops.mli
+++ b/kernel/declareops.mli
@@ -79,6 +79,20 @@ val is_record_with_eta : mind_specif -> Instance.t -> bool
 (** A default, safe set of flags for kernel type-checking *)
 val safe_flags : Conv_oracle.oracle -> typing_flags
 
+(** The four checks recorded on declarations and modules and reported by
+    [Print Assumptions]: [check_guarded], [check_positive], [check_universes]
+    and [check_eliminations]. *)
+
+val same_checks : typing_flags -> typing_flags -> bool
+
+(** [full_checking flags] holds when [flags] disables none of them. *)
+val full_checking : typing_flags -> bool
+
+(** [weaken_checks ~weak flags] turns off in [flags] every check that [weak]
+    turns off, leaving the other fields of [flags] alone. Physically equal to
+    [flags] when [full_checking weak]. *)
+val weaken_checks : weak:typing_flags -> typing_flags -> typing_flags
+
 (** {6 Hash-consing} *)
 
 (** Here, strictly speaking, we don't perform true hash-consing

--- a/kernel/mod_declarations.ml
+++ b/kernel/mod_declarations.ml
@@ -39,7 +39,13 @@ and 'a generic_module_body =
     mod_type : module_signature; (** expanded type *)
     mod_type_alg : module_expression option; (** algebraic type *)
     mod_delta : 'a Mod_subst.delta_resolver; (**
-      quotiented set of equivalent constants and inductive names *) }
+      quotiented set of equivalent constants and inductive names *)
+    mod_typing_flags : typing_flags; (** the checks that were performed to
+      build this module. Unlike the flags of a constant these are not the
+      flags some declaration was written under: they are the flags of the
+      module operation itself, i.e. of its subtyping checks and of the bodies
+      it inlined. The checker weakens its own re-checking by them, and
+      [Print Assumptions] reports them. *) }
 
 (** For a module, there are five possible situations:
     - [Declare Module M : T] then [mod_expr = Abstract; mod_type_alg = Some T]
@@ -70,11 +76,17 @@ and module_type_body = mod_type generic_module_body
 
 (** Builders *)
 
+(* Nothing was skipped until an operation says so; a module whose own
+   declarations were written under weakened flags records that on those
+   declarations, not here. *)
+let default_typing_flags = Declareops.safe_flags Conv_oracle.empty
+
 let make_module_body typ delta = {
   mod_expr = ModBodyVal FullStruct;
   mod_type = typ;
   mod_type_alg = None;
   mod_delta = delta;
+  mod_typing_flags = default_typing_flags;
 }
 
 let make_module_type typ delta = {
@@ -82,6 +94,7 @@ let make_module_type typ delta = {
   mod_type = typ;
   mod_type_alg = None;
   mod_delta = delta;
+  mod_typing_flags = default_typing_flags;
 }
 
 let strengthen_module_body ~src typ delta mb =
@@ -109,6 +122,7 @@ let module_type_of_module mb = {
   mod_type = mb.mod_type;
   mod_type_alg = None;
   mod_delta = of_body_delta_resolver mb.mod_delta;
+  mod_typing_flags = mb.mod_typing_flags;
 }
 
 let module_body_of_type mtb = {
@@ -119,6 +133,7 @@ let module_body_of_type mtb = {
      of the module type, and a module implementing it does not declare
      anything. *)
   mod_delta = forget_inline_delta_resolver mtb.mod_delta;
+  mod_typing_flags = mtb.mod_typing_flags;
 }
 
 (** Setters *)
@@ -135,12 +150,28 @@ let set_algebraic_type mb alg =
 let set_delta : type a. a delta_resolver -> a generic_module_body -> a generic_module_body =
   fun delta mb -> { mb with mod_delta = delta }
 
+(* Records that the operation which produced [mb] ran under [flags]. Only the
+   checks are taken from [flags]; the rest is not about this module. *)
+let weaken_typing_flags flags mb =
+  let cur = mb.mod_typing_flags in
+  let flags =
+    { cur with
+      check_guarded = cur.check_guarded && flags.check_guarded;
+      check_positive = cur.check_positive && flags.check_positive;
+      check_universes = cur.check_universes && flags.check_universes;
+      check_eliminations = cur.check_eliminations && flags.check_eliminations;
+    }
+  in
+  if Declareops.same_checks flags cur then mb
+  else { mb with mod_typing_flags = flags }
+
 (** Accessors *)
 
 let mod_expr { mod_expr = ModBodyVal v; _ } = v
 let mod_type m = m.mod_type
 let mod_type_alg m = m.mod_type_alg
 let mod_delta m = m.mod_delta
+let mod_typing_flags m = m.mod_typing_flags
 
 let mod_global_delta m = match m.mod_type with
 | MoreFunctor _ -> None
@@ -232,6 +263,7 @@ and hcons_generic_module_body :
     mod_type = type';
     mod_type_alg = type_alg';
     mod_delta = delta';
+    mod_typing_flags = mb.mod_typing_flags;
   }
 
 let hcons_module_body =
@@ -339,6 +371,7 @@ and subst_module_body : type a. _ -> _ -> _ -> _ -> a generic_module_body -> a g
       mod_type = ty';
       mod_type_alg = aty';
       mod_delta = delta';
+      mod_typing_flags = mb.mod_typing_flags;
     }
 
 and subst_module skind subst mp mb =

--- a/kernel/mod_declarations.mli
+++ b/kernel/mod_declarations.mli
@@ -62,6 +62,12 @@ val mod_type : 'a generic_module_body -> module_signature
 val mod_type_alg : 'a generic_module_body -> module_expression option
 val mod_delta : 'a generic_module_body -> 'a delta_resolver
 
+(** The checks that were performed by the module operation which built this
+    module: its subtyping checks, and the bodies it inlined. Not the flags the
+    module's own declarations were written under -- those are recorded on the
+    declarations. *)
+val mod_typing_flags : 'a generic_module_body -> Declarations.typing_flags
+
 val mod_global_delta : 'a generic_module_body -> 'a delta_resolver option
 (** [None] if the argument is a functor, [mod_delta] otherwise *)
 
@@ -94,6 +100,12 @@ val set_delta : 'a Mod_subst.delta_resolver -> 'a generic_module_body -> 'a gene
 val set_signature : module_signature -> 'a generic_module_body -> 'a generic_module_body
 (** Replace the expanded type, keeping the implementation and the algebraic
     type. *)
+
+(** [weaken_typing_flags flags mb] records that the operation which produced
+    [mb] ran with the checks of [flags]. Physically equal to [mb] when that
+    adds nothing. *)
+val weaken_typing_flags : Declarations.typing_flags ->
+  'a generic_module_body -> 'a generic_module_body
 
 (** {6 Substitution} *)
 

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -261,15 +261,20 @@ let check_with ustate vmstate env mp (sign,reso,cst,vm) = function
     let reso' = add_delta_resolver reso (upcast_delta_resolver mp subreso) in
     NoFunctor struc', reso', cst, vm
 
-let check_with_alg ustate vmstate env mp (sign, alg, reso, cst, vm) wd =
+let check_with_alg ustate vmstate env mp (sign, alg, reso, cst, vm, flags) wd =
   let struc, reso, cst, vm = check_with ustate vmstate env mp (sign, reso, cst, vm) wd in
-  struc, MEwith (alg, wd), reso, cst, vm
+  (* [with Definition] typechecks a term with whatever checks are in force. *)
+  let flags = Declareops.weaken_checks ~weak:(Environ.typing_flags env) flags in
+  struc, MEwith (alg, wd), reso, cst, vm, flags
 
-let rec translate_apply ustate env inl mp subst (sign, reso, cst) args = match args with
+(* [flags] accumulates what the application skipped: the checks in force for
+   its subtyping checks, and the checks the inlined bodies were accepted with.
+   Neither leaves any other trace in the resulting module (#12155, #16646). *)
+let rec translate_apply ustate env inl mp subst (sign, reso, cst, flags) args = match args with
 | [] ->
   let sign = subst_signature subst mp sign in
   let reso = subst_codom_delta_resolver subst reso in
-  (sign, reso, cst)
+  (sign, reso, cst, flags)
 | mp1 :: args ->
   let farg_id, farg_b, sign = destr_functor sign in
   let farg_b =
@@ -278,10 +283,11 @@ let rec translate_apply ustate env inl mp subst (sign, reso, cst) args = match a
   in
   let cst = Subtyping.check_subtypes (cst, ustate) env mp1 (MPbound farg_id) farg_b in
   let mp_delta = discr_resolver mp1 (lookup_module mp1 env) in
-  let mp_delta = inline_delta_resolver env inl mp1 farg_id farg_b mp_delta in
+  let mp_delta, inlined = inline_delta_resolver env inl mp1 farg_id farg_b mp_delta in
+  let flags = Declareops.weaken_checks ~weak:inlined flags in
   let nsubst = map_mbid farg_id mp1 mp_delta in
   let subst = join subst nsubst in
-  translate_apply ustate env inl mp subst (sign, reso, cst) args
+  translate_apply ustate env inl mp subst (sign, reso, cst, flags) args
 
 (** Translation of a module struct entry :
     - We translate to a module when a [module_path] is given,
@@ -306,14 +312,15 @@ let rec translate_mse (cst, ustate) (vm, vmstate) env mpo inl me = match me with
         let mt = lookup_modtype mp1 env in
         mod_type mt, mod_delta mt
     in
-    sign, me, reso, cst, vm
+    sign, me, reso, cst, vm, Declareops.safe_flags (Environ.oracle env)
   | MEapply _ ->
     let fe, args = decompose_apply [] me in
-    let (sign, alg, reso, cst, vm) = translate_mse (cst, ustate) (vm, vmstate) env mpo inl fe in
+    let (sign, alg, reso, cst, vm, flags) = translate_mse (cst, ustate) (vm, vmstate) env mpo inl fe in
     let mp = match mpo with Some mp -> mp | None -> mp_from_mexpr fe in
-    let (sign, reso, cst) = translate_apply ustate env inl mp empty_subst (sign, reso, cst) args in
+    let flags = Declareops.weaken_checks ~weak:(Environ.typing_flags env) flags in
+    let (sign, reso, cst, flags) = translate_apply ustate env inl mp empty_subst (sign, reso, cst, flags) args in
     let alg = List.fold_left (fun accu arg -> MEapply (accu, arg)) alg args in
-    (sign, alg, reso, cst, vm)
+    (sign, alg, reso, cst, vm, flags)
   | MEwith(me, with_decl) ->
     assert (Option.is_empty mpo); (* No 'with' syntax for modules *)
     let mp = mp_from_mexpr me in
@@ -323,34 +330,34 @@ let mk_modtype = Mod_declarations.make_module_type
 
 let rec translate_mse_funct (cst, ustate) (vm, vmstate) env ~is_mod mp inl mse = function
   | [] ->
-    let sign,alg,reso,cst,vm = translate_mse (cst, ustate) (vm, vmstate) env (if is_mod then Some mp else None) inl mse in
+    let sign,alg,reso,cst,vm,flags = translate_mse (cst, ustate) (vm, vmstate) env (if is_mod then Some mp else None) inl mse in
     let sign,reso =
       if is_mod then sign,reso
       else subst_modtype_signature_and_resolver (mp_from_mexpr mse) mp sign reso in
-    sign, MENoFunctor alg, reso, cst, vm
+    sign, MENoFunctor alg, reso, cst, vm, flags
   | (mbid, ty, ty_inl) :: params ->
     let mp_id = MPbound mbid in
     let mtb, cst, vm = translate_modtype (cst, ustate) (vm, vmstate) env mp_id ty_inl ([],ty) in
     let env' = add_module_parameter mbid mtb env in
-    let sign,alg,reso,cst,vm = translate_mse_funct (cst, ustate) (vm, vmstate) env' ~is_mod mp inl mse params in
+    let sign,alg,reso,cst,vm,flags = translate_mse_funct (cst, ustate) (vm, vmstate) env' ~is_mod mp inl mse params in
     let alg' = MEMoreFunctor alg in
-    MoreFunctor (mbid, mtb, sign), alg',reso, cst, vm
+    MoreFunctor (mbid, mtb, sign), alg',reso, cst, vm, flags
 
 and translate_modtype state vmstate env mp inl (params,mte) =
-  let sign,alg,reso,cst,vm = translate_mse_funct state vmstate env ~is_mod:false mp inl mte params in
+  let sign,alg,reso,cst,vm,flags = translate_mse_funct state vmstate env ~is_mod:false mp inl mte params in
   let mtb = mk_modtype sign reso in
-  set_algebraic_type mtb alg, cst, vm
+  weaken_typing_flags flags (set_algebraic_type mtb alg), cst, vm
 
 (** [finalize_module] :
     from an already-translated (or interactive) implementation and
     an (optional) signature entry, produces a final [module_body] *)
 
-let finalize_module_alg (cst, ustate) (vm, vmstate) env mp (sign,alg,reso) restype = match restype with
+let finalize_module_alg (cst, ustate) (vm, vmstate) env mp (sign,alg,reso,flags) restype = match restype with
   | None ->
     let impl = match alg with Some e -> Algebraic e | None -> FullStruct in
     let mb = make_module_body sign (forget_inline_delta_resolver reso) in
     let mb = set_implementation impl mb in
-    mb, cst, vm
+    weaken_typing_flags flags mb, cst, vm
   | Some (params_mte,inl) ->
     let res_mtb, cst, vm = translate_modtype (cst, ustate) (vm, vmstate) env mp inl params_mte in
     let auto_mtb =
@@ -372,13 +379,17 @@ let finalize_module_alg (cst, ustate) (vm, vmstate) env mp (sign,alg,reso) resty
     in
     let mb = module_body_of_type res_mtb in
     let mb = set_implementation impl mb in
+    (* Sealing M with T is a check of its own, run with whatever checks are in
+       force here. *)
+    let mb = weaken_typing_flags (Environ.typing_flags env) mb in
+    let mb = weaken_typing_flags flags mb in
     mb,
     (** constraints from module body typing + subtyping + module type. *)
     cst,
     vm
 
-let finalize_module univs vm env mp (sign, reso) typ =
-  finalize_module_alg univs vm env mp (sign, None, reso) typ
+let finalize_module univs vm env mp (sign, reso, flags) typ =
+  finalize_module_alg univs vm env mp (sign, None, reso, flags) typ
 
 let translate_module (cst, ustate) (vm, vmstate) env mp inl = function
   | MType (params,ty) ->
@@ -388,7 +399,7 @@ let translate_module (cst, ustate) (vm, vmstate) env mp inl = function
        declarations of [T], which the module body itself cannot hold. *)
     (module_body_of_type mtb, mod_global_delta mtb), cst, vm
   | MExpr (params,mse,oty) ->
-    let (sg,alg,reso,cst,vm) = translate_mse_funct (cst, ustate) (vm, vmstate) env ~is_mod:true mp inl mse params in
+    let (sg,alg,reso,cst,vm,flags) = translate_mse_funct (cst, ustate) (vm, vmstate) env ~is_mod:true mp inl mse params in
     let restype = Option.map (fun ty -> ((params,ty),inl)) oty in
     (* finalize_module_alg expects the subcomponents to be part of the environment *)
     let env = match sg with
@@ -396,7 +407,7 @@ let translate_module (cst, ustate) (vm, vmstate) env mp inl = function
     | MoreFunctor _ -> env
     in
     let mb, cst, vm =
-      finalize_module_alg (cst, ustate) (vm, vmstate) env mp (sg,Some alg,reso) restype
+      finalize_module_alg (cst, ustate) (vm, vmstate) env mp (sg,Some alg,reso,flags) restype
     in
     let delta = Option.map of_body_delta_resolver (mod_global_delta mb) in
     (mb, delta), cst, vm
@@ -432,12 +443,13 @@ let rec translate_mse_include_module (cst, ustate) (vm, vmstate) env mp inl = fu
   | MEident mp1 ->
     let mb = strengthen_and_subst_module_body mp1 (lookup_module mp1 env) mp true in
     let sign = clean_bounded_mod_expr (mod_type mb) in
-    sign, (), of_body_delta_resolver (mod_delta mb), cst, vm
+    sign, (), of_body_delta_resolver (mod_delta mb), cst, vm, mod_typing_flags mb
   | MEapply _ as me ->
     let fe, args = decompose_apply [] me in
-    let (sign, (), reso, cst, vm) = translate_mse_include_module (cst, ustate) (vm, vmstate) env mp inl fe in
-    let (sign, reso, cst) = translate_apply ustate env inl mp empty_subst (sign, reso, cst) args in
-    (sign, (), reso, cst, vm)
+    let (sign, (), reso, cst, vm, flags) = translate_mse_include_module (cst, ustate) (vm, vmstate) env mp inl fe in
+    let flags = Declareops.weaken_checks ~weak:(Environ.typing_flags env) flags in
+    let (sign, reso, cst, flags) = translate_apply ustate env inl mp empty_subst (sign, reso, cst, flags) args in
+    (sign, (), reso, cst, vm, flags)
   | MEwith _ -> assert false (* No 'with' syntax for modules *)
 
 let translate_mse_include is_mod (cst, ustate) (vm, vmstate) env mp inl me =
@@ -447,4 +459,4 @@ let translate_mse_include is_mod (cst, ustate) (vm, vmstate) env mp inl me =
   else
     let mtb, cst, vm = translate_modtype (cst, ustate) (vm, vmstate) env mp inl ([],me) in
     let sign = clean_bounded_mod_expr (mod_type mtb) in
-    sign, (), mod_delta mtb, cst, vm
+    sign, (), mod_delta mtb, cst, vm, mod_typing_flags mtb

--- a/kernel/mod_typing.mli
+++ b/kernel/mod_typing.mli
@@ -49,7 +49,8 @@ val translate_modtype :
 val finalize_module :
   ('a, Conversion.graph_inconsistency) Conversion.universe_state ->
   'b vm_state ->
-  env -> ModPath.t -> module_signature * mod_type delta_resolver ->
+  env -> ModPath.t ->
+  module_signature * mod_type delta_resolver * Declarations.typing_flags ->
   (module_type_entry * inline) option ->
   module_body * 'a * 'b
 
@@ -58,4 +59,5 @@ val finalize_module :
 
 val translate_mse_include :
   bool -> ('a, Conversion.graph_inconsistency) Conversion.universe_state -> 'b vm_state -> Environ.env -> ModPath.t -> inline ->
-  module_struct_entry -> module_signature * unit * mod_type delta_resolver * 'a * 'b
+  module_struct_entry ->
+  module_signature * unit * mod_type delta_resolver * 'a * 'b * Declarations.typing_flags

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -537,6 +537,10 @@ let clean_bounded_mod_expr sign =
    [delta] it starts from is the resolver of the module being passed. *)
 let inline_delta_resolver env inl mp mbid mtb delta =
   let constants = inline_of_delta inl (mod_delta mtb) in
+  (* Inlining a body leaves nothing pointing at the constant it came from, so
+     the checks that were skipped to accept it have to be recorded on the
+     module the body ends up in (#12155). *)
+  let flags = ref (Declareops.safe_flags (Environ.oracle env)) in
   let rec make_inline delta = function
     | [] -> delta
     | kn :: r ->
@@ -551,8 +555,12 @@ let inline_delta_resolver env inl mp mbid mtb delta =
         match constant.const_body with
         | Undef _ | OpaqueDef _ | Primitive _ | Symbol _ -> l
         | Def constr ->
+          let () =
+            flags := Declareops.weaken_checks ~weak:constant.const_typing_flags !flags
+          in
           let ctx = Declareops.constant_polymorphic_context constant in
           let constr = {UVars.univ_abstracted_value=constr; univ_abstracted_binder=ctx} in
           add_inline_body_delta_resolver kn constr l
   in
-  make_inline (forget_inline_delta_resolver delta) constants
+  let delta = make_inline (forget_inline_delta_resolver delta) constants in
+  delta, !flags

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -81,9 +81,11 @@ val subst_modtype_signature_and_resolver : ModPath.t -> ModPath.t ->
 
 (** {6 Building map of constants to inline } *)
 
+(** Also returns the flags the inlined bodies were checked with, for the
+    caller to record on the module they end up in. *)
 val inline_delta_resolver :
   env -> inline -> ModPath.t -> MBId.t -> module_type_body ->
-  'a delta_resolver -> mod_subst delta_resolver
+  'a delta_resolver -> mod_subst delta_resolver * typing_flags
 (** Enrich the resolver of the module being passed as a functor argument with
     the bodies of the fields the parameter type declared [Inline]. The result
     carries inlined bodies, hence is a substitution resolver. *)

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -231,6 +231,9 @@ type safe_environment =
     modpath : ModPath.t;
     modvariant : modvariant;
     modresolver : Mod_subst.mod_type Mod_subst.delta_resolver;
+    modflags : Declarations.typing_flags;
+    (** checks skipped by module operations performed inside the module being
+        built, i.e. by [Include]; see [Mod_declarations.mod_typing_flags] *)
     paramresolver : ParamResolver.t;
     revstruct : structure_body;
     modlabels : Id.Set.t;
@@ -262,6 +265,7 @@ let empty_environment =
     modpath = ModPath.dummy;
     modvariant = NONE;
     modresolver = Mod_subst.empty_delta_resolver ModPath.dummy;
+    modflags = Declareops.safe_flags Conv_oracle.empty;
     paramresolver = ParamResolver.empty DirPath.dummy;
     revstruct = [];
     modlabels = Id.Set.empty;
@@ -1419,6 +1423,7 @@ let start_mod_modtype ~istype l senv =
     env = senv.env;
     future_cst = senv.future_cst;
     modresolver = Mod_subst.empty_delta_resolver mp;
+    modflags = Declareops.safe_flags (Environ.oracle senv.env);
     paramresolver = ParamResolver.add_delta_resolver senv.modpath senv.modresolver senv.paramresolver;
     univ = senv.univ;
     qualities = senv.qualities;
@@ -1502,7 +1507,7 @@ let build_module_body params restype senv =
   (* XXX why are we dropping vmtab here? *)
   let mb, _, _vmtab =
     Mod_typing.finalize_module state vmstate senv.env senv.modpath
-      (struc, senv.modresolver) restype'
+      (struc, senv.modresolver, senv.modflags) restype'
   in
   let mb' = functorize_module params mb in
   mb'
@@ -1584,16 +1589,23 @@ let add_include me is_module inl senv =
   let mp_sup = senv.modpath in
   let state = check_state senv in
   let vmstate = vm_state senv in
-  let sign,(),resolver, _, vmtab =
+  let sign,(),resolver, _, vmtab, flags =
     translate_mse_include is_module state vmstate senv.env mp_sup inl me
   in
   let senv = set_vm_library vmtab senv in
+  (* An Include is an operation of the module we are building: what it skipped
+     is recorded on that module, not on the fields it adds. *)
+  let senv =
+    { senv with modflags = Declareops.weaken_checks ~weak:flags senv.modflags }
+  in
   (* Include Self support  *)
   let struc = NoFunctor (List.rev senv.revstruct) in
   let mb =
     Mod_declarations.make_module_body struc
       (Mod_subst.forget_inline_delta_resolver senv.modresolver)
   in
+  (* Include Self applies the functor here; same accounting as an application. *)
+  let incl_flags = ref (Environ.typing_flags senv.env) in
   let rec compute_sign sign resolver =
     match sign with
     | MoreFunctor(mbid,mtb,str) ->
@@ -1601,15 +1613,21 @@ let add_include me is_module inl senv =
       (* Module subcomponents are already part of senv.env at this point *)
       let env = Environ.shallow_add_module mp_sup mb senv.env in
       let (_ : UGraph.t) = Subtyping.check_subtypes state env mp_sup (MPbound mbid) mtb in
-      let mpsup_delta =
+      let mpsup_delta, inlined =
         Modops.inline_delta_resolver senv.env inl mp_sup mbid mtb senv.modresolver
       in
+      let () = incl_flags := Declareops.weaken_checks ~weak:inlined !incl_flags in
       let subst = Mod_subst.map_mbid mbid mp_sup mpsup_delta in
       let resolver = Mod_subst.subst_codom_delta_resolver subst resolver in
       compute_sign (Modops.subst_signature subst mp_sup str) resolver
     | NoFunctor str -> resolver, str
   in
   let resolver, str = compute_sign sign resolver in
+  let senv = match sign with
+  | NoFunctor _ -> senv (* nothing was applied, nothing was checked *)
+  | MoreFunctor _ ->
+    { senv with modflags = Declareops.weaken_checks ~weak:!incl_flags senv.modflags }
+  in
   let senv = update_resolver (Mod_subst.add_delta_resolver resolver) senv in
   let add senv ((l,elem) as field) =
     let new_name = match elem with
@@ -1665,6 +1683,7 @@ let start_library dir senv =
     required = senv.required;
 
     modresolver = Mod_subst.empty_delta_resolver mp;
+    modflags = Declareops.safe_flags (Environ.oracle senv.env);
     paramresolver = ParamResolver.empty dir;
     revstruct = [];
     modlabels = Id.Set.empty;

--- a/test-suite/output-coqchk/bug_12155.out
+++ b/test-suite/output-coqchk/bug_12155.out
@@ -1,0 +1,28 @@
+
+CONTEXT SUMMARY
+===============
+
+* Theory: Set is predicative
+  
+* Theory: Rewrite rules are not allowed
+  
+* Axioms:
+    bug_12155.M4.t
+  
+* Constants/Inductives relying on type-in-type:
+    bug_12155.Impl1.foo
+    bug_12155.M4.t
+    bug_12155.M3.u
+    bug_12155.M2.u
+    bug_12155.M1.foo
+  
+* Constants/Inductives relying on unsafe (co)fixpoints:
+    bug_12155.Impl5.f
+    bug_12155.M5.g
+  
+* Inductives whose positivity is assumed: <none>
+  
+* Inductives relying on indices not mattering:
+    Corelib.Init.Datatypes.eq_true
+    Corelib.Init.Logic.eq
+  

--- a/test-suite/output-coqchk/bug_12155.v
+++ b/test-suite/output-coqchk/bug_12155.v
@@ -1,0 +1,64 @@
+(* The checks a module operation skipped are recorded on the module it
+   produced: the constant an inlined body came from is gone (#12155), and the
+   operation's own subtyping checks belong to no declaration (#16646). *)
+
+Module Type T1.
+  Parameter Inline foo : Set.
+End T1.
+Module Impl1.
+  Unset Universe Checking.
+  Definition foo : Set := Set.
+  Set Universe Checking.
+End Impl1.
+Module F1 (X : T1).
+  Definition foo := X.foo.
+End F1.
+(* #12155: the inlined body was checked with universe checking off. *)
+Module M1 := F1 Impl1.
+
+Module Type T2.
+  Parameter t : Set.
+End T2.
+Module F2 (X : T2).
+  Definition u : Set := X.t.
+End F2.
+Module Impl2.
+  Definition t := Set.
+End Impl2.
+
+(* #16646: the application itself ran with universe checking off. *)
+Unset Universe Checking.
+Module M2 := F2 Impl2.
+Set Universe Checking.
+
+(* The same through Include ... *)
+Module M3.
+  Unset Universe Checking.
+  Include F2 Impl2.
+  Set Universe Checking.
+End M3.
+
+(* ... and through sealing. *)
+Unset Universe Checking.
+Module M4 : T2 := Impl2.
+Set Universe Checking.
+
+(* Not only universes: an inlined body accepted with the guard condition off. *)
+Module Type T5.
+  Parameter Inline f : nat -> nat.
+End T5.
+Module Impl5.
+  Unset Guard Checking.
+  Fixpoint f (n : nat) : nat := f n.
+  Set Guard Checking.
+End Impl5.
+Module F5 (X : T5).
+  Definition g := X.f.
+End F5.
+Module M5 := F5 Impl5.
+
+(* With every check on there is nothing to record. *)
+Module Impl6.
+  Definition t : Set := nat.
+End Impl6.
+Module M6 := F2 Impl6.

--- a/test-suite/output/bug_12155.out
+++ b/test-suite/output/bug_12155.out
@@ -1,0 +1,11 @@
+Axioms:
+M1.foo relies on an unsafe hierarchy.
+Axioms:
+M2.u relies on an unsafe hierarchy.
+Axioms:
+M3.u relies on an unsafe hierarchy.
+Axioms:
+M4.t relies on an unsafe hierarchy.
+Axioms:
+M5.g is assumed to be guarded.
+Closed under the global context

--- a/test-suite/output/bug_12155.v
+++ b/test-suite/output/bug_12155.v
@@ -1,0 +1,71 @@
+(* The checks a module operation skipped are recorded on the module it
+   produced: the constant an inlined body came from is gone (#12155), and the
+   operation's own subtyping checks belong to no declaration (#16646). *)
+
+Module Type T1.
+  Parameter Inline foo : Set.
+End T1.
+Module Impl1.
+  Unset Universe Checking.
+  Definition foo : Set := Set.
+  Set Universe Checking.
+End Impl1.
+Module F1 (X : T1).
+  Definition foo := X.foo.
+End F1.
+(* #12155: the inlined body was checked with universe checking off. *)
+Module M1 := F1 Impl1.
+
+Module Type T2.
+  Parameter t : Set.
+End T2.
+Module F2 (X : T2).
+  Definition u : Set := X.t.
+End F2.
+Module Impl2.
+  Definition t := Set.
+End Impl2.
+
+(* #16646: the application itself ran with universe checking off. *)
+Unset Universe Checking.
+Module M2 := F2 Impl2.
+Set Universe Checking.
+
+(* The same through Include ... *)
+Module M3.
+  Unset Universe Checking.
+  Include F2 Impl2.
+  Set Universe Checking.
+End M3.
+
+(* ... and through sealing. *)
+Unset Universe Checking.
+Module M4 : T2 := Impl2.
+Set Universe Checking.
+
+(* Not only universes: an inlined body accepted with the guard condition off. *)
+Module Type T5.
+  Parameter Inline f : nat -> nat.
+End T5.
+Module Impl5.
+  Unset Guard Checking.
+  Fixpoint f (n : nat) : nat := f n.
+  Set Guard Checking.
+End Impl5.
+Module F5 (X : T5).
+  Definition g := X.f.
+End F5.
+Module M5 := F5 Impl5.
+
+(* With every check on there is nothing to record. *)
+Module Impl6.
+  Definition t : Set := nat.
+End Impl6.
+Module M6 := F2 Impl6.
+
+Print Assumptions M1.foo.
+Print Assumptions M2.u.
+Print Assumptions M3.u.
+Print Assumptions M4.t.
+Print Assumptions M5.g.
+Print Assumptions M6.u.

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -146,14 +146,51 @@ let lookup_constant_in_impl cst fallback =
           Pp.(str "Print Assumption: unknown constant "
             ++ Constant.print cst ++ str ".")
 
+(** A module operation may have skipped checks that no declaration it produced
+    records: the body it inlined for [Parameter Inline] no longer points at the
+    constant that knew, and its own subtyping checks belong to no declaration
+    at all. The module records them instead, so we walk up from the constant
+    (#12155, #16646). We follow the user name: for a sealed module it is the
+    sealing that skipped the check, not the implementation. *)
+
+let modpath_flags_cache = ref (ModPath.Map.empty : typing_flags ModPath.Map.t)
+
+let rec modpath_flags mp =
+  match ModPath.Map.find_opt mp !modpath_flags_cache with
+  | Some flags -> flags
+  | None ->
+    let flags = match mp with
+    | MPfile _ | MPbound _ -> Declareops.safe_flags Conv_oracle.empty
+    | MPdot (mp', _) ->
+      let outer = modpath_flags mp' in
+      match lookup_module_in_impl mp with
+      | mb -> Declareops.weaken_checks ~weak:(mod_typing_flags mb) outer
+      | exception Not_found -> outer
+    in
+    let () = modpath_flags_cache := ModPath.Map.add mp flags !modpath_flags_cache in
+    flags
+
+let weaken_constant mp cb =
+  let flags = Declareops.weaken_checks ~weak:(modpath_flags mp) cb.const_typing_flags in
+  if flags == cb.const_typing_flags then cb
+  else { cb with const_typing_flags = flags }
+
+let weaken_mind mp mib =
+  let flags = Declareops.weaken_checks ~weak:(modpath_flags mp) mib.mind_typing_flags in
+  if flags == mib.mind_typing_flags then mib
+  else { mib with mind_typing_flags = flags }
+
 let lookup_constant cst =
   let env = Global.env() in
-  if not (Environ.mem_constant cst env)
-  then lookup_constant_in_impl cst None
-  else
-    let cb = Environ.lookup_constant cst env in
-    if Declareops.constant_has_body cb then cb
-    else lookup_constant_in_impl cst (Some cb)
+  let cb =
+    if not (Environ.mem_constant cst env)
+    then lookup_constant_in_impl cst None
+    else
+      let cb = Environ.lookup_constant cst env in
+      if Declareops.constant_has_body cb then cb
+      else lookup_constant_in_impl cst (Some cb)
+  in
+  weaken_constant (Constant.modpath cst) cb
 
 let lookup_mind_in_impl mind =
   try
@@ -167,8 +204,11 @@ let lookup_mind_in_impl mind =
 
 let lookup_mind mind =
   let env = Global.env() in
-  if Environ.mem_mind mind env then Environ.lookup_mind mind env
-  else lookup_mind_in_impl mind
+  let mib =
+    if Environ.mem_mind mind env then Environ.lookup_mind mind env
+    else lookup_mind_in_impl mind
+  in
+  weaken_mind (MutInd.modpath mind) mib
 
 (** Graph traversal of an object, collecting on the way the dependencies of
     traversed objects *)
@@ -350,6 +390,7 @@ and traverse_context access current ctx accu ctxt =
 
 let traverse access grs =
   let () = modcache := ModPath.Map.empty in
+  let () = modpath_flags_cache := ModPath.Map.empty in
   let env = Global.env () in
   List.fold_left (fun accu gr ->
     let t, _ = UnivGen.fresh_global_instance env gr in

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -193,7 +193,8 @@ struct
           let resolver = match mod_global_delta mb with
           | None -> empty_delta_resolver mp
           | Some delta ->
-            Modops.inline_delta_resolver env inl mp farg_id farg_b delta
+            (* the flags are recorded by the kernel, see Mod_typing *)
+            fst (Modops.inline_delta_resolver env inl mp farg_id farg_b delta)
           in
           mbid_left,join (map_mbid mbid mp resolver) subst
 
@@ -1027,7 +1028,8 @@ let inlined_bodies env inl ~is_mod me =
       | None -> accu (* a functor argument declares nothing *)
       | Some delta ->
         let reso =
-          Modops.inline_delta_resolver env inl mparg farg_id farg_b delta
+          (* the flags are recorded by the kernel, see Mod_typing *)
+          fst (Modops.inline_delta_resolver env inl mparg farg_id farg_b delta)
         in
         let fold kn c accu =
           let can = Constant.canonical (constant_of_delta_kn delta kn) in
@@ -1192,7 +1194,8 @@ let end_module_core id m_info objects fs =
   let state = ((Global.universes (), Univ.UnivConstraints.empty), Reductionops.inferred_universes) in
   let _, (_, cst), _ =
     Mod_typing.finalize_module state vm_state (Global.env ()) (Global.current_modpath ())
-      (struc, current_modresolver ()) restype'
+      (* only the constraints are used here; the kernel records the flags *)
+      (struc, current_modresolver (), Declareops.safe_flags Conv_oracle.empty) restype'
   in
   let () = Global.add_univ_constraints cst in
 
@@ -1489,7 +1492,8 @@ let rec include_subst env mp reso mbids sign inline = match mbids with
   | mbid::mbids ->
     let farg_id, farg_b, fbody_b = Modops.destr_functor sign in
     let subst = include_subst env mp reso mbids fbody_b inline in
-    let mp_delta =
+    let mp_delta, _flags =
+      (* the flags are recorded by the kernel, see Mod_typing *)
       Modops.inline_delta_resolver env inline mp farg_id farg_b reso
     in
     join (map_mbid mbid mp mp_delta) subst
@@ -1530,7 +1534,7 @@ let declare_one_include_core (me,base,kind,inl) =
   let base_mp = get_module_path me in
 
   let state = ((Global.universes (), Univ.UnivConstraints.empty), Reductionops.inferred_universes) in
-  let sign, (), resolver, (_, cst), _ =
+  let sign, (), resolver, (_, cst), _, _flags =
     Mod_typing.translate_mse_include is_mod state vm_state (Global.env ()) (Global.current_modpath ()) inl me
   in
   let () = Global.add_univ_constraints cst in
@@ -1551,7 +1555,8 @@ let declare_one_include_core (me,base,kind,inl) =
       let mpsup_delta = match mod_global_delta mb with
       | None -> assert false (* mb is guaranteed not to be a functor here *)
       | Some delta ->
-        Modops.inline_delta_resolver (Global.env ()) inl cur_mp mbid mtb delta
+        (* the flags are recorded by the kernel, see Safe_typing.add_include *)
+        fst (Modops.inline_delta_resolver (Global.env ()) inl cur_mp mbid mtb delta)
       in
       let subst = Mod_subst.map_mbid mbid cur_mp mpsup_delta in
       compute_sign (Modops.subst_signature subst cur_mp str)


### PR DESCRIPTION
`Print Assumptions` reports a definition as closed under the global context when it was built with universe checking off, if a module operation was involved.

```coq
Module Type T. Parameter Inline foo : Set. End T.
Module Impl.
  Unset Universe Checking.
  Definition foo : Set := Set.
  Set Universe Checking.
End Impl.
Module F (X : T). Definition foo := X.foo. End F.
Module M := F Impl.
Print Assumptions M.foo.   (* Closed under the global context *)
```

Four shapes, one cause. The operation either inlines a body someone else checked (`Parameter Inline`, above, #12155) or runs its own subtyping check (functor application #16646, `Include`, sealing `Module M : T := X`). Neither leaves a trace in a declaration: inlining drops the reference to the constant that recorded the skipped check, and a subtyping check belongs to no declaration at all.

Not only universes. The same setup with `Unset Guard Checking` and a non-terminating `Fixpoint` makes `rocq compile` accept and `rocqchk` reject with `Type error: IllFormedRecBody`, because the derived constant claims a guard check nobody ran.

### Fix

Module bodies get `mod_typing_flags`: the checks the operation actually performed, i.e. the flags in force for its subtyping checks, met with the flags of every body it inlined. An ordinary module records full checking.

- `rocqchk` weakens its own re-checking by them at the top of `check_module`. It has to be the module and not the declarations, because the checker redoes the operation: `check_mexpr` re-runs `check_subtypes` for the application, `check_module` re-compares the result against the stored signature, and neither is attributable to a declaration. `CheckFlags.set_local_flags` becomes a meet, so an inner declaration cannot ask back for a check the enclosing operation skipped.
- `Print Assumptions` reports a constant under the flags of the modules it sits in, following the user name — for a sealed module it is the sealing that skipped the check, not the implementation.

Behaviour change: `rocqchk` now **accepts** these files and lists the constants under `Constants/Inductives relying on type-in-type` (or `... unsafe (co)fixpoints`), where before it rejected two of the four.

All four `check_*` travel, `check_eliminations` included, though nothing can currently set that one.

`.vo` gains one field on module bodies. `vo_magic` is derived from the version number, so there is nothing to bump.

### Tests

`test-suite/output/bug_12155.v` for what `Print Assumptions` says and `test-suite/output-coqchk/bug_12155.v` for what the checker says, covering the four shapes, the guard case, and one where nothing is recorded. Full test-suite green.

Fixes #12155, fixes #16646.

Turned up on the way, unrelated: `rocqchk` printed `Anomaly "Uncaught exception Modops.ModuleTypingError(_)"` for two of these rather than an error message — #22373.

---

Opened autonomously by Claude (Opus 5) on behalf of Jason Gross (jason@theorem.dev).
