### PR TITLE
Perform functor subtyping in a single name space.

### DIFF
--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -360,7 +360,18 @@ and check_signatures (cst, ustate) trace env mp1 sig1 mp2 sig2 subst1 subst2 res
 and check_modtypes (cst, ustate) trace env mp1 mtb1 mp2 mtb2 subst1 subst2 =
   if mtb1==mtb2 || mod_type mtb1 == mod_type mtb2 then cst
   else
-    let rec check_structure cst ~nargs env struc1 struc2 subst1 subst2 =
+    (* Invariant: [delta1] is [mod_delta mtb1] transported into the name space
+       of [env], and [subst2] sends [mp2] to [mp1] with [delta1] as resolver.
+       As we descend into a functor, [subst1] renames the implementation's
+       parameters into the signature's ones, so [delta1] must follow, and the
+       resolver carried by [subst2] must be kept in sync with it. Otherwise the
+       canonical names computed through [subst2] live in a different name space
+       than the ones computed through [subst1] and can never be recognised as
+       equal. Note that re-adding the binding for [mp2] also matters when [mp2]
+       is a submodule of the module the enclosing [subst2] talks about: for a
+       functor field the enclosing resolver carries no information at all,
+       since [mod_global_delta] is [None] on functors. *)
+    let rec check_structure cst ~nargs env struc1 struc2 subst1 subst2 delta1 =
       match struc1,struc2 with
       | NoFunctor list1,
         NoFunctor list2 ->
@@ -373,25 +384,28 @@ and check_modtypes (cst, ustate) trace env mp1 mtb1 mp2 mtb2 subst1 subst2 =
             (* We only add the subcomponents, the functor per se is already
                part of the environment but the subtyping check will never access
                it directly *)
-            Modops.add_structure mp1 (subst_structure subst1 mp1 list1) (mod_delta mtb1) env
+            Modops.add_structure mp1 (subst_structure subst1 mp1 list1) delta1 env
         in
-        let delta_mtb1 = mod_delta mtb1 in
         let delta_mtb2 = mod_delta mtb2 in
         check_signatures (cst, ustate) trace env
           mp1 list1 mp2 list2 subst1 subst2
-          delta_mtb1 delta_mtb2
+          delta1 delta_mtb2
       | MoreFunctor (arg_id1,arg_t1,body_t1),
         MoreFunctor (arg_id2,arg_t2,body_t2) ->
         let mparg1 = MPbound arg_id1 in
         let mparg2 = MPbound arg_id2 in
-        let subst1 = join (map_mbid arg_id1 mparg2 (mod_delta arg_t2)) subst1 in
+        let nsubst = map_mbid arg_id1 mparg2 (mod_delta arg_t2) in
+        let subst1 = join nsubst subst1 in
+        let delta1 = subst_codom_delta_resolver nsubst delta1 in
+        let subst2 = add_mp mp2 mp1 delta1 subst2 in
         let env = add_module_parameter arg_id2 arg_t2 env in
         let cst = check_modtypes (cst, ustate) (FunctorArgument (nargs+1) :: trace) env mparg2 arg_t2 mparg1 arg_t1 subst2 subst1 in
         (* contravariant *)
-        check_structure cst ~nargs:(nargs + 1) env body_t1 body_t2 subst1 subst2
+        check_structure cst ~nargs:(nargs + 1) env body_t1 body_t2 subst1 subst2 delta1
       | _ , _ -> error_incompatible_modtypes mtb1 mtb2
     in
     check_structure cst ~nargs:0 env (mod_type mtb1) (mod_type mtb2) subst1 subst2
+      (subst_codom_delta_resolver subst1 (mod_delta mtb1))
 
 let check_subtypes state env mp_sup mp_super super =
   let sup = match Environ.lookup_module mp_sup env with

--- a/test-suite/bugs/bug_22411_1.v
+++ b/test-suite/bugs/bug_22411_1.v
@@ -1,0 +1,24 @@
+(* Minimal spurious rejection caused by the unsubstituted [mod_delta mtb1]
+   in Subtyping.check_modtypes. *)
+Module Type T.
+  Inductive I : Prop := c : I.
+End T.
+
+Module F (X : T) <: T.
+  Include X.
+End F.
+
+Module Type PS (X : T).
+  Include X.
+End PS.
+
+Module H (K : PS) (X : T).
+  Module Res := K X.
+End H.
+
+Module Q. Inductive I : Prop := c : I. End Q.
+
+(* [F] is compared against [PS], a functor-vs-functor subtyping check. *)
+Module R := H F Q.
+(* <in exception printer>: Anomaly "Uncaught exception Not_found." *)
+(* <original exception>: Uncaught exception Modops.ModuleTypingError(_). *)

--- a/test-suite/bugs/bug_22411_2.v
+++ b/test-suite/bugs/bug_22411_2.v
@@ -1,0 +1,48 @@
+(* Subtyping between two functors must be performed in a single name space.
+
+   As [Subtyping.check_modtypes] descends into a functor, [subst1] renames the
+   implementation's bound parameter into the signature's one. The
+   implementation's delta-resolver has to follow, both where it is used
+   directly (the environment given to the conversion checks, and [reso1] in
+   [check_signatures]) and where it is used indirectly, as the resolver carried
+   by [subst2] for [mp2]. Otherwise the canonical names computed on the
+   signature side mention the implementation's parameter while the ones
+   computed on the implementation side mention the signature's, and the two can
+   never be recognised as equal. Inductive types have no delta-rule, so unlike
+   constants they cannot recover by unfolding: the check below used to fail
+   with
+
+     Signature components for field G.I do not match:
+     types given to constructor c differ:
+       expected "Ind(MA.G.I,0)" but found "Ind(MA.G.I,0)"
+
+   (the two inductives print the same because only their canonical parts
+   differ), and printing that message used to raise
+   Anomaly "Uncaught exception Not_found." because it mentions a bound modpath
+   that is not in the environment.
+
+   Here [G] is moreover a *functor* field of the module being sealed, so the
+   binding [subst2] inherits is the one of the enclosing [MA], whose resolver
+   knows nothing about [MA.G]: [mod_global_delta] is [None] on functors, hence
+   a functor field's resolver is never merged into its parent. *)
+
+Module Type T. Parameter n : bool. Inductive I : Prop := c : I. End T.
+Module Q0. Definition n := true. Inductive I : Prop := c : I. End Q0.
+Module Type TQ0. Include Q0. End TQ0.
+
+Module F (X : T) <: T.
+  Module Sub := X.
+  Include X.
+End F.
+
+Module Type PS (X : TQ0).
+  Parameter n : bool.
+  Inductive I : Prop := c : I.
+  Declare Module Sub : TQ0.
+End PS.
+
+Module Type MF. Declare Module G : PS. End MF.
+
+Module MA : MF.
+  Module G := F.
+End MA.


### PR DESCRIPTION
Subtyping.check_modtypes compares an implementation [mtb1] living at [mp1] against a signature [mtb2] living at [mp2], and every comparison it makes happens inside one environment [env]. Write W for the name space of [env]: which kernames it can interpret, and which canonical form it gives to each of them. The code maintains, or rather ought to maintain, three invariants:

  (1) [subst1] maps the names of [mtb1] into W;
  (2) [subst2] maps the names of [mtb2] into W;
  (3) [delta1] is [mod_delta mtb1] expressed in W -- and it is precisely the
      resolver that [subst2] carries for [mp2], the two being the same value.

They hold at the entry point: [check_subtypes] passes [subst1 = empty_subst], since [mtb1] already lives at [mp1], and
[subst2 = map_mp mp2 mp1 (mod_delta sup)], whose resolver is what recomputes canonical names -- the implementation, not the signature, decides which of its own fields are identified. That resolver is [delta1], as [strengthen] is the identity on functors.

Every MoreFunctor step changes W: [env] gains the signature's parameter through [add_module_parameter arg_id2 arg_t2], so W now contains the names under [MPbound arg_id2], canonicalised by [mod_delta arg_t2], and no longer contains [MPbound arg_id1]. Re-establishing the invariants therefore amounts to applying

  nsubst = map_mbid arg_id1 mparg2 (mod_delta arg_t2)

to all three components. Only [subst1] was updated; [mod_delta mtb1] was used raw, both directly -- as the resolver given to [Modops.add_structure] and as [reso1] in [check_signatures] -- and indirectly, as the resolver sitting in the codomain of [subst2].

As a result the canonical names computed on the signature side mentioned the implementation's bound parameter while the ones computed on the implementation side mentioned the signature's, and the two could never be recognised as equal. Constants recover from that by delta-reduction, so the symptom only shows on inductive types, which have no delta-rule.

Invariant (3) is restored with [add_mp mp2 mp1 delta1 subst2] rather than by composing [subst2] with [nsubst]. The two agree when the binding [subst2] provides for [mp2] is the one for [mp2] itself, but not when [mp2] is a submodule of the module the enclosing [subst2] talks about: for a functor field the inherited binding carries no information at all, since [mod_global_delta] is [None] on functors and Safe_typing consequently never merges a functor field's resolver into its parent. Re-adding the binding also mirrors the entry point, [map_mp mp2 mp1 (mod_delta sup)] being exactly [add_mp mp2 mp1 delta1] on the empty substitution.

This is not a soundness issue. The fix normalises canonical names, that is, applies a function to them, and every decision the check takes from those names is an equality test; a function can merge names but never split them, so every equality that held before still holds and the buggy version was strictly the more discriminating one.

Fixes #22411: Incompleteness due to a missing substitution in module subtyping.
