### PR TITLE
Warning for Parameter Inline outside of a module type.

### DIFF
--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -892,6 +892,12 @@ let make_hbody = function
       assert (c == HConstr.self hc);
       snd @@ HConstr.hcons hc)
 
+let warn_inline_in_module =
+  CWarnings.create ~name:"inline-parameter-in-module"
+    ~category:CWarnings.CoreCategories.vernacular
+    (fun kn -> Pp.(str "Ignoring the Inline annotation of " ++
+      Constant.print kn ++ strbrk " outside of a module  type."))
+
 let add_constant_aux senv ?hbody (kn, cb) =
   let l = Constant.label kn in
   (* This is the only place where we hashcons the contents of a constant body *)
@@ -902,8 +908,13 @@ let add_constant_aux senv ?hbody (kn, cb) =
   let senv' = add_field (l,SFBconst cb) (C kn) senv in
   let senv'' = match cb.const_body with
     | Undef (Some lev) ->
-      update_resolver
-        (Mod_subst.add_inline_delta_resolver (Constant.user kn) (lev,None)) senv'
+      (* An inlining declaration only makes sense in a module type *)
+      if is_modtype senv' then
+        update_resolver
+          (Mod_subst.add_inline_delta_resolver (Constant.user kn) (lev,None)) senv'
+      else
+        let () = warn_inline_in_module kn in
+        senv'
     | _ -> senv'
   in
   senv''


### PR DESCRIPTION
Inlining hints only make sense for module types, and even there they belong semantically to a specific functor rather than to the type of its parameter. We only put it there for simplicity of the user-facing syntax. For modules, this data should have been ignored, but was added nonetheless to the module δ-resolver, leading to some broken invariants down the road.

This commit makes the kernel ignore such nonsensical annotations and emit a warning instead.