### PR TITLE
Properly print module typing errors in rocqchk.

### DIFF
--- a/checker/coqchk_main.ml
+++ b/checker/coqchk_main.ml
@@ -360,6 +360,9 @@ let explain_exn = function
   | Mod_checking.BadConstant (cst, why) ->
     hov 0 (Constant.print cst ++ spc() ++ why)
 
+  | Modops.ModuleTypingError _ ->
+    hov 0 (str "Module typing error")
+
   | Assert_failure (s,b,e) ->
       hov 0 (anomaly_string () ++ str "assert failure" ++ spc () ++
                (if s = "" then mt ()


### PR DESCRIPTION
Instead of printing an anomaly, we add a minimalistic handler for Modops.ModuleTypingError.

Fixes #22373: rocqchk prints an anomaly.