### PR TITLE
inferCumulativity treat letins in constructor types as invariant positions

### DIFF
--- a/dev/doc/critical-bugs.md
+++ b/dev/doc/critical-bugs.md
@@ -370,6 +370,18 @@ and lack of checking of relevance marks on constants in coqchk
 - risk: needs to convert stuck matches of a universe polymorphic inductive
   with a letin in the constructor type. The bug only appears if a polymorphic universe is used in the letin's body, and the match uses the letin.
 
+#### incorrect variance inference with letin in constructor type
+- component: inductive declarations, universe polymorphism
+- introduced: V8.6 (cumulative inductives)
+- impacted released versions: V8.6 to V9.2.0
+- impacted rocqchk versions: same
+- fixed in: V9.2.1, V9.3
+- found by: OpenAI
+- issue: #22385
+- risk: the bug comes from being able to bind a constructor type letin in a match,
+  which means those letins cannot be irrelevant for conversion.
+  Differences in reduction may mean the bug is harder to exploit before V8.19, see issue.
+
 ### Module system
 
 #### missing universe constraints in typing "with" clause of a module type

--- a/doc/changelog/01-kernel/22385-fix-infercumul-letin-Fixed.rst
+++ b/doc/changelog/01-kernel/22385-fix-infercumul-letin-Fixed.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  incorrect variance inference for :ref:`cumulative inductives <cumulative>`
+  with letins in the constructor type (bodies of constructor letins can be extracted by `match` without appearing in the `match` term, so they must be considered invariant positions instead of irrelevant)
+  (`#22385 <https://github.com/rocq-prover/rocq/pull/22385>`_,
+  fixes `#22383 <https://github.com/rocq-prover/rocq/issues/22383>`_,
+  by Gaëtan Gilbert).

--- a/kernel/inferCumulativity.ml
+++ b/kernel/inferCumulativity.ml
@@ -311,9 +311,12 @@ let infer_arity_constructor is_arity env variances arcn =
     match typ with
     | Context.Rel.Declaration.LocalAssum (_, typ') ->
       (Environ.push_rel typ env, infer_term CUMUL env variances typ')
-    | Context.Rel.Declaration.LocalDef _ -> assert false
+    | Context.Rel.Declaration.LocalDef (_, bdy, _) ->
+      (* no need to infer on the type of the letin AFAICT *)
+      let variances = infer_term CONV env variances bdy in
+      (Environ.push_rel typ env, variances)
   in
-  let typs, codom = Reduction.whd_decompose_prod env arcn in
+  let typs, codom = Reduction.whd_decompose_prod_decls env arcn in
   let env, variances = Context.Rel.fold_outside infer_typ typs ~init:(env, variances) in
   (* If we have Inductive foo@{i j} : ... -> Type@{i} := C : ... -> foo Type@{j}
      i is irrelevant, j is invariant. *)

--- a/test-suite/bugs/bug_22383.v
+++ b/test-suite/bugs/bug_22383.v
@@ -1,0 +1,24 @@
+
+Set Universe Polymorphism.
+
+Fail Cumulative Inductive token@{*u v | u < v} : Set :=
+| make_token (ghost : Type@{v} := Type@{u}).
+
+Cumulative Inductive token@{u v | u < v} : Set :=
+| make_token (ghost : Type@{v} := Type@{u}).
+
+Definition read_token@{u v | u < v} (t : token@{u v}) : Type@{v} :=
+  match t with make_token ghost => ghost end.
+
+Fail Definition small@{u v | Set < u, u < v} : Type@{u} :=
+  read_token@{Set u} (make_token@{u v}).
+
+(* Definition small_is_universe@{u v | Set < u, u < v} : *)
+(*   @eq Type@{v} small@{u v} Type@{u} := eq_refl. *)
+
+(* Require Import Hurkens. *)
+
+(* Definition contradiction : False := *)
+(*   TypeNeqSmallType.paradox small (eq_sym small_is_universe). *)
+
+(* Print Assumptions contradiction. *)


### PR DESCRIPTION


Fix #22383
