### PR TITLE
Only count uniform arguments that correponds to lambdas

### DIFF
--- a/dev/doc/critical-bugs.md
+++ b/dev/doc/critical-bugs.md
@@ -31,6 +31,7 @@ This file recollects knowledge about critical bugs found in Coq since version 8.
       - [guard checker sometimes does reduction in the wrong context accepting wrong fixpoints](#guard-checker-sometimes-does-reduction-in-the-wrong-context-accepting-wrong-fixpoints)
       - [guard checker sometimes forgets to check lambda domains in nested fixpoints](#guard-checker-sometimes-forgets-to-check-lambda-domains-in-nested-fixpoints)
       - [cofixpoint guard checker passes wrong rectree for nested mutual cofixpoints](#cofixpoint-guard-checker-passes-wrong-rectree-for-nested-mutual-cofixpoints)
+      - [guard checker counts local definitions as formal arguments in uniformity analysis](#guard-checker-counts-local-definitions-as-formal-arguments-in-uniformity-analysis)
     - [Module system](#module-system)
       - [missing universe constraints in typing "with" clause of a module type](#missing-universe-constraints-in-typing-with-clause-of-a-module-type)
       - [universe constraints for module subtyping not stored in vo files](#universe-constraints-for-module-subtyping-not-stored-in-vo-files)
@@ -403,6 +404,17 @@ and lack of checking of relevance marks on constants in coqchk
 - found by: Daniel Selsam
 - exploit / GH issue: [#22386](https://github.com/rocq-prover/rocq/issues/22386)
 - risk: ?
+
+#### guard checker counts local definitions as formal arguments in uniformity analysis
+- component: guard checking
+- introduced: V8.20 ([#17986](https://github.com/rocq-prover/rocq/pull/17986))
+- impacted released versions: V8.20, V9.0, V9.1, V9.2.0
+- impacted coqchk versions: Same
+- fixed in: V9.2.1, V9.3 ([#22384](https://github.com/rocq-prover/rocq/pull/22384))
+- found by: Daniel Selsam
+- exploit / GH issue: [#22382](https://github.com/rocq-prover/rocq/issues/22382)
+- risk: ?
+
 
 ### Module system
 

--- a/doc/changelog/01-kernel/22384-fix-uniform-arguments-Fixed.rst
+++ b/doc/changelog/01-kernel/22384-fix-uniform-arguments-Fixed.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Only count uniform arguments that correponds to lambdas in the guard checker
+  (`#22384 <https://github.com/rocq-prover/rocq/pull/22384>`_,
+  fixes `#22382 <https://github.com/rocq-prover/rocq/issues/22382>`_,
+  by Yann Leray).

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -72,6 +72,24 @@ let inductive_nonrec_rec_paramdecls (mib,u) =
 let instantiate_inductive_constraints mib u =
   UVars.AbstractContext.instantiate u (Declareops.inductive_polymorphic_context mib)
 
+(** Splits a fixpoint body between the context until the [recindx+1]-th
+    assumption, and the rest of the body. Inlines local definitions,
+    which is necessary for the computation of uniform arguments,
+    and incidentally allows local definitions in the prefix to circumvent
+    restrictions if their inlining passes them. *)
+let split_struct_arg ?evars env recindx =
+  let rec decrec env n ctx c =
+    if Int.equal n 0 then ctx, c
+    else
+    let rc = whd_all ?evars env c in
+    match kind rc with
+    | Lambda (na, ty, bd) ->
+        let d = LocalAssum (na, ty) in
+        decrec (push_rel d env) (n-1) (Context.Rel.add d ctx) bd
+    | _ -> invalid_arg "split_struct_arg"
+  in
+  decrec env (recindx + 1) Context.Rel.empty
+
 (************************************************************************)
 
 let instantiate_params t u args sign =
@@ -1291,12 +1309,11 @@ let rec subterm_specif ?evars renv stack t =
           (nbfix-i, lazy (Subterm.strict_subterm recargs)) in
         let decrArg = recindxs.(i) in
         let theBody = bodies.(i)   in
-        let nbOfAbst = decrArg+1 in
-        let sign,strippedBody = whd_decompose_lambda_n_assum ?evars renv.env nbOfAbst theBody in
+        let sign, strippedBody = split_struct_arg ?evars renv.env decrArg theBody in
                    (* pushing the fix parameters *)
         let renv = push_ctxt_renv renv sign in
         let renv =
-          if List.length stack < nbOfAbst then renv
+          if List.length stack < decrArg + 1 then renv
           else
             let decrArg = List.nth stack decrArg in
             let arg_spec = stack_element_specif ?evars decrArg in
@@ -1395,7 +1412,7 @@ type check_subterm_result = Subterm.check_result =
   | NeedReduce of Int.Set.t (* empty = NoNeedReduce *)
 
 
-let find_uniform_parameters recindx nargs bodies =
+let find_uniform_parameters illformed ?evars env recindx nargs bodies =
   let nbodies = Array.length bodies in
   (* Ensure that the structural argument is not uniform,
      so that it stays in [non_absorbed_stack] *)
@@ -1422,9 +1439,17 @@ let find_uniform_parameters recindx nargs bodies =
         nuniformparams
     | _ -> fold_constr_with_binders succ aux k nuniformparams c
   in
-  Array.fold_left (aux 0) min_indx bodies
+  Array.fold_left2_i (fun k nuniformparams recindx c ->
+    let _, c = try
+      split_struct_arg ?evars env recindx c
+      with Invalid_argument _ -> illformed k
+      (* Typing invariants are checked later for inner fixpoints *)
+    in
+    (* Typing invariants say no recursive call happen in prefix ctx *)
+    aux (recindx + 1) nuniformparams c)
+    min_indx recindx bodies
 
-(** Given a fixpoint [fix f x y z n {struct n} := phi(f x y u t, ..., f x y u' t')]
+(*  Given a fixpoint [fix f x y z n {struct n} := phi(f x y u t, ..., f x y u' t')]
     with [z] not uniform we build in context [x:A, y:B(x), z:C(x,y)] a term
     [fix f z n := phi(f u t, ..., f u' t')], say [psi], of some type
     [forall (z:C(x,y)) (n:I(x,y,z)), T(x,y,z,n)], so that
@@ -1582,20 +1607,22 @@ let check_one_fix ?evars renv recpos trees def =
             let nbodies = Array.length bodies in
             let rs' = Array.fold_left (check_inert_subterm_rec_call renv) (NoNeedReduce::rs) typarray in
             let renv' = push_fix_renv renv recdef in
-            let nuniformparams = find_uniform_parameters recindxs (List.length stack) bodies in
+            let illformed k =
+              error_ill_formed_rec_body renv.env (Type_errors.FixGuardError (NotEnoughAbstractionInFixBody recindxs.(k)))
+                (pi1 recdef) k (push_rec_types recdef renv.env)
+                (judgment_of_fixpoint recdef)
+            in
+            let nuniformparams = find_uniform_parameters illformed ?evars renv.env recindxs (List.length stack) bodies in
             let bodies = drop_uniform_parameters nuniformparams bodies in
             let fix_stack = filter_fix_stack_domain ?evars (redex_level rs) decrArg stack nuniformparams in
             let fix_stack = if List.length stack > decrArg then List.firstn (decrArg+1) fix_stack else fix_stack in
             let stack_this = lift_stack nbodies fix_stack in
             let stack_others = lift_stack nbodies (List.firstn nuniformparams fix_stack) in
             (* Check guard in the expanded fix *)
-            let illformed () =
-              error_ill_formed_rec_body renv.env (Type_errors.FixGuardError (NotEnoughAbstractionInFixBody recindxs.(i)))
-                (pi1 recdef) i (push_rec_types recdef renv.env)
-                (judgment_of_fixpoint recdef) in
+
             let rs' = Array.fold_left2_i (fun j rs' recindx body ->
                 let fix_stack = if Int.equal i j then stack_this else stack_others in
-                check_nested_fix_body illformed renv' (recindx+1) fix_stack rs' body) rs' recindxs bodies in
+                check_nested_fix_body renv' (recindx+1) fix_stack rs' body) rs' recindxs bodies in
             let needreduce_fix, rs = List.sep_first rs' in
             let absorbed_stack, non_absorbed_stack = List.chop nuniformparams stack in
             check_rec_call_state renv needreduce_fix non_absorbed_stack rs (fun () ->
@@ -1706,7 +1733,7 @@ let check_one_fix ?evars renv recpos trees def =
 
         | Meta _ -> assert false
 
-  and check_nested_fix_body illformed renv decr stack rs body =
+  and check_nested_fix_body renv decr stack rs body =
     if Int.equal decr 0 then
       check_inert_subterm_rec_call renv rs body
     else
@@ -1717,12 +1744,13 @@ let check_one_fix ?evars renv recpos trees def =
             match stack with
             | elt :: stack ->
               let renv', stack', body' = pop_argument NoNeedReduce renv elt stack x a body in
-              check_nested_fix_body illformed renv' (decr-1) stack' rs body'
+              check_nested_fix_body renv' (decr-1) stack' rs body'
             | [] ->
               let renv' = push_var_renv renv (redex_level rs) (x,a) in
-              check_nested_fix_body illformed renv' (decr-1) [] rs body
+              check_nested_fix_body renv' (decr-1) [] rs body
           end
-        | _ -> illformed ()
+        | _ -> assert false
+        (* We know from find_uniform_parameters that they are wellformed *)
 
   and check_rec_call_state renv needreduce_of_head stack rs expand_head =
     (* Test if either the head or the stack of a state
@@ -1775,35 +1803,34 @@ let inductive_of_mutfix ?evars env ((nvect, bodynum), (names, types, bodies as r
   then anomaly (Pp.str "Ill-formed fix term.");
   let fixenv = push_rec_types recdef env in
   let raise_err = raise_fix_guard_err_fn env recdef names in
-  (* Check the i-th definition with recarg, under k binders *)
-  let rec find_ind env i recarg k def =
-    match kind (whd_all ?evars env def) with
-    | Lambda (na, ty, body) ->
-      (* check no recursive call appear in the recarg+1 first abstractions,
-         gives the type of the recarg+1-th abstraction (must be an inductive) *)
-      let () = if not (noccur_with_meta k nbfix ty) then
-        anomaly ~label:"check_one_fix" (Pp.str "Bad occurrence of recursive call.")
-      in
-      if Int.equal k (recarg + 1) then
-        (* get the inductive type of the fixpoint *)
-        let (mind, _) =
-          try find_inductive ?evars env ty
-          with Not_found ->
-            raise_err env i (RecursionNotOnInductiveType ty)
-        in
-        let mib, _ = lookup_mind_specif env (out_punivs mind) in
-        let () = if mib.mind_finite != Finite then
-          raise_err env i (RecursionNotOnInductiveType ty)
-        in
-        let env = push_rel (LocalAssum (na, ty)) env in
-        (mind, (env, body))
-      else
-        let env = push_rel (LocalAssum (na, ty)) env in
-        find_ind env i recarg (k+1) body
-    | _ -> raise_err env i (NotEnoughAbstractionInFixBody recarg)
+  (* Check the i-th definition with recarg *)
+  let find_ind env i recarg def =
+    let ctx, body =
+      try split_struct_arg ?evars env recarg def
+      with Invalid_argument _ ->
+        raise_err env i (NotEnoughAbstractionInFixBody recarg)
+    in
+    (* check no recursive call appear in the first abstractions until recarg *)
+    let initial_context = Term.it_mkLambda_or_LetIn mkProp (* dummy *) ctx in
+    let () = if not (noccur_with_meta 1 nbfix initial_context) then
+      anomaly ~label:"check_one_fix" (Pp.str "Bad occurrence of recursive call.")
+    in
+    (* ctx has size [recarg+1], top entry is recarg *)
+    let ty = Context.Rel.Declaration.get_type (List.hd ctx) in
+    (* get the inductive type of the fixpoint *)
+    let mind, _ =
+      try find_inductive ?evars env ty
+      with Not_found ->
+        raise_err env i (RecursionNotOnInductiveType ty)
+    in
+    let mib, _ = lookup_mind_specif env (out_punivs mind) in
+    let () = if mib.mind_finite != Finite then
+      raise_err env i (RecursionNotOnInductiveType ty)
+    in
+    (mind, (Environ.push_rel_context ctx env, body))
   in
   (* Do it on every fixpoint *)
-  let rv = Array.map2_i (fun i recarg def -> find_ind fixenv i recarg 1 def) nvect bodies in
+  let rv = Array.map2_i (fun i recarg def -> find_ind fixenv i recarg def) nvect bodies in
   (Array.map fst rv, Array.map snd rv)
 
 (* Returns the pairs of (inductive sort * output sort) or

--- a/test-suite/bugs/bug_22382.v
+++ b/test-suite/bugs/bug_22382.v
@@ -1,0 +1,30 @@
+(* Source-only counterexample to nested-fixpoint uniformity analysis. *)
+Definition relay (outer : nat -> Type) (seed : nat) : nat -> nat -> Type :=
+  fix inner (carry : nat := seed) (p m : nat) {struct m} : Type :=
+    match m with
+    | O => outer p -> False
+    | S rest => inner carry rest
+    end.
+
+Fail
+Fixpoint russell (n : nat) : Type :=
+  match n with
+  | O => True
+  | S smaller => relay russell n smaller smaller
+  end.
+
+(*
+Definition diagonal (x : russell 2) : False := x x.
+Definition contradiction : False := diagonal diagonal.
+
+Print Assumptions contradiction.
+*)
+
+#[refine]
+Fixpoint error (n : nat) : nat :=
+  match n with 0 => 0 | S n' => _ n' 1 end.
+Proof.
+  fix rec 2.
+  exact ((fun (p : nat) (q r : nat) => match r with 0 => 1 + error q | S r' => rec p r' end) 1).
+  Fail Guarded.
+Abort.


### PR DESCRIPTION
Fixes / closes #22382

Fixpoint contexts (up to the structural argument) are alway checked in weak-head-normal form, *without lets*.
Therefore, this changes the behaviour of the function (hopefully purely) dedicated to separating the fixpoint context frmo its body to actually reduce lets.

Also, uses it to find uniform arguments, so that the first binders in the environment really correspond to the arguments of the fixpoint (instead of let-ins or hidden β-redexes).