### PR TITLE
Drop useless content from module parameter types.

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -259,6 +259,7 @@ let rec check_mexpr env mse mp_mse res = match mse with
   | MEapply (f,mp) ->
     let sign, delta = check_mexpr env f mp_mse res in
     let farg_id, farg_b, fbody_b = Modops.destr_functor sign in
+    let farg_b = repr_parameter farg_b in
     let state = (Environ.universes env, Conversion.checked_universes) in
     let _ : UGraph.t = Subtyping.check_subtypes state env mp (MPbound farg_id) farg_b in
     let mp_delta =
@@ -344,7 +345,7 @@ and check_structure_field env opac mp lab res opacify = function
 
 and check_signature env opac sign mp_mse res opacify = match sign with
   | MoreFunctor (arg_id, mtb, body) ->
-      let () = check_module_type env (MPbound arg_id) mtb in
+      let () = check_module_type env (MPbound arg_id) (repr_parameter mtb) in
       let env' = Modops.add_module_parameter arg_id mtb env in
       let opac = check_signature env' opac body mp_mse res empty_cset in
       opac

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -67,10 +67,14 @@ let constant_is_polymorphic cb =
   | Monomorphic -> false
   | Polymorphic _ -> true
 
-
 let constant_has_body cb = match cb.const_body with
   | Undef _ | Primitive _ | Symbol _ -> false
   | Def _ | OpaqueDef _ -> true
+
+let constant_drop_body cb = match cb.const_body with
+| Undef _ | Primitive _ | Symbol _ | Def _ -> cb
+| OpaqueDef _ ->
+  { cb with const_body = Undef None }
 
 let constant_polymorphic_context cb =
   universes_context cb.const_universes

--- a/kernel/declareops.mli
+++ b/kernel/declareops.mli
@@ -27,6 +27,8 @@ val subst_const_body : substitution -> constant_body -> constant_body
 
 val constant_has_body : ('a, 'b) pconstant_body -> bool
 
+val constant_drop_body : ('a, 'b) pconstant_body -> ('a, 'b) pconstant_body
+
 val constant_polymorphic_context : ('a, 'b) pconstant_body -> AbstractContext.t
 
 (** Is the constant polymorphic? *)

--- a/kernel/mod_declarations.ml
+++ b/kernel/mod_declarations.ml
@@ -68,6 +68,46 @@ and module_type_body = mod_type generic_module_body
       * the argument of [MEapply] is now directly forced to be a [ModPath.t].
 *)
 
+type module_type_parameter = module_type_body
+
+let rec drop_signature func = match func with
+| NoFunctor struc ->
+  let struc' = drop_structure_body struc in
+  if struc' == struc then func else NoFunctor struc'
+| MoreFunctor (mbid, mty, sign) ->
+  let sign' = drop_signature sign in
+  if sign' == sign then func else MoreFunctor (mbid, mty, sign)
+
+and drop_structure_body struc =
+  let map (l, e as field) =
+    let e' = drop_structure e in
+    if e' == e then field else (l, e')
+  in
+  List.Smart.map map struc
+
+and drop_structure e = match e with
+| SFBconst cb ->
+  let cb' = Declareops.constant_drop_body cb in
+  if cb' == cb then e else SFBconst cb'
+| SFBmodule mb ->
+  let mb' = drop_module_body mb in
+  if mb' == mb then e else SFBmodule mb'
+| SFBmind _ | SFBmodtype _ | SFBrules _ -> e
+
+and drop_module_body mb =
+  let mod_type = drop_signature mb.mod_type in
+  { mod_expr = ModBodyVal Abstract;
+    (* Subtyping of module bodies immediately turns them into module types *)
+    mod_type = mod_type;
+    mod_type_alg = None;
+    mod_delta = mb.mod_delta; }
+
+let make_parameter mty =
+  let sign' = drop_signature mty.mod_type in
+  if sign' == mty.mod_type then mty else { mty with mod_type = sign' }
+
+let repr_parameter mty = mty
+
 (** Builders *)
 
 let make_module_body typ delta = {

--- a/kernel/mod_declarations.mli
+++ b/kernel/mod_declarations.mli
@@ -25,6 +25,16 @@ type module_body = mod_body generic_module_body
 
 type module_type_body = mod_type generic_module_body
 
+type module_type_parameter
+(** A semantic subtype of {!module_type_body} guaranteed have all opaque data
+    stripped away *)
+
+val make_parameter : module_type_body -> module_type_parameter
+(** Drops opaque data of the the argument *)
+
+val repr_parameter : module_type_parameter -> module_type_body
+(** Effectively the identity. *)
+
 (** A [module_type_body] is just a [module_body] with no implementation. Its
     [mod_type_alg] contains the algebraic definition of this module type, or
     [None] if it has been built interactively. *)
@@ -37,7 +47,7 @@ type structure_body =
 
 (** A module signature is a structure, with possibly functors on top of it *)
 
-type module_signature = (module_type_body,structure_body) functorize
+type module_signature = (module_type_parameter,structure_body) functorize
 
 type module_implementation =
   | Abstract (** no accessible implementation *)
@@ -81,7 +91,7 @@ val replace_module_body : structure_body -> delta_resolver -> module_body -> mod
 val module_type_of_module : module_body -> module_type_body
 val module_body_of_type : module_type_body -> module_body
 
-val functorize_module : (Names.MBId.t * module_type_body) list -> module_body -> module_body
+val functorize_module : (Names.MBId.t * module_type_parameter) list -> module_body -> module_body
 
 (** {6 Setters} *)
 

--- a/kernel/mod_declarations.mli
+++ b/kernel/mod_declarations.mli
@@ -25,7 +25,7 @@ type module_body = mod_body generic_module_body
 
 type module_type_body = mod_type generic_module_body
 
-type module_type_parameter
+type module_type_parameter = module_type_body
 (** A semantic subtype of {!module_type_body} guaranteed have all opaque data
     stripped away *)
 

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -266,6 +266,7 @@ let rec translate_apply ustate env inl mp subst (sign, reso, cst) args = match a
   (sign, reso, cst)
 | mp1 :: args ->
   let farg_id, farg_b, sign = destr_functor sign in
+  let farg_b = repr_parameter farg_b in
   let farg_b =
     if is_empty_subst subst then farg_b
     else subst_modtype subst_codom subst (MPbound farg_id) farg_b
@@ -321,6 +322,7 @@ let rec translate_mse_funct (cst, ustate) (vm, vmstate) env ~is_mod mp inl mse =
   | (mbid, ty, ty_inl) :: params ->
     let mp_id = MPbound mbid in
     let mtb, cst, vm = translate_modtype (cst, ustate) (vm, vmstate) env mp_id ty_inl ([],ty) in
+    let mtb = make_parameter mtb in
     let env' = add_module_parameter mbid mtb env in
     let sign,alg,reso,cst,vm = translate_mse_funct (cst, ustate) (vm, vmstate) env' ~is_mod mp inl mse params in
     let alg' = MEMoreFunctor alg in

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -206,6 +206,7 @@ let add_module mp mb env =
   add_module mp mb no_link_info env
 
 let add_module_parameter mbid mtb env =
+  let mtb = repr_parameter mtb in
   add_module (MPbound mbid) (module_body_of_type mtb) env
 
 (** {6 Strengthening a signature for subtyping } *)

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -29,7 +29,7 @@ val destr_nofunctor : ModPath.t -> ('ty,'a) functorize -> 'a
 val check_modpath_equiv : env -> ModPath.t -> ModPath.t -> unit
 
 val annotate_module_expression : module_expression -> module_signature ->
-  (module_type_body, (constr * UVars.AbstractContext.t option) module_alg_expr) functorize
+  (module_type_parameter, (constr * UVars.AbstractContext.t option) module_alg_expr) functorize
 
 val annotate_struct_body : structure_body -> module_signature -> module_signature
 
@@ -51,7 +51,7 @@ the native compiler. The linking information is updated. *)
 val add_linked_module : ModPath.t -> module_body -> link_info -> env -> env
 
 (** add an abstract module parameter to the environment *)
-val add_module_parameter : MBId.t -> module_type_body -> env -> env
+val add_module_parameter : MBId.t -> module_type_parameter -> env -> env
 
 val add_retroknowledge : Retroknowledge.action list -> env -> env
 

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -110,7 +110,7 @@ let digest_match ~actual ~required =
 type library_info = DirPath.t * vodigest
 
 (** Functor and funsig parameters, most recent first *)
-type module_parameters = (MBId.t * module_type_body) list
+type module_parameters = (MBId.t * module_type_parameter) list
 
 type permanent_flags = {
   rewrite_rules_allowed : bool;
@@ -1428,6 +1428,7 @@ let add_module_parameter mbid mte inl senv =
   let state = check_state senv in
   let vmstate = vm_state senv in
   let mtb, _, vmtab = Mod_typing.translate_modtype state vmstate senv.env mp inl ([],mte) in
+  let mtb = make_parameter mtb in
   let senv = set_vm_library vmtab senv in
   let senv = { senv with env = Modops.add_module_parameter mbid mtb senv.env } in
   let new_variant = match senv.modvariant with
@@ -1435,7 +1436,7 @@ let add_module_parameter mbid mte inl senv =
     | SIG (params,oldenv) -> SIG ((mbid,mtb) :: params, oldenv)
     | _ -> assert false
   in
-  let new_paramresolver = match mod_global_delta mtb with
+  let new_paramresolver = match mod_global_delta (repr_parameter mtb) with
   | None -> senv.paramresolver
   | Some delta -> ParamResolver.add_delta_resolver mp delta senv.paramresolver
   in
@@ -1575,6 +1576,7 @@ let add_include me is_module inl senv =
       let state = check_state senv in
       (* Module subcomponents are already part of senv.env at this point *)
       let env = Environ.shallow_add_module mp_sup mb senv.env in
+      let mtb = repr_parameter mtb in
       let (_ : UGraph.t) = Subtyping.check_subtypes state env mp_sup (MPbound mbid) mtb in
       let mpsup_delta =
         Modops.inline_delta_resolver senv.env inl mp_sup mbid mtb senv.modresolver

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -204,7 +204,7 @@ val start_modtype : Id.t -> ModPath.t safe_transformer
 
 val add_module_parameter :
   MBId.t -> Entries.module_struct_entry -> Declarations.inline ->
-    Mod_declarations.module_type_body safe_transformer
+    Mod_declarations.module_type_parameter safe_transformer
 
 (** returns the number of module (type) parameters following the nested module
     structure. The inner module (type) comes first in the list. *)

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -384,9 +384,9 @@ and check_modtypes (cst, ustate) trace env mp1 mtb1 mp2 mtb2 subst1 subst2 =
         MoreFunctor (arg_id2,arg_t2,body_t2) ->
         let mparg1 = MPbound arg_id1 in
         let mparg2 = MPbound arg_id2 in
-        let subst1 = join (map_mbid arg_id1 mparg2 (mod_delta arg_t2)) subst1 in
+        let subst1 = join (map_mbid arg_id1 mparg2 (mod_delta (repr_parameter arg_t2))) subst1 in
         let env = add_module_parameter arg_id2 arg_t2 env in
-        let cst = check_modtypes (cst, ustate) (FunctorArgument (nargs+1) :: trace) env mparg2 arg_t2 mparg1 arg_t1 subst2 subst1 in
+        let cst = check_modtypes (cst, ustate) (FunctorArgument (nargs+1) :: trace) env mparg2 (repr_parameter arg_t2) mparg1 (repr_parameter arg_t1) subst2 subst1 in
         (* contravariant *)
         check_structure cst ~nargs:(nargs + 1) env body_t1 body_t2 subst1 subst2
       | _ , _ -> error_incompatible_modtypes mtb1 mtb2

--- a/library/global.mli
+++ b/library/global.mli
@@ -120,7 +120,7 @@ val end_modtype : Summary.Interp.frozen -> Id.t -> ModPath.t * MBId.t list
 
 val add_module_parameter :
   MBId.t -> Entries.module_struct_entry -> inline ->
-    module_type_body
+    module_type_parameter
 
 (** {6 Queries in the global environment } *)
 

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -320,7 +320,7 @@ and extract_mexpr_spec table venv env mp1 (me_struct_o,me_alg) = match me_alg wi
 and extract_mexpression_spec table venv env mp1 (me_struct,me_alg) = match me_alg with
   | MEMoreFunctor me_alg' ->
       let mbid, mtb, me_struct' = match me_struct with
-      | MoreFunctor (mbid, mtb, me') -> (mbid, mtb, me')
+      | MoreFunctor (mbid, mtb, me') -> (mbid, repr_parameter mtb, me')
       | _ -> assert false
       in
       let mp = MPbound mbid in
@@ -335,6 +335,7 @@ and extract_msignature_spec table venv env mp1 reso = function
       MTsig (mp1, extract_structure_spec table venv env' mp1 reso struc)
   | MoreFunctor (mbid, mtb, me) ->
       let mp = MPbound mbid in
+      let mtb = repr_parameter mtb in
       let env' = Environ.Internal.overwrite_module_parameter mbid mtb env in
       MTfunsig (mbid, extract_mbody_spec table venv env mp mtb,
                 extract_msignature_spec table venv env' mp1 reso me)
@@ -444,7 +445,7 @@ and extract_mexpression table access venv env mp mty = function
   | MENoFunctor me -> extract_mexpr table access venv env mp me
   | MEMoreFunctor me ->
       let (mbid, mtb, mty) = match mty with
-      | MoreFunctor (mbid, mtb, mty) -> (mbid, mtb, mty)
+      | MoreFunctor (mbid, mtb, mty) -> (mbid, repr_parameter mtb, mty)
       | NoFunctor _ -> assert false
       in
       let mp1 = MPbound mbid in
@@ -460,6 +461,7 @@ and extract_msignature table access venv env mp reso ~all = function
     Miniml.MEstruct (mp, extract_structure table access venv env' mp reso ~all struc)
   | MoreFunctor (mbid, mtb, me) ->
       let mp1 = MPbound mbid in
+      let mtb = repr_parameter mtb in
       let env' = Environ.Internal.overwrite_module_parameter mbid mtb env in
       Miniml.MEfunctor
         (mbid,

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -193,7 +193,7 @@ struct
           let resolver = match mod_global_delta mb with
           | None -> empty_delta_resolver mp
           | Some delta ->
-            Modops.inline_delta_resolver env inl mp farg_id farg_b delta
+            Modops.inline_delta_resolver env inl mp farg_id (repr_parameter farg_b) delta
           in
           mbid_left,join (map_mbid mbid mp resolver) subst
 
@@ -1048,7 +1048,7 @@ let intern_arg (acc, cst) (mbidl,(mty, base, kind, inl)) =
     let sp = Libnames.make_path DirPath.empty id in
     let mp = MPbound mbid in
     let mtb = Global.add_module_parameter mbid mty inl in
-    let resolver = mod_delta mtb in
+    let resolver = mod_delta (repr_parameter mtb) in
     let sobjs = subst_sobjs (map_mp mp0 mp resolver) sobjs in
     InterpVisitor.load_module 1 sp mp sobjs;
     (mbid, mtb, mty, inl) :: acc
@@ -1401,7 +1401,7 @@ let rec include_subst env mp reso mbids sign inline = match mbids with
     let farg_id, farg_b, fbody_b = Modops.destr_functor sign in
     let subst = include_subst env mp reso mbids fbody_b inline in
     let mp_delta =
-      Modops.inline_delta_resolver env inline mp farg_id farg_b reso
+      Modops.inline_delta_resolver env inline mp farg_id (repr_parameter farg_b) reso
     in
     join (map_mbid mbid mp mp_delta) subst
 
@@ -1454,12 +1454,12 @@ let declare_one_include_core (me,base,kind,inl) =
       let state = ((Global.universes (), Univ.UnivConstraints.empty), Reductionops.inferred_universes) in
       (* Module subcomponents are already part of env at this point *)
       let env = Environ.shallow_add_module cur_mp mb (Global.env ()) in
-      let (_, cst) = Subtyping.check_subtypes state env cur_mp (MPbound mbid) mtb in
+      let (_, cst) = Subtyping.check_subtypes state env cur_mp (MPbound mbid) (repr_parameter mtb) in
       let () = Global.add_univ_constraints cst in
       let mpsup_delta = match mod_global_delta mb with
       | None -> assert false (* mb is guaranteed not to be a functor here *)
       | Some delta ->
-        Modops.inline_delta_resolver (Global.env ()) inl cur_mp mbid mtb delta
+        Modops.inline_delta_resolver (Global.env ()) inl cur_mp mbid (repr_parameter mtb) delta
       in
       let subst = Mod_subst.map_mbid mbid cur_mp mpsup_delta in
       compute_sign (Modops.subst_signature subst cur_mp str)

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -357,10 +357,10 @@ let print_mod_expr env mp locals = function
 let rec print_functor fty fatom is_type extent env mp used locals = function
   | NoFunctor me -> fatom is_type extent env mp locals me
   | MoreFunctor (mbid,mtb1,me2) ->
-      let id = nametab_register_modparam !used mbid mtb1 in
+      let id = nametab_register_modparam !used mbid (repr_parameter mtb1) in
       let () = used := Id.Set.add id !used in
       let mp1 = MPbound mbid in
-      let pr_mtb1 = fty extent env mp1 used locals mtb1 in
+      let pr_mtb1 = fty extent env mp1 used locals (repr_parameter mtb1) in
       let env' = Modops.add_module_parameter mbid mtb1 env in
       let avoid = List.fold_left (fun accu (_, id) -> Id.Set.add id accu) Id.Set.empty locals in
       let locals' = (mbid, get_new_id avoid (MBId.to_id mbid))::locals in


### PR DESCRIPTION
In theory, some parts of what we store in module types are not used by the system. The two principal examples are opaque proof bodies and sealed module implementations, as they are never accessed when typechecking modules. In both cases we only ever care about the type of the corresponding object, not its implementation.

In practice, we do want to keep them for one single use case, namely the infamous ability to include module types into plain modules. While we could interpret this operation as adding axioms with opaque proofs and modules, users typically expect that it keeps the underlying body instead. This pattern is unfortunately used in several places in the standard library to work around user syntax limitations.

Instead of doing it this violently, in this commit we go for a slightly more refined approach. We drop the opaque content of the parameters of functors only. There is no easy way to include the type of module parameters, hence one cannot rely on the aforementioned hack.

To easily keep track of which modules are assumed to have no opaque content, we introduce a new type and carefully add wrappers that drop this content at the right place.