### PR TITLE
Do not let an inclusion add an equivalence for the includer itself.

### DIFF
--- a/dev/doc/critical-bugs.md
+++ b/dev/doc/critical-bugs.md
@@ -551,6 +551,16 @@ and lack of checking of relevance marks on constants in coqchk
 - risk: need to use module subtyping to confuse inductives with different letins,
   and use those letins in a match.
 
+### Including functor application generates garbage delta-resolvers
+
+- component: module inclusion and functors
+- introduced: unclear, only exploitable since #21905
+- impacted released versions: V9.3+rc1
+- fixed in: 9.2.1, 9.3.0
+- found by: Pierre-Marie Pédrot flanked by Claude Opus 5
+- issue: #22409
+- risk: any development relying on inclusion of functor applications
+
 ### Universes
 
 #### issue with two parameters in the same universe level

--- a/kernel/mod_declarations.ml
+++ b/kernel/mod_declarations.ml
@@ -118,6 +118,9 @@ let set_implementation e mb =
 let set_algebraic_type mb alg =
   { mb with mod_type_alg = Some alg }
 
+let set_delta : type a. delta_resolver -> a generic_module_body -> a generic_module_body =
+  fun delta mb -> { mb with mod_delta = delta }
+
 (** Accessors *)
 
 let mod_expr { mod_expr = ModBodyVal v; _ } = v

--- a/kernel/mod_declarations.mli
+++ b/kernel/mod_declarations.mli
@@ -89,6 +89,7 @@ val functorize_module : (Names.MBId.t * module_type_body) list -> module_body ->
 
 val set_implementation : module_implementation -> module_body -> module_body
 val set_algebraic_type : module_type_body -> module_expression -> module_type_body
+val set_delta : Mod_subst.delta_resolver -> 'a generic_module_body -> 'a generic_module_body
 
 (** {6 Substitution} *)
 

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -59,7 +59,6 @@ module Deltamap = struct
 
   let find_mp mp reso = ModPath.Map.find mp reso.mmap
   let find_kn kn reso = KerName.Map.find kn reso.kmap
-  let mem_mp mp reso = ModPath.Map.mem mp reso.mmap
   let fold_kn f reso i = KerName.Map.fold f reso.kmap i
   let fold fmp fkn reso accu =
     ModPath.Map.fold fmp reso.mmap (KerName.Map.fold fkn reso.kmap accu)
@@ -221,11 +220,6 @@ let map_mbid mbid mp resolve =
   add_mbid mbid mp resolve empty_subst
 let map_mp mp1 mp2 resolve = add_mp mp1 mp2 resolve empty_subst
 
-let mp_in_delta mp = Deltamap.mem_mp mp
-
-let mp_of_delta resolve mp =
- try Deltamap.find_mp mp resolve with Not_found -> mp
-
 let find_prefix resolve mp =
   let rec sub_mp = function
     | MPdot(mp,l) as mp_sup ->
@@ -234,6 +228,11 @@ let find_prefix resolve mp =
     | p -> Deltamap.find_mp p resolve
   in
   try sub_mp mp with Not_found -> mp
+
+(* TODO: remove the indirection at some point *)
+let mp_of_delta = find_prefix
+
+let mp_is_alias resolve mp = not (ModPath.equal mp (find_prefix resolve mp))
 
 (** Applying a resolver to a kernel name *)
 

--- a/kernel/mod_subst.mli
+++ b/kernel/mod_subst.mli
@@ -51,6 +51,12 @@ val upcast_delta_resolver : ModPath.t -> delta_resolver -> delta_resolver
 val mp_of_delta : delta_resolver -> ModPath.t -> ModPath.t
 val kn_of_delta : delta_resolver -> KerName.t -> KerName.t
 
+(** [mp_is_alias reso mp] tells whether [reso] makes [mp] equivalent to some
+    other modpath. Note that both this and [mp_of_delta] take prefixes into
+    account: a module is equivalent to another one as soon as one of its
+    ancestors is. *)
+val mp_is_alias : delta_resolver -> ModPath.t -> bool
+
 (** Build a constant whose canonical part is obtained via a resolver *)
 
 val constant_of_delta_kn : delta_resolver -> KerName.t -> Constant.t
@@ -61,10 +67,6 @@ val mind_of_delta_kn : delta_resolver -> KerName.t -> MutInd.t
 
 (** Extract the set of inlined constant in the resolver *)
 val inline_of_delta : int option -> delta_resolver -> (int * KerName.t) list
-
-(** Does a [delta_resolver] contains a [mp]? *)
-
-val mp_in_delta : ModPath.t -> delta_resolver -> bool
 
 (** {6 Substitution} *)
 

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -356,6 +356,53 @@ and strengthen_and_subst_struct struc subst mp_from mp_to alias incl reso =
   in
   List.Smart.fold_left_map strengthen_and_subst_field (empty_delta_resolver mp_to) struc
 
+(** Delta-resolver of the inclusion of an application.
+
+    An inclusion must not add an equivalence for the includer itself: the
+    module it is included into will typically receive further fields, and such
+    an equivalence is applied to every label under the includer, so those fields
+    would silently be identified with unrelated ones of the included module.
+
+    The non-functor case of [strengthen_and_subst_module_body] already avoids
+    it, by building the resolver field by field and dropping [new_resolver]
+    when [include_b] is set. The functor case cannot: [mod_delta] of a functor
+    whose body is one of its arguments, e.g. [Module F (X : T) := X.], has a
+    binding for the functor path itself, and [subst_module] keeps it. We
+    therefore expand that binding into the per-field equivalences it stands for,
+    and drop it. Doing so before the functor is applied also prevents
+    [Mod_subst.subst_mp_delta] from later injecting the whole resolver of the
+    argument under the includer's path. *)
+
+let expand_self_delta mp sign reso =
+  if not (mp_is_alias reso mp) then reso
+  else
+    let rec struct_of_signature = function
+    | NoFunctor struc -> struc
+    | MoreFunctor (_, _, sign) -> struct_of_signature sign
+    in
+    let self = mp_of_delta reso mp in
+    (* [mp] is only equivalent to itself, it stops the prefix rule from reaching
+       the fields the includer will get later. *)
+    let reso0 = add_mp_delta_resolver mp mp reso in
+    let expand accu (l, item) = match item with
+    | SFBconst _ | SFBmind _ | SFBrules _ ->
+      let kn = KerName.make mp l in
+      let kn' = kn_of_delta reso kn in
+      if KerName.equal kn kn' then accu else add_kn_delta_resolver kn kn' accu
+    | SFBmodule _ ->
+      let mp' = MPdot (mp, l) in
+      (* a more precise equivalence takes precedence and is already there *)
+      if mp_is_alias reso0 mp' then accu
+      else
+        let mp'' = MPdot (self, l) in
+        if ModPath.equal mp' mp'' then accu else add_mp_delta_resolver mp' mp'' accu
+    | SFBmodtype _ ->
+      (* as in [strengthen_and_subst_struct], module types are only equivalent
+         to themselves *)
+      add_mp_delta_resolver (MPdot (mp, l)) (MPdot (mp, l)) accu
+    in
+    List.fold_left expand reso0 (struct_of_signature sign)
+
 (** Let P be a module path when we write:
      "Module M:=P." or "Module M. Include P. End M."
     We need to perform two operations to compute the body of M.
@@ -392,7 +439,11 @@ let strengthen_and_subst_module_body mp_from mb mp include_b = match mod_type mb
     strengthen_module_body ~src:mp_from (NoFunctor struc') reso' mb
   | MoreFunctor _ ->
     let subst = map_mp mp_from mp (empty_delta_resolver mp) in
-    Mod_declarations.subst_module subst_dom_codom subst mp_from mb
+    let mb = Mod_declarations.subst_module subst_dom_codom subst mp_from mb in
+    if include_b then
+      Mod_declarations.set_delta
+        (expand_self_delta mp (mod_type mb) (mod_delta mb)) mb
+    else mb
 
 (* [mp_from] is the ambient modpath of [sign] *)
 let subst_modtype_signature_and_resolver mp_from mp_to sign reso =

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -224,7 +224,7 @@ let strengthen_const mp_from l cb resolver =
 let rec strengthen_module mp mb = match mod_type mb with
 | NoFunctor struc ->
   let delta_mb = get_global_delta mb in
-  if mp_in_delta mp delta_mb then mb
+  if mp_is_alias delta_mb mp then mb (* already strengthened *)
   else
     let reso, struc' = strengthen_signature mp struc delta_mb in
     let reso = add_mp_delta_resolver mp mp (add_delta_resolver delta_mb reso) in
@@ -255,7 +255,7 @@ let strengthen mtb mp = match mod_type mtb with
 | NoFunctor struc ->
   let delta_mtb = get_global_delta mtb in
   (* Has mtb already been strengthened ? *)
-  if mp_in_delta mp delta_mtb then mtb
+  if mp_is_alias delta_mtb mp then mtb
   else
     let reso', struc' = strengthen_signature mp struc delta_mtb in
     let reso' = add_delta_resolver delta_mtb (add_mp_delta_resolver mp mp reso') in
@@ -268,7 +268,7 @@ let rec strengthen_and_subst_module mb subst mp_from mp_to =
   match mod_type mb with
   | NoFunctor struc ->
     let delta_mb = get_global_delta mb in
-    let mb_is_an_alias = mp_in_delta mp_from delta_mb in
+    let mb_is_an_alias = mp_is_alias delta_mb mp_from in
     if mb_is_an_alias then
       subst_module subst_dom_codom subst mp_from mb
     else
@@ -375,7 +375,7 @@ and strengthen_and_subst_struct struc subst mp_from mp_to alias incl reso =
 let strengthen_and_subst_module_body mp_from mb mp include_b = match mod_type mb with
   | NoFunctor struc ->
     let delta_mb = get_global_delta mb in
-    let mb_is_an_alias = mp_in_delta mp_from delta_mb in
+    let mb_is_an_alias = mp_is_alias delta_mb mp_from in
     (* if mb.mod_mp is an alias then the strengthening is useless
        (i.e. it is already done)*)
     let mp_alias = mp_of_delta delta_mb mp_from in

--- a/test-suite/modules/include_functor_alias.v
+++ b/test-suite/modules/include_functor_alias.v
@@ -1,0 +1,136 @@
+(* An inclusion must not add a delta-equivalence for the includer itself.
+
+   The body of a functor can be algebraically one of its arguments, in which
+   case its codomain delta-resolver holds an equivalence for the functor path
+   itself. Applying the functor turns it into an equivalence for the path of
+   the module being built, and [find_prefix] then applies it to *every* label
+   under that path -- including fields that are not part of the included
+   signature. Those fields used to be identified with unrelated fields of the
+   included module, which made False provable:
+
+     Module P. Include Id A. Definition extra := false. End P.
+     Definition h1 : A.extra = true  := eq_refl.
+     Definition h2 : P.extra = false := eq_refl.
+     Definition h3 : A.extra = P.extra := eq_refl.   (* accepted! *)
+
+   Each [Fail] below is one way to build such a functor, and each of them used
+   to be accepted. The positive checks guard the converse: the per-field
+   equivalences an inclusion legitimately provides must be preserved. *)
+
+Module Type T. Parameter n : bool. End T.
+Module Type TS. Parameter n : bool. Declare Module Sub : T. End TS.
+Module Type EXTRA. Parameter extra : bool. End EXTRA.
+
+Module A.
+  Definition n := true.
+  Definition extra := true.
+  Inductive I : Prop := c : I.
+  Module Sub. Definition n := true. Definition extra := true. End Sub.
+End A.
+
+(* Functors whose body is algebraically built from their arguments. *)
+Module Id (X : T) := X.
+Module IdS (X : TS) := X.
+Module Proj (X : TS) := X.Sub.
+Module Id2 (X : T) := Id X.
+Module Bin (X : T) (Y : T) := X.
+
+(* The identity functor. *)
+Module C1.
+  Include Id A.
+  Definition extra := false.
+End C1.
+Definition c1_ok : C1.n = A.n := eq_refl.
+Fail Definition c1_ko : A.extra = C1.extra := eq_refl.
+
+(* Same, on an inductive type: no conversion check can ever repair that one. *)
+Module C2.
+  Include Id A.
+  Inductive I : Prop := .
+End C2.
+Fail Definition c2_ko : C2.I := A.c.
+
+(* Through an indirection. *)
+Module C3.
+  Include Id2 A.
+  Definition extra := false.
+End C3.
+Definition c3_ok : C3.n = A.n := eq_refl.
+Fail Definition c3_ko : A.extra = C3.extra := eq_refl.
+
+(* A binary functor projecting its first argument. *)
+Module C4.
+  Include Bin A A.
+  Definition extra := false.
+End C4.
+Definition c4_ok : C4.n = A.n := eq_refl.
+Fail Definition c4_ko : A.extra = C4.extra := eq_refl.
+
+(* A functor projecting a submodule of its argument. *)
+Module C5.
+  Include Proj A.
+  Definition extra := false.
+End C5.
+Definition c5_ok : C5.n = A.Sub.n := eq_refl.
+Fail Definition c5_ko : A.Sub.extra = C5.extra := eq_refl.
+
+(* The [<+] form, the extra fields coming from a module type. *)
+Module C6 := Id A <+ EXTRA.
+Definition c6_ok : C6.n = A.n := eq_refl.
+Fail Definition c6_ko : A.extra = C6.extra := eq_refl.
+
+(* The inclusion happening inside a functor: the bogus equivalence is then
+   created afresh at every instantiation. *)
+Module F7 (X : T).
+  Include Id X.
+  Definition extra := false.
+End F7.
+Module C7 := F7 A.
+Definition c7_ok : C7.n = A.n := eq_refl.
+Fail Definition c7_ko : A.extra = C7.extra := eq_refl.
+
+(* The clashing field declared *before* the inclusion. *)
+Module C8.
+  Definition extra := false.
+  Include Id A.
+End C8.
+Definition c8_ok : C8.n = A.n := eq_refl.
+Fail Definition c8_ko : A.extra = C8.extra := eq_refl.
+
+Module C9.
+  Inductive I : Prop := .
+  Include Id A.
+End C9.
+Fail Definition c9_ko : C9.I := A.c.
+
+(* Including the result of an inclusion. This one was never a wrongdoer --
+   [C10a] is not a functor, so the non-functor case already drops the
+   equivalence -- but the assertion is the same and worth pinning down. *)
+Module C10a. Include Id A. End C10a.
+Module C10.
+  Include C10a.
+  Definition extra := false.
+End C10.
+Definition c10_ok : C10.n = A.n := eq_refl.
+Fail Definition c10_ko : A.extra = C10.extra := eq_refl.
+
+(* The equivalence has to be *removed*, not neutralised by mapping the includer
+   to itself: [mp_in_delta] is also how [strengthen] recognises an already
+   strengthened module, so an equivalence [C12 -> C12] would keep [C12.m] from
+   being strengthened and the ascription below would be rejected. Before the
+   fix this raised Anomaly "Constant A.m does not appear in the environment",
+   [m] not being a field of [A]. *)
+Module C12.
+  Include Id A.
+  Parameter m : bool.
+End C12.
+Module Type S12. Parameter n : bool. Definition m := C12.m. End S12.
+Module Q12 : S12 := C12.
+
+(* Submodule fields of the included signature are legitimately shared, and
+   must stay so: a fix that simply dropped the equivalence would break this. *)
+Module C11.
+  Include IdS A.
+End C11.
+Definition c11_ok1 : C11.n = A.n := eq_refl.
+Definition c11_ok2 : C11.Sub.n = A.Sub.n := eq_refl.


### PR DESCRIPTION
An [Include] must not add a delta-equivalence whose key is the path of the module being built: that module will typically receive further fields, and [Mod_subst.find_prefix] applies such an equivalence to every label under the key, so fields that have nothing to do with the included signature end up identified with fields of the included module.

The non-functor case of [strengthen_and_subst_module_body] already avoids this: it builds the resolver field-wise through [strengthen_and_subst_struct] and drops [new_resolver], the one holding the equivalence for the includer, when [include_b] is set. The functor case ignored the flag. It cannot simply drop the equivalence: [mod_delta] of a functor whose body is algebraically one of its arguments ([Module F (X : T) := X.]) has a required binding for the functor path itself. So we expand it into the per-field equivalences it stands for and drop it.

Expanding before the functor is applied also keeps [Mod_subst.subst_mp_delta] from later injecting the whole resolver of the argument under the includer's path: that injection is keyed on the very binding we have just removed, and it would otherwise reintroduce the problem for labels of the argument that the includer does not have.

The equivalence is dropped the way [strengthen_and_subst_struct] already does it for functor fields and module types, by making [mp] equivalent to itself: that is what stops the prefix rule, and since the previous commit no longer reads the modpath map by mere membership, such a self-equivalence is not mistaken for an alias.

The first commit could be considered a standalone cleanup, but it is needed to write the soundness fix in a way that doesn't make it horrible, i.e. by adding APIs allowing to remove data from δ-resolvers rather than adding it monotonically.

Fixes #22409: Name confusion in δ-resolver inclusion.
