### PR TITLE
Print "Expands to: Abbreviation" not "Notation"

### DIFF
--- a/test-suite/output/PrintInfos.out
+++ b/test-suite/output/PrintInfos.out
@@ -83,7 +83,7 @@ bar : forall {x : nat}, x = 0
 Arguments bar {x}
 Module Corelib.Init.Peano
 Abbreviation sym_eq := eq_sym
-Expands to: Notation Corelib.Init.Logic.sym_eq
+Expands to: Abbreviation Corelib.Init.Logic.sym_eq
 Declared in library Corelib.Init.Logic, line 767, characters 0-45
 
 eq_sym : forall [A : Type] [x y : A], x = y -> y = x

--- a/test-suite/output/wish_18097.out
+++ b/test-suite/output/wish_18097.out
@@ -10,7 +10,7 @@ fix pow (n m : nat) {struct m} : nat :=
 
 Arguments Nat.pow (n m)%_nat_scope
 Abbreviation pow := Nat.pow
-Expands to: Notation wish_18097.pow
+Expands to: Abbreviation wish_18097.pow
 Declared in library wish_18097, line 1, characters 0-28
 
 Nat.pow : nat -> nat -> nat

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -950,7 +950,7 @@ let pr_located_qualid env = function
       let extra = canonical_info env ref in
       v 0 (hov 0 (str ref_str ++ spc () ++ pr_path (Nametab.path_of_global ref) ++ extra))
   | Abbreviation kn ->
-    str "Notation" ++ spc () ++ pr_path (Nametab.path_of_abbreviation kn)
+    str "Abbreviation" ++ spc () ++ pr_path (Nametab.path_of_abbreviation kn)
   | Dir dir -> pr_dir dir
   | Module mp ->
     str "Module" ++ spc () ++ pr_path (Nametab.path_of_module mp)


### PR DESCRIPTION
Followup of https://github.com/rocq-prover/rocq/pull/22368

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
<!-- Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] ~Added **changelog**.~
- [ ] ~Added / updated **documentation**.~
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] ~Opened **overlay** pull requests.~

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
