### PR TITLE
Use substituted univ instances for convert_branches/convert_return_clause

### DIFF
--- a/dev/doc/critical-bugs.md
+++ b/dev/doc/critical-bugs.md
@@ -359,6 +359,17 @@ and lack of checking of relevance marks on constants in coqchk
 - risk: needs a cumulative inductive in which a match on an empty SProp inductive
   or inductive using Definitional UIP appears
 
+#### missing universe substitution when converting matches with letin in constructor type
+- component: conversion
+- introduced: V8.17
+- impacted released versions: V8.17 to V9.2.0
+- impacted rocqchk versions: same
+- fixed in: V9.2.1, V9.3
+- found by: OpenAI
+- issue: #22391
+- risk: needs to convert stuck matches of a universe polymorphic inductive
+  with a letin in the constructor type. The bug only appears if a polymorphic universe is used in the letin's body, and the match uses the letin.
+
 ### Module system
 
 #### missing universe constraints in typing "with" clause of a module type

--- a/doc/changelog/01-kernel/22393-fix-subst-conv-branches-Fixed.rst
+++ b/doc/changelog/01-kernel/22393-fix-subst-conv-branches-Fixed.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  incorrect substitution of polymorphic universes when converting stuck matches
+  involving an inductive with letins in the indexes or constructor types
+  (`#22393 <https://github.com/rocq-prover/rocq/pull/22393>`_,
+  fixes `#22391 <https://github.com/rocq-prover/rocq/issues/22391>`_,
+  by Gaëtan Gilbert).

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -784,11 +784,11 @@ and eqwhnf cv_pb l2r infos (lft1, (hd1, v1) as appr1) (lft2, (hd2, v2) as appr2)
       (** FIXME: cache the presence of let-bindings in the case_info *)
       let mind = Environ.lookup_mind (fst ci1.ci_ind) (info_env infos.cnv_inf) in
       let mip = mind.Declarations.mind_packets.(snd ci1.ci_ind) in
+      let u1 = CClosure.usubst_instance e1 u1 in
+      let u2 = CClosure.usubst_instance e2 u2 in
       let cuniv =
         let ind = (mind,snd ci1.ci_ind) in
         let nargs = inductive_cumulativity_arguments ind in
-        let u1 = CClosure.usubst_instance e1 u1 in
-        let u2 = CClosure.usubst_instance e2 u2 in
         fail_check infos @@ convert_inductives CONV ind nargs u1 u2 cuniv
       in
       let pms1 = mk_clos_vect e1 pms1 in
@@ -880,12 +880,12 @@ and convert_stacks ?(mask = [||]) l2r infos lft1 lft2 stk1 stk2 cuniv =
                 (** FIXME: cache the presence of let-bindings in the case_info *)
                 let mind = Environ.lookup_mind (fst ci1.ci_ind) (info_env infos.cnv_inf) in
                 let mip = mind.Declarations.mind_packets.(snd ci1.ci_ind) in
+                let u1 = CClosure.usubst_instance e1 u1 in
+                let u2 = CClosure.usubst_instance e2 u2 in
                 let cu =
                   if UVars.Instance.is_empty u1 || UVars.Instance.is_empty u2 then
                     convert_instances ~flex:false u1 u2 cu
                   else
-                    let u1 = CClosure.usubst_instance e1 u1 in
-                    let u2 = CClosure.usubst_instance e2 u2 in
                     match mind.Declarations.mind_variance with
                     | None -> convert_instances ~flex:false u1 u2 cu
                     | Some variances -> convert_instances_cumul CONV variances u1 u2 cu

--- a/test-suite/bugs/bug_22391.v
+++ b/test-suite/bugs/bug_22391.v
@@ -1,0 +1,31 @@
+Set Universe Polymorphism.
+
+NonCumulative Inductive token@{u v | u < v} : Set :=
+| make_token (ghost : Type@{v} := Type@{u}).
+
+Definition read_token@{u v | u < v} (t : token@{u v}) : Type@{v} :=
+  match t with make_token ghost => ghost end.
+
+Definition read_constant@{lo hi top | lo < hi, hi < top}
+    (t : token@{hi top}) : Type@{top} :=
+  match t with make_token ghost => Type@{lo} end.
+
+Definition collision@{lo hi top | lo < hi, hi < top}
+    (t : token@{hi top}) :
+  @eq Type@{top}
+    (read_token@{hi top} t) (read_constant@{lo hi top} t).
+Proof.
+  exact_no_check (@eq_refl Type@{top} (read_token@{hi top} t)).
+  Fail Defined.
+Abort.
+
+(* Definition collapse@{lo hi top | lo < hi, hi < top} : *)
+(*   @eq Type@{top} Type@{hi} Type@{lo} := *)
+(*   collision@{lo hi top} make_token@{hi top}. *)
+
+(* Require Import Hurkens. *)
+
+(* Definition contradiction : False := *)
+(*   TypeNeqSmallType.paradox _ collapse. *)
+
+(* Print Assumptions contradiction. *)


### PR DESCRIPTION


Fix #22391
