### PR TITLE
Fix a memory leak in LStream.

### DIFF
--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -257,6 +257,8 @@ type 'a ty_desc =
 | Dlevels of 'a ty_level list
 | Dparser of (L.keyword_state -> 'a parser_t)
 
+type position = LStream.position
+
 (** The closures are built by partially applying the parsing functions
     to [edesc] but without depending on the state (so when we update
     an entry we don't need to update closures in unrelated entries).
@@ -268,7 +270,7 @@ type ('t,'a) entry_data = {
   eentry : 'a ty_entry;
   edesc : 'a ty_desc;
   estart : 't -> int -> 'a parser_t;
-  econtinue : 't -> int option -> int -> int -> 'a -> 'a parser_t;
+  econtinue : 't -> int option -> int -> position -> 'a -> 'a parser_t;
 }
 
 module rec EState : DMap.MapS
@@ -1074,6 +1076,20 @@ let top_tree : type s tr a. s ty_entry -> (s, tr, a) ty_tree -> (s, tr, a) ty_tr
     Node (NoRec3, {node = s'; brother = bro; son = son})
   | LocAct _ | DeadEnd -> Error ()
 
+let locate_pos = LStream.current
+
+let interval_loc bpos epos =
+  let bp = LStream.pos_offset bpos in
+  let ep = LStream.pos_offset epos in
+  let () = assert (bp <= ep) in
+  if Int.equal bp ep then
+    let cur = LStream.pos_current bpos in
+    Loc.after cur 0 0
+  else
+    let next = LStream.pos_next bpos in
+    let last = LStream.pos_current epos in
+    Loc.merge next last
+
 let warn_tolerance =
   CWarnings.(create_in (create_warning ~name:"level-tolerance"
                           ~from:[CoreCategories.parsing; Deprecation.Version.v9_2] ())
@@ -1086,8 +1102,8 @@ let warn_tolerance =
 
 let warn_recover_qf ename bp ?ep strm__ msg =
   let has_ep = Option.has_some ep in
-  let ep = Option.default (LStream.count strm__) ep in
-  let loc = LStream.interval_loc bp ep strm__ in
+  let ep = Option.default (locate_pos strm__) ep in
+  let loc = interval_loc bp ep in
   let qf =
     let paren_enames = ["term"; "pattern"; "ltac_expr"] in
     if not (has_ep && List.mem ename paren_enames) then [] else
@@ -1147,7 +1163,7 @@ let rec parser_of_tree : type s tr r. s ty_entry -> int -> int -> (s, tr, r) ty_
           let p1 = parser_of_tree entry nlevn alevn son in
           let p1 = parser_cont p1 entry nlevn alevn s son in
           (fun gstate (strm__ : _ LStream.t) ->
-             let bp = LStream.count strm__ in
+             let bp = locate_pos strm__ in
              let* a = ps gstate strm__ in
              p1 gstate bp a strm__)
   | Node (_, {node = s; son = son; brother = bro}) ->
@@ -1156,13 +1172,13 @@ let rec parser_of_tree : type s tr r. s ty_entry -> int -> int -> (s, tr, r) ty_
           let p1 = parser_cont p1 entry nlevn alevn s son in
           let p2 = parser_of_tree entry nlevn alevn bro in
           (fun gstate (strm : _ LStream.t) ->
-             let bp = LStream.count strm in
+             let bp = locate_pos strm in
              match ps gstate strm with
              | Ok a -> p1 gstate bp a strm
              | Error () -> p2 gstate strm)
 
 and parser_cont : type s tr tr' a r.
-  (GState.t -> (a -> r) parser_t) -> s ty_entry -> int -> int -> (s, tr, a) ty_symbol -> (s, tr', a -> r) ty_tree -> GState.t -> int -> a -> _ -> r parser_v =
+  (GState.t -> (a -> r) parser_t) -> s ty_entry -> int -> int -> (s, tr, a) ty_symbol -> (s, tr', a -> r) ty_tree -> GState.t -> position -> a -> _ -> r parser_v =
   fun p1 entry nlevn alevn s son gstate bp a0 (strm__ : _ LStream.t) ->
   match p1 gstate strm__ with
   | Ok v -> Ok (v a0)
@@ -1176,7 +1192,7 @@ and parser_cont : type s tr tr' a r.
        « OPT "!"; ident » fails to see an ident and the OPT was resolved
        into the empty sequence, with application e.g. to being able to
        safely write « LIST1 [ OPT "!"; id = ident -> id] ». *)
-    if LStream.count strm__ == bp then Error ()
+    if LStream.count strm__ == LStream.pos_offset bp then Error ()
     else if not gstate.recover then fail a0
     else
       (* Try to replay the son with the top occurrence of NEXT (by
@@ -1204,7 +1220,7 @@ and parser_cont : type s tr tr' a r.
           let* s' = entry_of_symb entry s in
           continue_parser_of_entry gstate s' None 0 bp a0 strm__
         in
-        let ep = LStream.count strm__ in
+        let ep = locate_pos strm__ in
         let a = or_fail a0 a in
         let act = or_fail a (p1 gstate strm__) in
         warn_recover entry.ename bp ~ep strm__;
@@ -1254,7 +1270,7 @@ and parser_of_token_list : type s tr lt r.
            if not gstate.recover then v else
              v <+> fun () ->
                (* Tolerance: retry w/o granting the level constraint (see recover) *)
-               let bp = LStream.count strm in
+               let bp = locate_pos strm in
                let* top = top_tree entry tree in
                let+ a = parser_of_tree entry nlevn alevn top gstate strm in
                warn_recover entry.ename bp strm;
@@ -1329,7 +1345,7 @@ and parser_of_symbol : type s tr a.
             | Ok a -> Ok a
             | Error () ->
               if not gstate.recover then Error () else
-                let bp = LStream.count strm__ in
+                let bp = locate_pos strm__ in
                 let a =
                   match
                     let* top = top_symb entry symb in
@@ -1357,10 +1373,10 @@ and parser_of_symbol : type s tr a.
   | Stree t ->
       let pt = parser_of_tree entry 1 0 t in
       (fun gstate (strm__ : _ LStream.t) ->
-         let bp = LStream.count strm__ in
+         let bp = locate_pos strm__ in
          let+ a = pt gstate strm__ in
-         let ep = LStream.count strm__ in
-         let loc = LStream.interval_loc bp ep strm__ in a loc)
+         let ep = locate_pos strm__ in
+         let loc = interval_loc bp ep in a loc)
   | Snterm e -> (fun gstate (strm__ : _ LStream.t) -> start_parser_of_entry gstate e 0 strm__)
   | Snterml (e, l) ->
     (fun gstate (strm__ : _ LStream.t) ->
@@ -1439,10 +1455,10 @@ let rec start_parser_of_levels entry clevn =
                 if not gstate.recover && levn > clevn then Error ()
                 else
                  let (strm__ : _ LStream.t) = strm in
-                 let bp = LStream.count strm__ in
+                 let bp = locate_pos strm__ in
                  let* act = p2 gstate strm__ in
-                 let ep = LStream.count strm__ in
-                 let a = act (LStream.interval_loc bp ep strm__) in
+                 let ep = locate_pos strm__ in
+                 let a = act (interval_loc bp ep) in
                  let () = if levn > clevn then
                      warn_recover_last_start entry.ename bp ep strm__
                  in
@@ -1454,11 +1470,11 @@ let rec start_parser_of_levels entry clevn =
                   p1 gstate levn strm
                 else
                   let (strm__ : _ LStream.t) = strm in
-                  let bp = LStream.count strm__ in
+                  let bp = locate_pos strm__ in
                   match p2 gstate strm__ with
                   | Ok act ->
-                      let ep = LStream.count strm__ in
-                      let a = act (LStream.interval_loc bp ep strm__) in
+                      let ep = locate_pos strm__ in
+                      let a = act (interval_loc bp ep) in
                       continue_parser_of_entry gstate entry (Some clevn) levn bp a strm
                   | Error () -> p1 gstate levn strm__
 
@@ -1497,11 +1513,11 @@ let rec continue_parser_of_levels entry clevn =
               Error ()
             else
               let (strm__ : _ LStream.t) = strm in
-              let ep = LStream.count strm__ in
+              let ep = locate_pos strm__ in
               let+ c = p1 gstate levfrom levn bp a strm__ <+> fun () ->
                   let* act = p2 gstate strm__ in
-                  let ep = LStream.count strm__ in
-                  let a = act a (LStream.interval_loc bp ep strm__) in
+                  let ep = locate_pos strm__ in
+                  let a = act a (interval_loc bp ep) in
                   if gstate.has_non_assoc && lev.assoc = NonA then
                     if clevn = levn then
                       Ok a

--- a/gramlib/lStream.ml
+++ b/gramlib/lStream.ml
@@ -18,6 +18,8 @@ type ('e,'a) t = {
   mutable max_peek : int;
 }
 
+type position = int * (int -> Loc.t)
+
 let from ?(loc=Loc.(initial ToplevelInput)) f =
   let loct = Hashtbl.create 207 in
   let loct_func loct i = Hashtbl.find loct i in
@@ -35,21 +37,13 @@ let from ?(loc=Loc.(initial ToplevelInput)) f =
 
 let count strm = Stream.count strm.strm
 
+let current strm = (count strm, strm.fun_loc)
+
 let current_loc strm =
   strm.fun_loc (Stream.count strm.strm)
 
 let max_peek_loc strm =
   strm.fun_loc strm.max_peek
-
-let interval_loc bp ep strm =
-  assert (bp <= ep);
-  if ep > strm.max_peek then failwith "Not peeked position";
-  if bp == ep then
-    Loc.after (strm.fun_loc bp) 0 0
-  else
-    let loc1 = strm.fun_loc (bp + 1) in
-    let loc2 = strm.fun_loc ep in
-    Loc.merge loc1 loc2
 
 let get_relative_loc n strm =
   let () = assert (0 <= n) in
@@ -74,3 +68,7 @@ let junk e strm = Stream.junk e strm.strm
 let njunk e len strm = Stream.njunk e len strm.strm
 
 let next e strm = Stream.next e strm.strm
+
+let pos_offset (i, _) = i
+let pos_current (i, loct) = try loct i with Not_found -> assert false
+let pos_next (i, loct) = try loct (i + 1) with Not_found -> assert false

--- a/gramlib/lStream.ml
+++ b/gramlib/lStream.ml
@@ -8,67 +8,137 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+module Stream :
+sig
+
+type ('e, 'a) t = private { mutable data : ('e, 'a) node }
+and ('e, 'a) node =
+| Nil
+| Cons of 'a * ('e, 'a) t
+| Gen of ('e -> 'a option)
+
+val make : ('e -> 'a option) -> ('e, 'a) t
+val force : 'e -> ('e, 'a) t -> unit
+
+end =
+struct
+
+type ('e, 'a) t = { mutable data : ('e, 'a) node }
+and ('e, 'a) node =
+| Nil
+| Cons of 'a * ('e, 'a) t
+| Gen of ('e -> 'a option)
+
+let make f = { data = Gen f }
+
+let force e s = match s.data with
+| Nil -> ()
+| Cons (x, s) -> ()
+| Gen f as gen ->
+  let v = f e in
+  match v with
+  | None -> s.data <- Nil
+  | Some x ->
+    let next = { data = gen } in
+    s.data <- Cons (x, next)
+
+end
+
 (** Streams equipped with a (non-canonical) location function *)
 
-type ('e,'a) t = {
-  strm : ('e,'a) Stream.t;
-  (* Give the loc of i-th element (counting from 1) and the empty initial interval if 0 *)
-  fun_loc : int -> Loc.t;
-  (* Remember max token peeked *)
-  mutable max_peek : int;
+type ('e, 'a) t = {
+  mutable strm : ('e, 'a * Loc.t) Stream.t;
+  mutable loc : Loc.t;
+  mutable count : int;
 }
 
-type position = int * (int -> Loc.t)
+type position = Position : int * Loc.t * ('e, 'a * Loc.t) Stream.t -> position
 
 let from ?(loc=Loc.(initial ToplevelInput)) f =
-  let loct = Hashtbl.create 207 in
-  let loct_func loct i = Hashtbl.find loct i in
-  let loct_add loct i loc = Hashtbl.add loct i loc in
-  let strm =
-    let i = ref 0 in
-    Stream.from
-      (fun e ->
-        match f e with
-        | None -> None
-        | Some (a,loc) ->
-        loct_add loct !i loc; incr i; Some a) in
-  let fun_loc i = if i = 0 then loc else loct_func loct (i - 1) in
-  { strm; max_peek = 0; fun_loc }
+  let strm = Stream.make f in
+  { strm; loc; count = 0; }
 
-let count strm = Stream.count strm.strm
+let count s = s.count
 
-let current strm = (count strm, strm.fun_loc)
+let current s =
+  Position (s.count, s.loc, s.strm)
 
-let current_loc strm =
-  strm.fun_loc (Stream.count strm.strm)
+let current_loc s = s.loc
 
-let max_peek_loc strm =
-  strm.fun_loc strm.max_peek
+let max_peek_loc s =
+  let open Stream in
+  let rec get_max cur s = match s.data with
+  | Nil -> cur
+  | Cons ((_, loc), s) -> get_max loc s
+  | Gen _ -> cur
+  in
+  get_max s.loc s.strm
 
 let get_relative_loc n strm =
+  let open Stream in
   let () = assert (0 <= n) in
-  let pos = Stream.count strm.strm in
-  strm.fun_loc (pos + n + 1)
+  let rec get_pos n s = match s.data with
+  | Nil | Gen _ -> assert false
+  | Cons ((_, loc), s) ->
+    if Int.equal n 0 then loc
+    else get_pos (n - 1) s
+  in
+  get_pos n strm.strm
 
-let peek e strm =
-  let a = Stream.peek e strm.strm in
-  if Option.has_some a then strm.max_peek <- max (Stream.count strm.strm + 1) strm.max_peek;
-  a
+let peek e s =
+  let s = s.strm in
+  let () = Stream.force e s in
+  let open Stream in
+  match s.data with
+  | Nil -> None
+  | Cons ((x, _), _) -> Some x
+  | Gen _ -> assert false
 
-let npeek e n strm =
-  let l = Stream.npeek e n strm.strm in
-  strm.max_peek <- max (Stream.count strm.strm + List.length l) strm.max_peek;
-  l
+let npeek e n s =
+  let rec npeek n s =
+    if Int.equal n 0 then []
+    else
+      let open Stream in
+      let () = Stream.force e s in
+      match s.Stream.data with
+      | Nil -> []
+      | Cons ((x, _), s) ->
+        let l = npeek (n - 1) s in
+        x :: l
+      | Gen _ -> assert false
+  in
+  npeek n s.strm
 
 let peek_nth e n strm =
   let list = npeek e (n + 1) strm in
   List.nth_opt list n
 
-let junk e strm = Stream.junk e strm.strm
-let njunk e len strm = Stream.njunk e len strm.strm
+let junk e strm =
+  let s = strm.strm in
+  let () = Stream.force e s in
+  let open Stream in
+  let () = strm.count <- strm.count + 1 in
+  match s.data with
+  | Nil -> ()
+  | Cons ((x, loc), next) ->
+    let () = strm.strm <- next in
+    strm.loc <- loc
+  | Gen _ -> assert false
 
-let next e strm = Stream.next e strm.strm
+let rec njunk e len strm =
+  if Int.equal len 0 then ()
+  else
+    let () = junk e strm in
+    njunk e (len - 1) strm
 
-let pos_offset (i, _) = i
-let pos_current (i, loct) = try loct i with Not_found -> assert false
-let pos_next (i, loct) = try loct (i + 1) with Not_found -> assert false
+let next e strm = match peek e strm with
+| None -> None
+| Some v ->
+  let () = junk e strm in
+  Some v
+
+let pos_offset (Position (i, _, _)) = i
+let pos_current (Position (_, cur, _)) = cur
+let pos_next (Position (_, _, strm)) = match strm.Stream.data with
+| Stream.Cons ((_, loc), _) -> loc
+| Stream.Nil | Stream.Gen _ -> assert false

--- a/gramlib/lStream.mli
+++ b/gramlib/lStream.mli
@@ -13,21 +13,17 @@
 type ('e,'a) t
 val from : ?loc:Loc.t -> ('e -> ('a * Loc.t) option) -> ('e,'a) t
 
+type position
+
 (** Returning the loc of the last consumed element or the initial loc
     if no element is consumed *)
 val current_loc : ('e,'a) t -> Loc.t
 
+val current : ('e, 'a) t -> position
+
 (** Returning the loc of the max visited element or the initial loc
     if no element is consumed *)
 val max_peek_loc : ('e,'a) t -> Loc.t
-
-(** [interval_loc bp ep strm] returns the loc starting after element
-    [bp] (counting from 0) and spanning up to already peeked element
-    at position [ep], under the assumption that [bp] <= [ep]; returns
-    an empty interval if [bp] = [ep]; returns the empty initial
-    interval if additionally [bp] = 0; fails if the elements have not
-    been peeked yet *)
-val interval_loc : int -> int -> ('e,'a) t -> Loc.t
 
 (** Return location of an already peeked element at some position counting from
     {!count}; fails if the element has not been peeked yet. That is,
@@ -58,3 +54,9 @@ val next : 'e -> ('e,'a) t -> 'a option
 val peek_nth : 'e -> int -> ('e,'a) t -> 'a option
   (** [peek_nth e n strm] returns the nth element counting from 0 without
       consuming the stream; [None] if not enough elements *)
+
+(** Position manipulation. Internal. *)
+
+val pos_offset : position -> int
+val pos_current : position -> Loc.t
+val pos_next : position -> Loc.t


### PR DESCRIPTION
We stop storing all stream locations from the past in a global hash table and rely instead on an explicit type pointing to specific positions of the stream.