### PR TITLE
Fix the implementation of substitution composition in the kernel.

### DIFF
--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -649,4 +649,10 @@ let join subst1 subst2 =
     Umap.join prefixed_subst (Umap.add_mp mpk resolve' res)
   in
   let subst = Umap.fold apply_subst subst1 empty_subst in
-  Umap.join subst2 subst
+  let fold mp delta accu = match subst_mp_opt subst1 mp with
+  | None -> Umap.add_mp mp delta accu
+  | Some _ ->
+    (* [mp] was already mapped away by [subst1] *)
+    accu
+  in
+  Umap.fold fold subst2 subst


### PR DESCRIPTION
When computing σ₂ ∘ σ₁, the previous implementation was overwriting bindings from σ₁ with bindings from σ₂ because the join was performed in the wrong direction. Thankfully, this was not exploitable from the kernel as the two only callers of Mod_subst.join were ensuring that the domain of both substitutions was disjoint and thus that it commuted.

This bug was found by good old randomized code review and for once did not imply our LLM overlords.