### PR TITLE
Forbid recursive calls in nested cofixpoints outside of the main branch

### DIFF
--- a/dev/doc/critical-bugs.md
+++ b/dev/doc/critical-bugs.md
@@ -30,6 +30,7 @@ This file recollects knowledge about critical bugs found in Coq since version 8.
       - [guard checker does not check arguments of recursive calls in uniformity analysis](#guard-checker-does-not-check-arguments-of-recursive-calls-in-uniformity-analysis)
       - [guard checker sometimes does reduction in the wrong context accepting wrong fixpoints](#guard-checker-sometimes-does-reduction-in-the-wrong-context-accepting-wrong-fixpoints)
       - [guard checker sometimes forgets to check lambda domains in nested fixpoints](#guard-checker-sometimes-forgets-to-check-lambda-domains-in-nested-fixpoints)
+      - [cofixpoint guard checker passes wrong rectree for nested mutual cofixpoints](#cofixpoint-guard-checker-passes-wrong-rectree-for-nested-mutual-cofixpoints)
     - [Module system](#module-system)
       - [missing universe constraints in typing "with" clause of a module type](#missing-universe-constraints-in-typing-with-clause-of-a-module-type)
       - [universe constraints for module subtyping not stored in vo files](#universe-constraints-for-module-subtyping-not-stored-in-vo-files)
@@ -381,6 +382,16 @@ and lack of checking of relevance marks on constants in coqchk
 - risk: the bug comes from being able to bind a constructor type letin in a match,
   which means those letins cannot be irrelevant for conversion.
   Differences in reduction may mean the bug is harder to exploit before V8.19, see issue.
+
+#### cofixpoint guard checker passes wrong rectree for nested mutual cofixpoints
+- component: cofixpoints, guard checking
+- introduced: before V7.0, probably when coinductives first appeared
+- impacted released versions: all releases until V9.2.0 included
+- impacted coqchk versions: Same
+- fixed in: V9.2.1, V9.3 ([#22392](https://github.com/rocq-prover/rocq/pull/22392))
+- found by: Daniel Selsam
+- exploit / GH issue: [#22389](https://github.com/rocq-prover/rocq/issues/22389)
+- risk: ?
 
 ### Module system
 

--- a/doc/changelog/01-kernel/22392-no-nested-mutual-cofix-Fixed.rst
+++ b/doc/changelog/01-kernel/22392-no-nested-mutual-cofix-Fixed.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  On mutual cofixpoints nested in another, only the main branch of the mutual may do a recursive call of the outer cofixpoint
+  (`#22392 <https://github.com/rocq-prover/rocq/pull/22392>`_,
+  fixes `#22389 <https://github.com/rocq-prover/rocq/issues/22389>`_,
+  by Yann Leray).

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1921,18 +1921,19 @@ let check_one_cofix ?evars env nbfix def deftype =
             else
               raise (CoFixGuardError (env,RecCallInTypeOfAbstraction a))
 
-        | CoFix (_j,(_,varit,vdefs as recdef)) ->
-            if List.for_all (noccur_with_meta n nbfix) args
-            then
-              if Array.for_all (noccur_with_meta n nbfix) varit then
-                let nbfix = Array.length vdefs in
-                let env' = push_rec_types recdef env in
-                (Array.iter (check_rec_call env' alreadygrd (n+nbfix) tree) vdefs;
-                 List.iter (check_rec_call env alreadygrd n tree) args)
-              else
-                raise (CoFixGuardError (env,RecCallInTypeOfDef c))
-            else
-              raise (CoFixGuardError (env,UnguardedRecursiveCall c))
+        | CoFix (i, (_, varit, vdefs as recdef)) ->
+          let () = if not (List.for_all (noccur_with_meta n nbfix) args) then
+            raise (CoFixGuardError (env, UnguardedRecursiveCall c))
+          in
+          let () = if not (Array.for_all (noccur_with_meta n nbfix) varit) then
+            raise (CoFixGuardError (env, RecCallInTypeOfDef c))
+          in
+          let nbfixinner = Array.length vdefs in
+          let env' = push_rec_types recdef env in
+          let () = if not (Array.for_all_i (fun j c -> Int.equal i j || noccur_with_meta (n + nbfixinner) nbfix c) 0 vdefs) then
+            raise (CoFixGuardError (env, RecCallInNonMainMutual c))
+          in
+          check_rec_call env' alreadygrd (n + nbfixinner) tree vdefs.(i)
 
         | Case (ci, u, pms, p, iv, tm, br) -> (* iv ignored: just a cache *)
           begin

--- a/kernel/type_errors.ml
+++ b/kernel/type_errors.ml
@@ -32,6 +32,7 @@ type 'constr pcofix_guard_error =
   | RecCallInTypeOfAbstraction of 'constr
   | RecCallInNonRecArgOfConstructor of 'constr
   | RecCallInTypeOfDef of 'constr
+  | RecCallInNonMainMutual of 'constr
   | RecCallInCaseFun of 'constr
   | RecCallInCaseArg of 'constr
   | RecCallInCasePred of 'constr
@@ -206,6 +207,7 @@ let map_pcofix_guard_error f = function
 | RecCallInTypeOfAbstraction c -> RecCallInTypeOfAbstraction (f c)
 | RecCallInNonRecArgOfConstructor c -> RecCallInNonRecArgOfConstructor (f c)
 | RecCallInTypeOfDef c -> RecCallInTypeOfDef (f c)
+| RecCallInNonMainMutual c -> RecCallInNonMainMutual (f c)
 | RecCallInCaseFun c -> RecCallInCaseFun (f c)
 | RecCallInCaseArg c -> RecCallInCaseArg (f c)
 | RecCallInCasePred c -> RecCallInCasePred (f c)

--- a/kernel/type_errors.mli
+++ b/kernel/type_errors.mli
@@ -34,6 +34,7 @@ type 'constr pcofix_guard_error =
   | RecCallInTypeOfAbstraction of 'constr
   | RecCallInNonRecArgOfConstructor of 'constr
   | RecCallInTypeOfDef of 'constr
+  | RecCallInNonMainMutual of 'constr
   | RecCallInCaseFun of 'constr
   | RecCallInCaseArg of 'constr
   | RecCallInCasePred of 'constr

--- a/test-suite/bugs/bug_22389.v
+++ b/test-suite/bugs/bug_22389.v
@@ -1,0 +1,23 @@
+CoInductive D (X Y : Type) := dc : X -> Y -> D X Y.
+CoInductive C (A : Type) := cc : C A -> D (C A) A -> C A.
+Inductive I : Type := ic : C I -> I.
+
+Fail
+CoFixpoint cycle : C I :=
+  (cofix f : C I := cc I f g
+   with g : D (C I) I := dc (C I) I cycle (ic cycle)
+   for f).
+
+(*
+Fixpoint empty (i : I) : False :=
+  match i with
+  | ic c => match c with
+    | cc _ _ d => match d with
+      | dc _ _ _ j => empty j
+      end
+    end
+  end.
+
+Definition contradiction : False := empty (ic cycle).
+Print Assumptions contradiction.
+*)

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -594,6 +594,9 @@ let explain_ill_formed_cofix_body env sigma = function
   | RecCallInTypeOfDef c ->
       str "Recursive call forbidden in the type of a recursive definition" ++
       spc () ++ pr_leconstr_env env sigma c
+  | RecCallInNonMainMutual c ->
+    str "Recursive call forbidden in non-main cofix in nested mutual cofixpoints" ++
+    spc () ++ pr_leconstr_env env sigma c
   | RecCallInCaseFun c ->
       str "Invalid recursive call in a branch of" ++
       spc () ++ pr_leconstr_env env sigma c


### PR DESCRIPTION
Fixes / closes #22389

Simply forbids recursive call of an outer cofixpoint in a nested mutual cofixpoint, for branches other than the main one.
This is more drastic that really necessary, but the theory needs to be improved before we have a proper criterion that would allow them again.