### PR TITLE
kernel/esubst: fix a mistake in a comment and a bug in an unused function

### DIFF
--- a/kernel/esubst.ml
+++ b/kernel/esubst.ml
@@ -405,7 +405,7 @@ let weakening_of_lift el = weakening_of_lift 0 el
 let rec weakening_to_lift =
   function
   | ID -> ELID
-  | LIFT (k, w) -> el_shft_rec k (weakening_to_lift w)
+  | LIFT (k, w) -> el_liftn_rec k (weakening_to_lift w)
   | WEAK (k, w) ->
       el_shft_rec k (el_liftn_rec k (weakening_to_lift w))
 [@@warning "-unused-value-declaration"]

--- a/kernel/esubst.mli
+++ b/kernel/esubst.mli
@@ -85,9 +85,12 @@ val comp : ('a subs -> 'b -> 'a) -> (int -> 'a -> 'a) -> 'a subs -> 'b subs -> '
     two consecutive [ELLFT] or two consecutive [ELSHFT].
 
     Relocations are a particular kind of substitutions that only contain
-    variables. In particular, [el_*] enjoys similar typing rules as the
-    equivalent substitution function [subs_*].
-*)
+    variables. [el_id] is analogous to [subs_id], and [el_lift] is analogous
+    to [subs_lift]. Note, however, that [el_shft] and [subs_shft] are
+    different operations. (This is visible in their typing rules.)
+    [el_shft] is a pre-increment (it acts on the domain of the transformation)
+    whereas [subs_shft] is a post-increment (it acts on the codomain of the
+    transformation). *)
 type lift = private
   | ELID
   | ELSHFT of lift * int


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

One commit fixes an incorrect comment in `kernel/esubst.mli` and points out that `el_shft` and `subs_shft` are conceptually different operations.

One commit fixes a bug in the unused function `weakening_to_lift`.

Considering that no (live) code is affected, if the maintainers agree with these changes, then no testing is needed.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
