### PR TITLE
Add a proper dummy constr, instead of using mkProp

### DIFF
--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -183,6 +183,7 @@ type 'a puniverses = 'a * EInstance.t
 
 let in_punivs a = (a, EInstance.empty)
 
+let dummy = of_kind (Var (Id.of_string "_DUMMY_"))
 let mkSProp = of_kind (Sort (ESorts.make Sorts.sprop))
 let mkProp = of_kind (Sort (ESorts.make Sorts.prop))
 let mkSet = of_kind (Sort (ESorts.make Sorts.set))
@@ -679,7 +680,7 @@ let contract_case env sigma (ci, (p,rp), iv, c, br) =
     let (ind, u) = destInd sigma ind in
     let () = assert (Environ.QInd.equal env ind ci.ci_ind) in
     let pms = Array.sub args 0 mib.mind_nparams in
-    let dummy = List.make mip.mind_nrealdecls Constr.mkProp in
+    let dummy = List.make mip.mind_nrealdecls Constr.dummy in
     let pms = Array.map (fun c -> of_constr (CVars.substl dummy (unsafe_to_constr c))) pms in
     (u, pms)
   | _ -> assert false

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -153,6 +153,7 @@ val of_constr : Constr.t -> t
 
 (** {6 Constructors} *)
 
+val dummy : t
 val mkRel : int -> t
 val mkVar : Id.t -> t
 val mkMeta : metavariable -> t

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -1138,7 +1138,7 @@ let rec eta_reduce_head sigma c =
 
 let eta_expand_instantiation ?evars env inst ctxt =
   let open Context.Rel.Declaration in
-  let eta_inst = Array.make (Array.length inst) mkProp in
+  let eta_inst = Array.make (Array.length inst) dummy in
   let rec fold subst i = function
   | [] -> assert (Array.length inst = i)
   | LocalAssum (_, ty) :: ctx ->

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -330,6 +330,8 @@ let decompose_app c =
 (*********************)
 
 (* Constructs a de Bruijn index with number n *)
+let dummy = T (Var (Id.of_string "_DUMMY_"))
+
 let rels = Array.init 17 (fun i -> T (Rel i))
 
 let mkRel n = if 0<=n && n<=16 then rels.(n) else T (Rel n)

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -64,6 +64,9 @@ type types = constr
 
 (** {6 Term constructors. } *)
 
+(** A dummy term *)
+val dummy : constr
+
 (** Constructs a de Bruijn index (DB indices begin at 1) *)
 val mkRel : int -> constr
 

--- a/kernel/discharge.ml
+++ b/kernel/discharge.ml
@@ -89,10 +89,10 @@ let cook_constant _env info cb =
 let cook_rel_context cache ctx =
   (* Dealing with substitutions between contexts is too annoying, so
      we reify [ctx] into a big [forall] term and work on that. *)
-  let t = it_mkProd_or_LetIn mkProp ctx in
+  let t = it_mkProd_or_LetIn dummy ctx in
   let t = abstract_as_type cache t in
   let ctx, t = decompose_prod_decls t in
-  assert (Constr.equal t mkProp);
+  assert (Constr.equal t dummy);
   ctx
 
 let cook_lc cache ~ntypes t =
@@ -104,7 +104,7 @@ let cook_lc cache ~ntypes t =
   abstract_as_type cache t
 
 let cook_projection cache ~params t =
-  let t = mkArrowR mkProp t in (* dummy type standing in for the inductive *)
+  let t = mkArrowR dummy t in (* dummy type standing in for the inductive *)
   let t = it_mkProd_or_LetIn t params in
   let t = abstract_as_type cache t in
   let nrels = Context.Rel.nhyps (rel_context_of_cooking_cache cache) in

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -547,7 +547,7 @@ let contract_case env (ci, (p,rp), iv, c, br) =
     let () = assert (QInd.equal env ind ci.ci_ind) in
     let pms = Array.sub args 0 mib.mind_nparams in
     (** Unlift the parameters from under the index binders *)
-    let dummy = List.make mip.mind_nrealdecls mkProp in
+    let dummy = List.make mip.mind_nrealdecls dummy in
     let pms = Array.map (fun c -> Vars.substl dummy c) pms in
     (u, pms)
   | _ -> assert false

--- a/kernel/inferCumulativity.ml
+++ b/kernel/inferCumulativity.ml
@@ -256,7 +256,7 @@ let rec infer_fterm cv_pb infos variances hd stk =
     (* don't check discriminee: inductive is guaranteed proof irrelevant *)
     let mib = Environ.lookup_mind (fst ci.ci_ind) (info_env (fst infos)) in
     let (_, (p, _), _, _, br) =
-      Inductive.expand_case_specif mib (ci, u, pms, p, NoInvert, mkProp, br)
+      Inductive.expand_case_specif mib (ci, u, pms, p, NoInvert, dummy, br)
     in
     let infer c variances = infer_fterm CONV infos variances (mk_clos e c) [] in
     let variances = Array.fold_left (fun variances i ->
@@ -283,7 +283,6 @@ and infer_stack infos variances (stk:CClosure.stack) =
         let variances = infer_fterm CONV infos variances fx [] in
         infer_stack infos variances a
       | ZcaseT (ci,u,pms,p,br,e) ->
-        let dummy = mkProp in
         let case = (ci, u, pms, p, NoInvert, dummy, br) in
         let (_, (p, _), _, _, br) = Inductive.expand_case (info_env (fst infos)) case in
         let variances = infer_fterm CONV infos variances (mk_clos e p) [] in

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -25,7 +25,7 @@ let is_rec_info sigma scheme_info =
     acc
     ||
     let new_branche =
-      it_mkProd_or_LetIn mkProp
+      it_mkProd_or_LetIn dummy
         (fst (decompose_prod_decls sigma (RelDecl.get_type decl)))
     in
     let free_rels_in_br = Termops.free_rels sigma new_branche in

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -230,7 +230,7 @@ let exec_tactic env sigma n f args =
   let get_res = CAst.make (TacML (get_res, [TacGeneric (None, n)])) in
   let getter = Tacexp (CAst.make (TacFun (List.map (fun n -> Name n) lid, get_res))) in
   (* Evaluate the whole result *)
-  let _, pv = Proofview.init sigma [env, EConstr.mkProp] in
+  let _, pv = Proofview.init sigma [env, EConstr.dummy] in
   let tac = Tacinterp.eval_tactic_ist ist (ltac_call f (args@[getter])) in
   let ((), pv, _, _, _) = Proofview.apply ~name:(Id.of_string "ring") ~poly:ist.Tacinterp.poly (Global.env ()) tac pv in
   let sigma = Evd.minimize_universes (Proofview.return pv) in

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -718,10 +718,10 @@ let rwargtac ?under ?map_redex ist ((dir, mult), (((oclr, occ), grx), (kind, gt)
   let interp_rpattern env sigma gc =
     try interp_rpattern env sigma gc
     with e when CErrors.noncritical e && snd mult = May ->
-      fail := true; { pat_sigma = sigma; pat_pat = T EConstr.mkProp } in
+      fail := true; { pat_sigma = sigma; pat_pat = T EConstr.dummy } in
   let interp env sigma gc =
     try interp_term env sigma ist gc
-    with e when CErrors.noncritical e && snd mult = May -> fail := true; (sigma, EConstr.mkProp) in
+    with e when CErrors.noncritical e && snd mult = May -> fail := true; (sigma, EConstr.dummy) in
   let rwtac =
     Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -291,7 +291,7 @@ let intro_clear ids =
     let env = Proofview.Goal.env gl in
     let fold (used_ids, clear_ids, ren) id =
       let new_id = Ssrcommon.mk_anon_id (Id.to_string id) used_ids in
-      let used_ids = Environ.push_named_context_val ProofVar (LocalAssum (annotR new_id, mkProp)) used_ids in
+      let used_ids = Environ.push_named_context_val ProofVar (LocalAssum (annotR new_id, dummy)) used_ids in
       (used_ids, new_id :: clear_ids, (id, new_id) :: ren)
     in
     let _, clear_ids, ren = List.fold_left fold (Environ.named_context_val env, [], []) ids in

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -289,7 +289,7 @@ and unif_FO_skip_impl env ise metas p c =
         failure_FO ()
     end
   | _ ->
-    let kludge v = EConstr.mkLambda (make_annot Anonymous EConstr.ERelevance.relevant, EConstr.mkProp, v) in
+    let kludge v = EConstr.mkLambda (make_annot Anonymous EConstr.ERelevance.relevant, EConstr.dummy, v) in
     Unification.w_unify ~metas env ise Conversion.CONV ~flags:(flags_FO env) (kludge p) (kludge c)
 and unif_FO_skip_impl3 env ise metas args1 args2 imp =
   match args1, args2, imp with
@@ -450,7 +450,7 @@ let pr_econstr_pat env sigma c0 =
   let rec wipe_evar c = let open EConstr in
     if isEvar sigma c then ehole_var else map sigma wipe_evar c in
   let dummy_decl =
-    let dummy_prod = mkProd (make_annot Anonymous Sorts.Relevant,mkProp,mkProp) in
+    let dummy_prod = mkProd (make_annot Anonymous Sorts.Relevant,dummy,dummy) in
     let na = make_annot (EConstr.destVar sigma ehole_var) Sorts.Relevant in
     Context.Named.Declaration.(LocalAssum (na, dummy_prod)) in
   let env = Environ.push_named ProofVar dummy_decl env in
@@ -643,7 +643,7 @@ let match_upats_FO upats env sigma0 ise orig_c =
          if skip || not (EConstr.Vars.closed0 ise c') then () else try
            let () = match u.up_k with
            | KpatFlex ->
-             let kludge v = mkLambda (make_annot Anonymous ERelevance.relevant, mkProp, v) in
+             let kludge v = mkLambda (make_annot Anonymous ERelevance.relevant, dummy, v) in
              let (metas, p_FO) = u.up_FO in
              unif_FO env ise metas (kludge p_FO) (kludge c')
            | KpatLet ->

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -1782,7 +1782,7 @@ let abstract_tycon ?loc env sigma subst tycon extenv t =
         let sigma, res = refresh_universes (Some false) !!env !evdref ty in
         evdref := sigma; res
       in
-      let dummy_subst = List.init k (fun _ -> mkProp) in
+      let dummy_subst = List.init k (fun _ -> dummy) in
       let ty = substl dummy_subst (aux x ty) in
       let sigma = !evdref in
       let depvl = free_rels sigma ty in

--- a/pretyping/cbv.ml
+++ b/pretyping/cbv.ml
@@ -911,7 +911,7 @@ let rec apply_stack info t = function
       apply_stack info (mkApp(t,Array.map_of_list (cbv_norm_value info) args)) st
   | CASE (u,pms,ty,br,iv,ci,env,st) ->
     (* FIXME: Prevent this expansion by caching whether an inductive contains let-bindings *)
-    let (_, (ty,r), _, _, br) = Inductive.expand_case info.env (ci, u, pms, ty, iv, mkProp, br) in
+    let (_, (ty,r), _, _, br) = Inductive.expand_case info.env (ci, u, pms, ty, iv, dummy, br) in
     let ty =
       let (_, mip) = Inductive.lookup_mind_specif info.env ci.ci_ind in
       Term.decompose_lambda_n_decls (mip.Declarations.mind_nrealdecls + 1) ty

--- a/pretyping/constr_matching.ml
+++ b/pretyping/constr_matching.ml
@@ -120,7 +120,7 @@ let rec build_lambda sigma vars ctx m = match vars with
   let keep, shift = List.fold_left fold (0, []) clear in
   let shift = List.rev shift in
   let map = function
-  | None -> mkProp (* dummy term *)
+  | None -> dummy
   | Some i -> mkRel (i + 1)
   in
   (* [x1 ... xn y z1 ... zm] -> [x1 ... xn f(z1) ... f(zm) y] *)
@@ -166,15 +166,13 @@ let rec extract_bound_aux k accu frels ctx = match ctx with
 let extract_bound_vars frels ctx =
   extract_bound_aux 1 Id.Set.empty frels ctx
 
-let dummy_constr = EConstr.mkProp
-
 let make_renaming ids = function
 | (Name id, _, _) ->
   begin
     try EConstr.mkRel (List.index Id.equal id ids)
-    with Not_found -> dummy_constr
+    with Not_found -> EConstr.dummy
   end
-| _ -> dummy_constr
+| _ -> EConstr.dummy
 
 let push_binder na1 na2 t ctx =
   let id2 = map_annot (function

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -94,7 +94,7 @@ let return_clause env sigma ind u params ((nas, p),_) =
     let realdecls = instantiate_context u paramsubst nas realdecls in
     List.map EConstr.of_rel_decl realdecls, p
   with e when CErrors.noncritical e ->
-    let dummy na = LocalAssum (na, EConstr.mkProp) in
+    let dummy na = LocalAssum (na, EConstr.dummy) in
     List.rev (Array.map_to_list dummy nas), p
 
 let branch env sigma (ind, i) u params (nas, br) =
@@ -115,7 +115,7 @@ let branch env sigma (ind, i) u params (nas, br) =
     let ctx = instantiate_context u paramsubst nas ctx in
     List.map EConstr.of_rel_decl ctx, br
   with e when CErrors.noncritical e ->
-    let dummy na = LocalAssum (na, EConstr.mkProp) in
+    let dummy na = LocalAssum (na, EConstr.dummy) in
     List.rev (Array.map_to_list dummy nas), br
 
 end
@@ -1043,7 +1043,7 @@ let detype_closed_glob ~flags ?isgoal ?avoid env sigma t =
           (* spiwack: I'm not sure it is the right thing to do,
              but I'm computing the detyping environment like
              [Printer.pr_constr_under_binders_env] does. *)
-          let assums = List.map (fun id -> LocalAssum (make_annot (Name id) ERelevance.relevant,(* dummy *) mkProp)) b in
+          let assums = List.map (fun id -> LocalAssum (make_annot (Name id) ERelevance.relevant, dummy)) b in
           let env = push_rel_context assums env in
           DAst.get (detype Now ~flags ?isgoal ?avoid env sigma c)
         (* if [id] is bound to a [closed_glob_constr]. *)

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -445,7 +445,6 @@ struct
     (List.skipn (n+1) kargs, strip_n_app n stk)
 
   let expand_case env sigma ((ci, u, pms, t, iv, br) : case_stk) =
-    let dummy = mkProp in
     let (ci, u, pms, t, _, _, br) = EConstr.annotate_case env sigma (ci, u, pms, t, iv, dummy, br) in
     (ci, u, pms, t, br)
 
@@ -795,7 +794,6 @@ and apply_rule whrec env sigma ctx psubst es stk =
       apply_rule whrec env sigma ctx psubst e s
   | Declarations.PECase (pind, pret, pbrs) :: e, Stack.Case (ci, u, pms, p, iv, brs) :: s ->
       if not @@ QInd.equal env pind ci.ci_ind then raise PatternFailure;
-      let dummy = mkProp in
       let (_, _, _, ((ntys_ret, ret), _), _, _, brs) = EConstr.annotate_case env sigma (ci, u, pms, p, NoInvert, dummy, brs) in
       let psubst = match_arg_pattern whrec env sigma (ntys_ret @ ctx) psubst pret ret in
       let psubst = Array.fold_left2 (fun psubst pat (ctx', br) -> match_arg_pattern whrec env sigma (ctx' @ ctx) psubst pat br) psubst pbrs brs in

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -66,7 +66,7 @@ let pr_constr_under_binders_env_gen pr ?flags env sigma (ids,c) =
   (* Warning: clashes can occur with variables of same name in env but *)
   (* we also need to preserve the actual names of the patterns *)
   (* So what to do? *)
-  let assums = List.map (fun id -> (make_annot (Name id) Sorts.Relevant,(* dummy *) mkProp)) ids in
+  let assums = List.map (fun id -> (make_annot (Name id) Sorts.Relevant, dummy)) ids in
   pr ?inctx:None ?scope:None ?flags (Termops.push_rels_assum assums env) sigma c
 
 let pr_constr_under_binders_env = pr_constr_under_binders_env_gen pr_econstr_env

--- a/proofs/subproof.ml
+++ b/proofs/subproof.ml
@@ -84,8 +84,8 @@ let rec shrink ctx sign c t accu =
   | [], [] -> (c, t, accu)
   | p :: ctx, decl :: sign ->
     if noccurn 1 c && noccurn 1 t then
-      let c = subst1 mkProp c in
-      let t = subst1 mkProp t in
+      let c = subst1 dummy c in
+      let t = subst1 dummy t in
       shrink ctx sign c t accu
     else
       let c = Term.mkLambda_or_LetIn p c in

--- a/tactics/cbn.ml
+++ b/tactics/cbn.ml
@@ -822,7 +822,7 @@ let apply_branch env sigma (ind, i) args subs (ci, u, pms, iv, r, lf) =
       List.fold_left (fun subst arg -> Esubst.subs_cons arg subst) subs args
     else
       let pms = Array.Fun1.map CbnClos.force_constr subs pms in
-      let ctx = expand_branch env sigma u pms (ind, i) (fst br, mkProp) in
+      let ctx = expand_branch env sigma u pms (ind, i) (fst br, dummy) in
       cbn_subst_of_rel_context_instance_list ctx args subs
   in
   CbnClos.mk_clos subs body
@@ -920,7 +920,6 @@ and apply_rule whrec env sigma ctx psubst es stk =
       apply_rule whrec env sigma ctx psubst e s
   | Declarations.PECase (pind, pret, pbrs) :: e, Stack.Case (subs,(ci, _, _, _, _, _ as case), cst_l) :: s ->
       if not @@ QInd.equal env pind ci.ci_ind then raise PatternFailure;
-      let dummy = mkProp in
       let (ci, u, pms, p, iv, brs) = CbnClos.force_case subs case in
       let (_, _, _, ((ntys_ret, ret), _), _, _, brs) = EConstr.annotate_case env sigma (ci, u, pms, p, iv, dummy, brs) in
       let psubst = match_arg_pattern whrec env sigma (ntys_ret @ ctx) psubst pret (CbnClos.inject ret) in

--- a/tactics/eClause.ml
+++ b/tactics/eClause.ml
@@ -80,7 +80,7 @@ let make_evar_clause env sigma ?len t =
       let inst, ctx, args, subst = match inst with
       | None ->
         (* Dummy type *)
-        let ctx, _, args, subst = push_rel_context_to_named_context env sigma mkProp in
+        let ctx, _, args, subst = push_rel_context_to_named_context env sigma dummy in
         Some (ctx, args, subst), ctx, args, subst
       | Some (ctx, args, subst) -> inst, ctx, args, subst
       in

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1441,7 +1441,7 @@ let inject_at_positions env sigma l2r eq posns tac =
       let args = Array.map mk [|t; resty; injfun; t1; t2|] in
       let sigma, pf = Typing.judge_of_apply env sigma (mk congr) args in
       let { Environ.uj_val = pf; Environ.uj_type = pf_typ } = pf in
-      let pf_typ = Vars.subst1 mkProp (pi3 @@ destProd sigma pf_typ) in
+      let pf_typ = Vars.subst1 dummy (pi3 @@ destProd sigma pf_typ) in
       let pf = mkApp (pf, [| v |]) in
       let ty = simplify_args env sigma pf_typ in
         evdref := sigma;

--- a/tactics/generalize.ml
+++ b/tactics/generalize.ml
@@ -113,7 +113,7 @@ let generalized_name env sigma c t ids cl = function
 let generalize_goal_gen env sigma ids i ((occs,c,b),na) t cl =
   let open Context.Rel.Declaration in
   let decls,cl = decompose_prod_n_decls sigma i cl in
-  let dummy_prod = it_mkProd_or_LetIn mkProp decls in
+  let dummy_prod = it_mkProd_or_LetIn dummy decls in
   let newdecls,_ =
     let arity = Array.length (snd (EConstr.decompose_app sigma c)) in
     let cache = ref Int.Map.empty in

--- a/tactics/induction.ml
+++ b/tactics/induction.ml
@@ -699,7 +699,7 @@ type elim_scheme = {
 
 let empty_scheme =
   {
-    elimt = mkProp;
+    elimt = dummy;
     indref = None;
     params = [];
     nparams = 0;
@@ -710,7 +710,7 @@ let empty_scheme =
     args = [];
     nargs = 0;
     indarg = None;
-    concl = mkProp;
+    concl = dummy;
     indarg_in_concl = false;
     farg_in_concl = false;
   }
@@ -960,7 +960,7 @@ let compute_case_signature env mind dep names_info =
       if dep then Array.append indices (Context.Rel.instance Constr.mkRel 0 argctx)
       else indices
     in
-    let base = Constr.mkApp (Constr.mkProp, base) in (* only used for noccurn *)
+    let base = Constr.mkApp (Constr.dummy, base) in (* only used for noccurn *)
     let lchck_brch = check_branch (Term.it_mkProd_or_LetIn base argctx) in
     let n = List.count (fun (b, _, _) -> b == RecArg) lchck_brch in
     let recvarname, hyprecname, avoid = make_up_names n (Some indref) names_info in

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -180,7 +180,7 @@ let decompose_app_rel env evd t =
   match Reductionops.splay_arity env evd ty with
   | [_, ty2; _, ty1], concl ->
     if noccurn evd 1 ty2 then
-      Some (rel, ty1, subst1 mkProp ty2, concl, t1, t2)
+      Some (rel, ty1, subst1 dummy ty2, concl, t1, t2)
     else None
   | _ -> assert false
 
@@ -313,7 +313,7 @@ end) = struct
           let b = Reductionops.nf_betaiota env (goalevars evars) b in
           if noccurn (goalevars evars) 1 b (* non-dependent product *) then
             let ty = Reductionops.nf_betaiota env (goalevars evars) ty in
-            let (evars, b', arg, cstrs) = aux env evars (subst1 mkProp b) cstrs in
+            let (evars, b', arg, cstrs) = aux env evars (subst1 dummy b) cstrs in
             let evars, relty = mk_relty evars env ty obj in
             let evars', b' = Evarsolve.refresh_universes ~onlyalg:true ~status:(Evd.UnivFlexible false)
               (Some false) env (fst evars) b' in
@@ -1051,7 +1051,7 @@ let fold_match ?(force=false) env sigma c =
     let sortc = Retyping.get_sort_quality_of env sigma cty in
     let dep = not (noccurn sigma 1 body) in
     let pred = if dep then p else
-        it_mkProd_or_LetIn (subst1 mkProp body) (List.tl ctx)
+        it_mkProd_or_LetIn (subst1 dummy body) (List.tl ctx)
     in
     let sk =
       (* not sure how correct this is *)
@@ -1228,7 +1228,7 @@ let subterm all flags (s : 'a pure_strategy) : 'a pure_strategy =
         state, res
 
       | Prod (n, x, b) when noccurn (goalevars evars) 1 b ->
-          let b = subst1 mkProp b in
+          let b = subst1 dummy b in
           let evars, tx = get_type_of_refresh env evars x in
           let evars, tb = get_type_of_refresh env evars b in
           let arr = if prop then PropGlobal.arrow_morphism

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -2840,7 +2840,7 @@ let specialize (c,lbind) ipat =
           let rels = lift (Int.Set.remove 1 rels) in
           let rels = RelDecl.fold_constr (fun c accu -> Int.Set.union accu (free_rels sigma c)) decl rels in
           mkLambda_or_LetIn decl c, mkProd_or_LetIn decl ty, rels
-        else subst1 mkProp (* dummy *) c, subst1 mkProp ty, lift rels
+        else subst1 dummy c, subst1 dummy ty, lift rels
       in
       rebuild rels ctx c ty
     in

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -232,7 +232,7 @@ let rec traverse access (current:GlobRef.t) ctx accu t =
       let obj = ConstRef kn in
       let already_in = GlobRef.Map_env.mem obj data in
       let data = if not already_in then GlobRef.Map_env.add obj None data else data in
-      let ty = (current, ctx, Vars.subst1 mkProp oty) in
+      let ty = (current, ctx, Vars.subst1 dummy oty) in
       let ax2ty =
         try let l = GlobRef.Map_env.find obj ax2ty in GlobRef.Map_env.add obj (ty::l) ax2ty
         with Not_found -> GlobRef.Map_env.add obj [ty] ax2ty in
@@ -399,13 +399,13 @@ let assumptions ?(add_opaque=false) ?(add_transparent=false) access st grs =
         if cb.const_typing_flags.check_guarded then accu
         else
           let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
-          ContextObjectMap.add (Axiom (Guarded obj, l)) Constr.mkProp accu
+          ContextObjectMap.add (Axiom (Guarded obj, l)) Constr.dummy accu
       in
       let accu =
         if cb.const_typing_flags.check_universes then accu
         else
           let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
-          ContextObjectMap.add (Axiom (TypeInType obj, l)) Constr.mkProp accu
+          ContextObjectMap.add (Axiom (TypeInType obj, l)) Constr.dummy accu
       in
     if not (Option.has_some contents) then
       let t = type_of_constant cb in
@@ -426,31 +426,31 @@ let assumptions ?(add_opaque=false) ?(add_transparent=false) access st grs =
         if mind.mind_typing_flags.check_positive then accu
         else
           let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
-          ContextObjectMap.add (Axiom (Positive m, l)) Constr.mkProp accu
+          ContextObjectMap.add (Axiom (Positive m, l)) Constr.dummy accu
       in
       let accu =
         if mind.mind_typing_flags.check_guarded then accu
         else
           let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
-          ContextObjectMap.add (Axiom (Guarded obj, l)) Constr.mkProp accu
+          ContextObjectMap.add (Axiom (Guarded obj, l)) Constr.dummy accu
       in
       let accu =
         if mind.mind_typing_flags.check_universes then accu
         else
           let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
-          ContextObjectMap.add (Axiom (TypeInType obj, l)) Constr.mkProp accu
+          ContextObjectMap.add (Axiom (TypeInType obj, l)) Constr.dummy accu
       in
       let accu =
         if not (uses_uip mind) then accu
         else
           let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
-          ContextObjectMap.add (Axiom (UIP m, l)) Constr.mkProp accu
+          ContextObjectMap.add (Axiom (UIP m, l)) Constr.dummy accu
       in
       let accu =
         if not (Array.exists (fun mip -> mip.mind_relies_on_indices_not_mattering) mind.mind_packets) then accu
         else
           let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
-          ContextObjectMap.add (Axiom (IndicesNotMattering m, l)) Constr.mkProp accu
+          ContextObjectMap.add (Axiom (IndicesNotMattering m, l)) Constr.dummy accu
       in
       accu
   in

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -374,7 +374,7 @@ let build_fix_type sigma ctx ccl (_, extradecl) =
 let build_dummy_fix_type sigma ctx ccl (_, extradecl) =
   (* Hack: the extra declarations are smashed to a dummy non-dependent
      so as not to contribute to the computation of implicit arguments *)
-  let ccl = it_mkProd_or_LetIn (Vars.lift (Context.Rel.length extradecl) ccl) (List.map (RelDecl.map_type (fun _ -> mkProp)) extradecl) in
+  let ccl = it_mkProd_or_LetIn (Vars.lift (Context.Rel.length extradecl) ccl) (List.map (RelDecl.map_type (fun _ -> dummy)) extradecl) in
   Evarutil.nf_evar sigma (it_mkProd_or_LetIn ccl ctx)
 
 (* Wellfounded definition *)

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -410,7 +410,7 @@ let non_template_levels sigma ~params ~arity ~constructors =
     | LocalAssum (_, t) ->
       match get_template_binding_arity sigma t with
       | None -> add_levels t levels
-      | Some (decls, _, _) -> add_levels (EConstr.it_mkProd_or_LetIn EConstr.mkProp decls) levels
+      | Some (decls, _, _) -> add_levels (EConstr.it_mkProd_or_LetIn EConstr.dummy decls) levels
   in
   (* Levels in LocalDef params, on the left of the context in LocalAssum params,
      in the indices and in the constructor types are not allowed to be template.
@@ -748,7 +748,7 @@ let interp_mutual_inductive_gen env0 ~flags udecl (uparamsl,paramsl,indl) notati
   let arities, relevances, template_syntax, indimpls = List.split4 arities in
 
   let lift_ctx n ctx =
-    let t = EConstr.it_mkProd_or_LetIn EConstr.mkProp ctx in
+    let t = EConstr.it_mkProd_or_LetIn EConstr.dummy ctx in
     let t = EConstr.Vars.lift n t in
     let ctx, _ = EConstr.decompose_prod_decls sigma t in
     ctx

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1264,7 +1264,7 @@ let it_mkLambda_or_LetIn_or_clean t ctx =
   let open Context.Rel.Declaration in
   let fold t decl =
     if is_local_assum decl then Term.mkLambda_or_LetIn decl t
-    else if Vars.noccurn 1 t then Vars.subst1 mkProp t
+    else if Vars.noccurn 1 t then Vars.subst1 dummy t
     else Term.mkLambda_or_LetIn decl t
   in
   Context.Rel.fold_inside fold ctx ~init:t
@@ -1308,7 +1308,7 @@ let shrink_body c ty =
     List.fold_left
       (fun (b, ty, i, args) decl ->
         if Vars.noccurn 1 b && Option.cata (Vars.noccurn 1) true ty then
-          (Vars.subst1 mkProp b, Option.map (Vars.subst1 mkProp) ty, succ i, args)
+          (Vars.subst1 dummy b, Option.map (Vars.subst1 dummy) ty, succ i, args)
         else
           let open Context.Rel.Declaration in
           let args = if is_local_assum decl then mkRel i :: args else args in


### PR DESCRIPTION
I was tired of seeing `mkProp` used transparently as a dummy.
I replaced all uses of it with `dummy`, then went and checked whether these were dummies or actual uses of Prop.
I am pretty sure for all uses, but this warrants a second opinion.

I'm also not too sure about
https://github.com/rocq-prover/rocq/blob/e47214bc2ad266bd499450f61e6483037f5a411b/plugins/ssr/ssrfwd.ml#L351
which, if a dummy, hides it very deep, and
https://github.com/rocq-prover/rocq/blob/e47214bc2ad266bd499450f61e6483037f5a411b/plugins/ssr/ssrequality.ml#L419
which may just need a substitution instead of an apparently useless let-in.