### PR TITLE
Fix reification of FCase(Invert) in cclosure

### DIFF
--- a/dev/doc/critical-bugs.md
+++ b/dev/doc/critical-bugs.md
@@ -334,6 +334,20 @@ and lack of checking of relevance marks on constants in coqchk
 - exploit / GH issue: [#22021](https://github.com/rocq-prover/rocq/issues/22021)
 - risk: low (no known way to exploit the issue)
 
+#### incorrect reification in lazy machine of matches with universe polymorphism
+- component: "lazy" reduction
+- introduced: V8.17
+- impacted released versions: V8.17 to V9.2.0
+- impacted rocqchk versions: same
+- fixed in: V9.2.1, V9.3
+- found by: OpenAI
+- issue: #22380
+- risk: reification of the lazy machine is only trusted
+  when it is used to check an application or match/proj
+  (typically in `f x`, the inferred type of `f` is reduced to expose a `forall`).
+  The bug occurs when the reduced type has a stuck match on a universe polymorphic inductive.
+  The exploit in the issue uses Definitional UIP but the code is incorrect even without that flag.
+
 ### Module system
 
 #### missing universe constraints in typing "with" clause of a module type

--- a/doc/changelog/01-kernel/22381-fix-case-reif-Fixed.rst
+++ b/doc/changelog/01-kernel/22381-fix-case-reif-Fixed.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  incorrect reification in `lazy` machine of matches with universe polymorphism
+  (`#22381 <https://github.com/rocq-prover/rocq/pull/22381>`_,
+  fixes `#22380 <https://github.com/rocq-prover/rocq/issues/22380>`_,
+  by Gaëtan Gilbert).

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -628,7 +628,16 @@ and to_constr_case lfts ci u pms (p,r) iv c ve env =
   let subs = comp_subs lfts env in
   let r = usubst_relevance subs r in
   if is_subs_id (fst env) && is_lift_id lfts then
-    mkCase (ci, usubst_instance subs u, pms, (p,r), iv, to_constr lfts c, ve)
+    let f_ctx (nas, c as o) =
+      let c' = subst_instance_constr (snd env) c in
+      if c == c' then o else nas, c'
+    in
+    mkCase (ci, usubst_instance subs u,
+            Array.Smart.map (subst_instance_constr (snd env)) pms,
+            (f_ctx p,r),
+            map_invert (subst_instance_constr (snd env)) iv,
+            to_constr lfts c,
+            Array.Smart.map f_ctx ve)
   else
     let f_ctx (nas, c) =
       let nas = Array.map (usubst_binder subs) nas in
@@ -639,7 +648,7 @@ and to_constr_case lfts ci u pms (p,r) iv c ve env =
             usubst_instance subs u,
             Array.map (fun c -> subst_constr subs c) pms,
             (f_ctx p,r),
-            iv,
+            map_invert (subst_constr subs) iv,
             to_constr lfts c,
             Array.map f_ctx ve)
 

--- a/test-suite/bugs/bug_22380.v
+++ b/test-suite/bugs/bug_22380.v
@@ -1,0 +1,98 @@
+Set Universe Polymorphism.
+Set Definitional UIP.
+
+Definition flag : bool. Proof. exact true. Qed.
+
+Inductive seq@{i} {A : Type@{i}} (x : A) : A -> SProp :=
+| srefl : seq x x.
+
+Definition transport@{i j} {A : Type@{i}} (P : A -> Type@{j})
+    {x y : A} (e : seq x y) : P x -> P y :=
+  match e in seq _ y return P x -> P y with
+  | srefl _ => fun v => v
+  end.
+
+Definition certificate@{anchor data out | anchor < out, data < out}
+    : Type@{out} :=
+  { A : Type@{data} & @eq Type@{out} A Type@{anchor} }.
+
+Definition cert_choice@{anchor data out | anchor < out, data < out}
+    : Type@{out} :=
+  if flag then certificate@{anchor data out}
+  else certificate@{anchor data out}.
+
+Definition cert_inhabitant@{anchor data out | anchor < data, data < out}
+    : cert_choice@{anchor data out} :=
+  match flag as b return
+    (if b then certificate@{anchor data out}
+     else certificate@{anchor data out}) with
+  | true => @existT (Type@{data})
+      (fun A : Type@{data} => @eq Type@{out} A Type@{anchor})
+      Type@{anchor} (@eq_refl Type@{out} Type@{anchor})
+  | false => @existT (Type@{data})
+      (fun A : Type@{data} => @eq Type@{out} A Type@{anchor})
+      Type@{anchor} (@eq_refl Type@{out} Type@{anchor})
+  end.
+
+Definition cert_force_type@{anchor data out top |
+    anchor < data, data < out, out < top} : Type@{out} :=
+  let T := (fun _ : unit => cert_choice@{anchor data out}) tt in
+  @transport@{top top} Type@{out}
+    (fun X : Type@{out} => X -> Type@{out})
+    T (if flag then certificate@{anchor data out}
+       else certificate@{anchor data out})
+    (@srefl@{top} Type@{out} T)
+    (fun _ : T => unit -> T)
+    cert_inhabitant@{anchor data out}.
+
+Definition cert_payload@{anchor data out | anchor < data, data < out}
+    : unit -> cert_choice@{anchor data out} :=
+  fun _ => cert_inhabitant@{anchor data out}.
+
+Definition cert_escaped@{lo lo' hi w z |
+    lo = lo', lo < hi, hi < w, w < z}
+    : cert_choice@{lo lo' hi}.
+Proof.
+  exact_no_check
+    ((cert_payload@{lo hi w} : cert_force_type@{lo hi w z}) tt).
+  Fail Defined. (* should fail *)
+Abort.
+
+(* Definition cert_collapse@{anchor data out | anchor < out, data < out} *)
+(*     (x : cert_choice@{anchor data out}) : certificate@{anchor data out} := *)
+(*   (match flag as b return *)
+(*      (if b then certificate@{anchor data out} *)
+(*       else certificate@{anchor data out}) -> certificate@{anchor data out} *)
+(*    with *)
+(*    | true => fun x => x *)
+(*    | false => fun x => x *)
+(*    end) x. *)
+
+(* Definition cert_first@{anchor data out | anchor < out, data < out} *)
+(*     (x : certificate@{anchor data out}) : Type@{data} := *)
+(*   match x with existT _ A _ => A end. *)
+
+(* Definition cert_second@{anchor data out | anchor < out, data < out} *)
+(*     (x : certificate@{anchor data out}) *)
+(*     : @eq Type@{out} (cert_first@{anchor data out} x) Type@{anchor} := *)
+(*   match x as x return *)
+(*     @eq Type@{out} (cert_first@{anchor data out} x) Type@{anchor} *)
+(*   with existT _ A e => e end. *)
+
+(* Definition cert_small@{lo lo' hi w z | *)
+(*     lo = lo', lo < hi, hi < w, w < z} : Type@{lo} := *)
+(*   cert_first@{lo lo' hi} *)
+(*     (cert_collapse@{lo lo' hi} cert_escaped@{lo lo' hi w z}). *)
+
+(* Definition cert_small_is_universe@{lo lo' hi w z | *)
+(*     lo = lo', lo < hi, hi < w, w < z} *)
+(*     : @eq Type@{hi} cert_small@{lo lo' hi w z} Type@{lo} := *)
+(*   cert_second@{lo lo' hi} *)
+(*     (cert_collapse@{lo lo' hi} cert_escaped@{lo lo' hi w z}). *)
+
+(* Require Import Hurkens. *)
+
+(* Definition contradiction : False := *)
+(*   TypeNeqSmallType.paradox cert_small (eq_sym cert_small_is_universe). *)
+
+(* Print Assumptions contradiction. *)


### PR DESCRIPTION
The reported inconsistency uses definitional UIP but considering the predicate and branches are also missing substitutions UIP is probably not needed for inconsistency.

Fix #22380
