### PR TITLE
Compute rectrees for cofixpoints in the right environment

### DIFF
--- a/dev/doc/critical-bugs.md
+++ b/dev/doc/critical-bugs.md
@@ -394,6 +394,16 @@ and lack of checking of relevance marks on constants in coqchk
 - exploit / GH issue: [#22389](https://github.com/rocq-prover/rocq/issues/22389)
 - risk: ?
 
+#### cofixpoint guard checker computes rectree in the wrong environment
+- component: cofixpoints, guard checking
+- introduced: before V7.0, probably when coinductives first appeared
+- impacted released versions: all releases until V9.2.0 included
+- impacted coqchk versions: Same
+- fixed in: V9.2.1, V9.3 ([#22388](https://github.com/rocq-prover/rocq/pull/22388))
+- found by: Daniel Selsam
+- exploit / GH issue: [#22386](https://github.com/rocq-prover/rocq/issues/22386)
+- risk: ?
+
 ### Module system
 
 #### missing universe constraints in typing "with" clause of a module type

--- a/doc/changelog/01-kernel/22388-cofix-trees-env-Fixed.rst
+++ b/doc/changelog/01-kernel/22388-cofix-trees-env-Fixed.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Compute cofixpoint recursive tree in the right enviroment
+  (`#22388 <https://github.com/rocq-prover/rocq/pull/22388>`_,
+  fixes `#22386 <https://github.com/rocq-prover/rocq/issues/22386>`_,
+  by Yann Leray).

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1881,7 +1881,7 @@ let rec codomain_is_coind ?evars env c =
         with Not_found ->
           raise (CoFixGuardError (env, CodomainNotInductiveType b)))
 
-let check_one_cofix ?evars env nbfix def deftype =
+let check_one_cofix ?evars env nbfix def vlra =
   let rec check_rec_call env alreadygrd n tree t =
     if not (noccur_with_meta n nbfix t) then
       let c,args = decompose_app_list (whd_all ?evars env t) in
@@ -1963,8 +1963,6 @@ let check_one_cofix ?evars env nbfix def deftype =
           | Array _ ->
            raise (CoFixGuardError (env,NotGuardedForm t)) in
 
-  let ((mind, _),_) = codomain_is_coind ?evars env deftype in
-  let vlra = WfPaths.lookup_subterms env mind in
   check_rec_call env false 1 vlra def
 
 (* The  function which checks that the whole block of definitions
@@ -1976,7 +1974,10 @@ let check_cofix ?evars env (_bodynum,(names,types,bodies as recdef)) =
     let nbfix = Array.length bodies in
     for i = 0 to nbfix-1 do
       let fixenv = push_rec_types recdef env in
-      try check_one_cofix ?evars fixenv nbfix bodies.(i) types.(i)
+      try
+        let ((mind, _),_) = codomain_is_coind ?evars env types.(i) in
+        let vlra = WfPaths.lookup_subterms env mind in
+        check_one_cofix ?evars fixenv nbfix bodies.(i) vlra
       with CoFixGuardError (errenv,err) ->
         error_ill_formed_rec_body errenv (Type_errors.CoFixGuardError err) names i
           fixenv (judgment_of_fixpoint recdef)

--- a/test-suite/bugs/bug_22386.v
+++ b/test-suite/bugs/bug_22386.v
@@ -1,0 +1,16 @@
+CoInductive Stream : Type := next : Stream -> Stream.
+Inductive Empty : Type := wrap : Empty -> Empty.
+
+Fail
+Definition cycle : Empty :=
+  let actual := Empty in
+  let decoy := Stream in
+  cofix recur : actual := wrap recur.
+
+(*
+Fixpoint absurd (x : Empty) : False :=
+  match x with wrap y => absurd y end.
+
+Definition contradiction : False := absurd cycle.
+Print Assumptions contradiction.
+*)

--- a/test-suite/output/bug_19047.out
+++ b/test-suite/output/bug_19047.out
@@ -13,10 +13,9 @@ P : A -> Type
 f :
   forall x : A,
   (forall y : A, R x y -> coAcc R y) -> (forall y : A, R x y -> P y) -> P x
-F : forall x : A, coAcc R x -> P x
-x : R
-a : coAcc P x
-The codomain is "f x"
+x : A
+a : coAcc R x
+The codomain is "P x"
 which should be a coinductive type.
 Recursive definition is:
 "fun (x : A) (a : coAcc R x) =>


### PR DESCRIPTION
Fixes / closes #22386

Compute the rectrees before adding the recursive callls to the environment.