### PR TITLE
inferCumulativity check stack and invert data of FCaseInvert

### DIFF
--- a/dev/doc/critical-bugs.md
+++ b/dev/doc/critical-bugs.md
@@ -348,6 +348,17 @@ and lack of checking of relevance marks on constants in coqchk
   The bug occurs when the reduced type has a stuck match on a universe polymorphic inductive.
   The exploit in the issue uses Definitional UIP but the code is incorrect even without that flag.
 
+#### variance inference ignores stack of stuck irrelevant to relevant matches
+- component: inductive declarations, universe polymorphism
+- introduced: 8.13
+- impacted released versions: V8.13 to V9.2.0
+- impacted rocqchk versions: same
+- fixed in: V9.2.1, V9.3
+- found by: OpenAI
+- issue: #22376
+- risk: needs a cumulative inductive in which a match on an empty SProp inductive
+  or inductive using Definitional UIP appears
+
 ### Module system
 
 #### missing universe constraints in typing "with" clause of a module type

--- a/doc/changelog/01-kernel/22377-infercumul-invert-Fixed.rst
+++ b/doc/changelog/01-kernel/22377-infercumul-invert-Fixed.rst
@@ -1,0 +1,8 @@
+- **Fixed:**
+  incorrect variance inference for :ref:`cumulative inductives <cumulative>`
+  with applied stuck matches from irrelevant to relevant types
+  (eg match from `sFalse : SProp` or identity in SProp (the later needing :flag:`Definitional UIP`)
+  to a relevant type)
+  (`#22377 <https://github.com/rocq-prover/rocq/pull/22377>`_,
+  fixes `#22376 <https://github.com/rocq-prover/rocq/issues/22376>`_,
+  by Gaëtan Gilbert).

--- a/kernel/inferCumulativity.ml
+++ b/kernel/inferCumulativity.ml
@@ -252,14 +252,20 @@ let rec infer_fterm cv_pb infos variances hd stk =
     let variances = infer_vect infos variances elems in
     infer_stack infos variances stk
 
-  | FCaseInvert (ci, u, pms, p, _, _, br, e) ->
+  | FCaseInvert (ci, u, pms, p, iv, _, br, e) ->
+    (* don't check discriminee: inductive is guaranteed proof irrelevant *)
     let mib = Environ.lookup_mind (fst ci.ci_ind) (info_env (fst infos)) in
     let (_, (p, _), _, _, br) =
       Inductive.expand_case_specif mib (ci, u, pms, p, NoInvert, mkProp, br)
     in
     let infer c variances = infer_fterm CONV infos variances (mk_clos e c) [] in
+    let variances = Array.fold_left (fun variances i ->
+        infer_fterm CONV infos variances i [])
+        variances (get_invert iv)
+    in
     let variances = infer p variances in
-    Array.fold_right infer br variances
+    let variances = Array.fold_right infer br variances in
+    infer_stack infos variances stk
 
   (* Removed by whnf *)
   | FLOCKED | FCaseT _ | FLetIn _ | FApp _ | FLIFT _ | FCLOS _ -> assert false

--- a/test-suite/bugs/bug_22376.v
+++ b/test-suite/bugs/bug_22376.v
@@ -1,0 +1,55 @@
+Set Universe Polymorphism.
+Set Definitional UIP.
+
+Inductive seq@{i} {A : Type@{i}} (x : A) : A -> SProp :=
+| srefl : seq x x.
+
+Definition transport@{i j} {A : Type@{i}} (P : A -> Type@{j})
+    {x y : A} (e : seq x y) : P x -> P y :=
+  match e in seq _ y return P x -> P y with
+  | srefl _ => fun v => v
+  end.
+
+(* incorrect irrelevant annotation *)
+Fail Cumulative Inductive Hidden@{*u z w h | u < z, z < w, w < h}
+    (Y : Type@{w}) (e : @seq@{h} Type@{w} Type@{z} Y)
+    (Q : Y -> Type@{w}) : Type@{w} :=
+| hide : Q (@transport@{h w} Type@{w} (fun T : Type@{w} => T)
+              Type@{z} Y e Type@{u}) -> Hidden Y e Q.
+
+Cumulative Inductive Hidden@{u z w h | u < z, z < w, w < h}
+    (Y : Type@{w}) (e : @seq@{h} Type@{w} Type@{z} Y)
+    (Q : Y -> Type@{w}) : Type@{w} :=
+| hide : Q (@transport@{h w} Type@{w} (fun T : Type@{w} => T)
+              Type@{z} Y e Type@{u}) -> Hidden Y e Q.
+
+Definition Box@{u z w h | u < z, z < w, w < h} : Type@{w} :=
+  Hidden@{u z w h} Type@{z}
+    (@srefl@{h} Type@{w} Type@{z}) (fun A : Type@{z} => A).
+
+Definition box@{u z w h | u < z, z < w, w < h}
+    (A : Type@{u}) : Box@{u z w h} :=
+  hide@{u z w h} Type@{z}
+    (@srefl@{h} Type@{w} Type@{z}) (fun A : Type@{z} => A) A.
+
+Definition unbox@{u z w h | u < z, z < w, w < h}
+    (x : Box@{u z w h}) : Type@{u} :=
+  match x with hide _ _ _ A => A end.
+
+Fail Definition lower@{lo hi z w h | lo < hi, hi < z, z < w, w < h}
+    (A : Type@{hi}) : Type@{lo} :=
+  unbox@{lo z w h} (box@{hi z w h} A).
+
+(* Definition small@{lo hi z w h | lo < hi, hi < z, z < w, w < h} *)
+(*     : Type@{lo} := lower@{lo hi z w h} Type@{lo}. *)
+
+(* Definition small_is_universe@{lo hi z w h + | lo < hi, hi < z, z < w, w < h +} *)
+(*     : @eq Type@{hi} small@{lo hi z w h} Type@{lo} := eq_refl. *)
+
+(* From Stdlib Require Import Hurkens. *)
+
+(* Definition contradiction : False := *)
+(*   TypeNeqSmallType.paradox small (eq_sym small_is_universe). *)
+
+(* Print Assumptions contradiction. *)
+(* (* seq needs UIP *) *)


### PR DESCRIPTION
Not sure if the invert data matters but we check it in conversion so also should here.

Forgetting the stack caused inconsistency #22376

Close #22376