### PR TITLE
Correctly validate block tags in rocqchk demarshaller.

### DIFF
--- a/checker/validate.ml
+++ b/checker/validate.ml
@@ -117,7 +117,8 @@ let val_tag t mem ctx o =
 
 let val_block mem ctx o =
   if is_block mem o then
-    (if tag mem o > Obj.no_scan_tag then
+    let t = tag mem o in
+    (if not (Obj.first_non_constant_constructor_tag <= t && t <= Obj.last_non_constant_constructor_tag) then
       fail mem ctx o "block: found no scan tag")
   else fail mem ctx o "expected block obj"
 


### PR DESCRIPTION
Contrarily to the recommended fix in the report, we rely on the OCaml Obj API that exposes bounds on the valid block tags.

Fixes #22407: rocqchk admits no-scan-tag blocks into validated .vo values.