### PR TITLE
Prune context annotations to remove local defs when they are substituted

### DIFF
--- a/dev/doc/critical-bugs.md
+++ b/dev/doc/critical-bugs.md
@@ -80,6 +80,7 @@ This file recollects knowledge about critical bugs found in Coq since version 8.
       - [tactic code could mutate a global cache of values for section variables](#tactic-code-could-mutate-a-global-cache-of-values-for-section-variables)
       - [incorrect handling of universe polymorphism](#incorrect-handling-of-universe-polymorphism)
       - [Forgotten universe substitution with Register Inline on universe polymorphic definition](#forgotten-universe-substitution-with-register-inline-on-universe-polymorphic-definition)
+      - [conversion under contexts is done in the wrong environment](#conversion-under-contexts-is-done-in-the-wrong-environment)
     - [Side-effects](#side-effects)
       - [polymorphic side-effects inside monomorphic definitions incorrectly handled as not inlined](#polymorphic-side-effects-inside-monomorphic-definitions-incorrectly-handled-as-not-inlined)
       - [Section variables used in side effects not checked by Proof using](#section-variables-used-in-side-effects-not-checked-by-proof-using)
@@ -928,6 +929,18 @@ For instance `α` and `__U03b1_` were the same in the native compiler.
 - additional note: does not seem to be exploitable before 8.8 (until 8.6 Register
   Inline fails with anomaly on universe polymorphic constants, and before
   8.8 Register Inline only affects native which fails in ocamlopt)
+
+#### conversion under contexts is done in the wrong environment
+
+- component: lazy conversion
+- introduced: 8.14 ([d72e5c154f, PR #13563](https://github.com/rocq-prover/rocq/pull/13563))
+- impacted versions: until 9.2.0 (included)
+- impacted coqchk versions: same
+- fixed in: 9.2.1, 9.3.0 ([rocq-prover/rocq#22379](https://github.com/rocq-prover/rocq/pull/22379))
+- found by: Daniel Selsam
+- GH issue number: ([rocq-prover/rocq#22378](https://github.com/rocq-prover/rocq/pull/22378))
+- exploit: see issue
+- risk: ?
 
 ### Side-effects
 

--- a/doc/changelog/01-kernel/22379-case-branch-contexts-Fixed.rst
+++ b/doc/changelog/01-kernel/22379-case-branch-contexts-Fixed.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Compare terms under contexts in the right relevance environment
+  (`#22379 <https://github.com/rocq-prover/rocq/pull/22379>`_,
+  fixes `#22378 <https://github.com/rocq-prover/rocq/issues/22378>`_,
+  by Yann Leray).

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -291,6 +291,9 @@ let eta_expand_constructor env ((ind,ctor),u as pctor) =
   let c = Term.it_mkLambda_or_LetIn c ctx in
   inject c
 
+let annots_of_context ctx nas =
+  Array.filter_with (List.rev_map (fun d -> not (Option.has_some d)) ctx) nas
+
 let irr_flex infos = function
   | ConstKey (con,u) -> is_irrelevant infos @@ UVars.subst_instance_relevance u @@ Environ.constant_relevance con (info_env infos)
   | VarKey x -> is_irrelevant infos @@ Context.Named.Declaration.get_relevance (Environ.lookup_named x (info_env infos))
@@ -925,20 +928,22 @@ and convert_vect l2r infos lft1 lft2 v1 v2 cuniv =
 and convert_under_context l2r infos e1 e2 lft1 lft2 ctx (nas1, c1) (nas2, c2) cu =
   let n = Array.length nas1 in
   let () = assert (Int.equal n (Array.length nas2)) in
-  let n, e1, e2 = match ctx with
+  let nas, n, e1, e2 = match ctx with
   | None -> (* nolet *)
     let e1 = usubs_liftn n e1 in
     let e2 = usubs_liftn n e2 in
-    (n, e1, e2)
+    (nas1, n, e1, e2)
   | Some (ctx, args1, args2) ->
+    let nas = annots_of_context ctx nas1 in
     let n1, e1 = esubst_of_context ctx args1 e1 in
     let n2, e2 = esubst_of_context ctx args2 e2 in
     let () = assert (Int.equal n1 n2) in
-    n1, e1, e2
+    let () = assert (Int.equal n1 (Array.length nas)) in
+    nas, n1, e1, e2
   in
   let lft1 = el_liftn n lft1 in
   let lft2 = el_liftn n lft2 in
-  let infos = push_relevances infos (Array.map (usubst_binder e1) nas1) in
+  let infos = push_relevances infos (Array.map (usubst_binder e1) nas) in
   ccnv CONV l2r infos lft1 lft2 (mk_clos e1 c1) (mk_clos e2 c2) cu
 
 and convert_return_clause mib mip l2r infos e1 e2 l1 l2 u1 u2 pms1 pms2 p1 p2 cu =

--- a/test-suite/bugs/bug_22378.v
+++ b/test-suite/bugs/bug_22378.v
@@ -1,0 +1,26 @@
+Inductive sUnit : SProp := stt.
+
+Inductive pair_with_lets : Type :=
+| pack (x y : bool)
+    (ghost1 : sUnit := stt) (ghost2 : sUnit := stt).
+
+Definition left (p : pair_with_lets) : bool :=
+  match p with pack x y ghost1 ghost2 => x end.
+
+Definition right (p : pair_with_lets) : bool :=
+  match p with pack x y ghost1 ghost2 => y end.
+
+Fail
+Definition collision (p : pair_with_lets) :
+  left p = right p := eq_refl.
+
+(*
+Theorem contradiction : False.
+Proof.
+  pose proof (collision (pack true false)) as h.
+  cbn in h.
+  discriminate h.
+Qed.
+
+Print Assumptions contradiction.
+*)


### PR DESCRIPTION
Fixes / closes #22378

I didn't concern myself with speed, I don't know if I should have.