### PR TITLE
Restrict STM error resilience to interactive documents

### DIFF
--- a/doc/changelog/09-cli-tools/22423-fix-async-proofs-cmd-error-resilience-batch-Fixed.rst
+++ b/doc/changelog/09-cli-tools/22423-fix-async-proofs-cmd-error-resilience-batch-Fixed.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  Batch compilation with :n:`-async-proofs on` now reports command and tactic
+  errors instead of absorbing them, which could cause misleading later errors
+  or incomplete ``.vo`` files
+  (`#22423 <https://github.com/rocq-prover/rocq/pull/22423>`_,
+  fixes `#19189 <https://github.com/rocq-prover/rocq/issues/19189>`_,
+  by Jason Gross).

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1955,11 +1955,14 @@ let known_state ~doc ?(redefine_qed=false) ~cache id =
             (str "Unknown proof block delimiter " ++ str name ++ str ".")
   in
 
+  (* Error resilience is an interactive feature. Queue workers do not call
+     [VCS.init], so they retain the interactive default and remain resilient. *)
+  let error_resilience_allowed () = VCS.is_interactive () in
+
   (* Absorb tactic errors from f () *)
   let resilient_tactic id blockname f =
     if (cur_opt()).async_proofs_tac_error_resilience = FNone ||
-       (async_proofs_is_master (cur_opt()) &&
-        (cur_opt()).async_proofs_mode = APoff)
+       not (error_resilience_allowed ())
     then f ()
     else
       try f ()
@@ -1969,8 +1972,7 @@ let known_state ~doc ?(redefine_qed=false) ~cache id =
   (* Absorb errors from f x *)
   let resilient_command f x =
     if not (cur_opt()).async_proofs_cmd_error_resilience ||
-       (async_proofs_is_master (cur_opt()) &&
-        (cur_opt()).async_proofs_mode = APoff)
+       not (error_resilience_allowed ())
     then f x
     else
       try f x

--- a/test-suite/misc/bug_19189.sh
+++ b/test-suite/misc/bug_19189.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Batch compilation with -async-proofs on must report the original error
+# instead of absorbing it (#19189).
+set -e
+
+TMP=misc/bug_19189.tmp
+rm -rf $TMP
+mkdir -p $TMP
+cp misc/bug_19189/*.v $TMP/
+
+# A failing tactic before Abort must surface.
+if $coqc -async-proofs on $TMP/abort_section.v > $TMP/abort.log 2>&1; then
+  echo "abort_section.v should have failed"; cat $TMP/abort.log; exit 1
+fi
+if ! grep -q "Tactic failure" $TMP/abort.log; then
+  echo "expected the real error (Tactic failure), got:"; cat $TMP/abort.log; exit 1
+fi
+if grep -q "Open proofs remain" $TMP/abort.log; then
+  echo "bogus error reported at End:"; cat $TMP/abort.log; exit 1
+fi
+
+# An ill-typed definition before a delegated proof must fail.
+if $coqc -async-proofs on $TMP/baddef_section.v > $TMP/baddef.log 2>&1; then
+  echo "baddef_section.v should have failed"; cat $TMP/baddef.log; exit 1
+fi
+if ! grep -q "expected to have type" $TMP/baddef.log; then
+  echo "expected the real error (type error on d), got:"; cat $TMP/baddef.log; exit 1
+fi
+
+# Valid control.
+$coqc -async-proofs on $TMP/valid_section.v > $TMP/valid.log 2>&1
+
+rm -rf $TMP

--- a/test-suite/misc/bug_19189/abort_section.v
+++ b/test-suite/misc/bug_19189/abort_section.v
@@ -1,0 +1,5 @@
+Section S.
+Goal True.
+fail.
+Abort.
+End S.

--- a/test-suite/misc/bug_19189/baddef_section.v
+++ b/test-suite/misc/bug_19189/baddef_section.v
@@ -1,0 +1,5 @@
+Section S.
+Definition d : nat := true.
+Lemma a : True.
+Proof using. exact I. Qed.
+End S.

--- a/test-suite/misc/bug_19189/valid_section.v
+++ b/test-suite/misc/bug_19189/valid_section.v
@@ -1,0 +1,7 @@
+Section S.
+Variable x : nat.
+Lemma a : x = x.
+Proof using x. reflexivity. Qed.
+Lemma b : True.
+Proof using. exact I. Qed.
+End S.


### PR DESCRIPTION
Fixes #22422 and the batch-mode manifestations of #19189.

With `-async-proofs on`, STM command/tactic error resilience was enabled during batch compilation. The existing batch-master exception was unreachable because `async_proofs_is_master` implies `APon`, while the exception tested for `APoff`. As a result, batch compilation could mask the original error, report a later misleading error, or even succeed and write a `.vo` that omitted the failed command.

This PR gates `resilient_command` and `resilient_tactic` on `VCS.is_interactive ()`. Interactive behavior is unchanged. Queue workers are also unaffected because they do not call `VCS.init`, so their document type retains its `Interactive` default.

The regression test covers the misleading-error and false-success cases, plus a valid async-proofs control. `make check`, `make world`, and `make -C test-suite misc ide interactive` pass.

The original interactive RocqIDE behavior from #19189 is not fixed here.

*Originally drafted with Claude Fable 5 (Anthropic).*

> *Authorship note: this was researched and written by an AI coding agent
> (OpenAI Codex), working on Jason Gross's behalf; Jason reviews what is
> posted from this account.*
