### PR TITLE
Print Assumptions: do not report an unreachable opaque body as an axiom

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/22431-print-assumptions-unreachable-opaque-body-Fixed.rst
+++ b/doc/changelog/08-vernac-commands-and-options/22431-print-assumptions-unreachable-opaque-body-Fixed.rst
@@ -1,0 +1,11 @@
+- **Fixed:**
+  :cmd:`Print Assumptions` reported an opaque constant whose body it could
+  not read as an axiom, which is what happens to every proof coming from a
+  library compiled with ``-vos``, and in particular in ``-vok`` builds (see
+  :ref:`compiled-interfaces`). Such a constant is now listed under its own
+  ``Opaque proofs that could not be accessed:`` heading instead of under
+  ``Axioms:``, and the new :warn:`unreachable-opaque-body` warning is
+  emitted, so that the situation can be detected without reading the output
+  (`#22431 <https://github.com/rocq-prover/rocq/pull/22431>`_,
+  fixes `#22430 <https://github.com/rocq-prover/rocq/issues/22430>`_,
+  by remix7531).

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -454,6 +454,18 @@ Requests to the environment
    The message "Closed under the global context" indicates that all the theorems and
    definitions have no dependencies.
 
+   The body of an opaque constant is not available when the library defining
+   it was compiled with ``-vos``, which is in particular the case in ``-vok``
+   builds (see :ref:`compiled-interfaces`). Such a constant is reported under
+   "Opaque proofs that could not be accessed" rather than under "Axioms",
+   since what it assumes is unknown.
+
+   .. warn:: Cannot access the opaque body of @qualid, its assumptions are unknown.
+      :name: unreachable-opaque-body
+
+      The body of :n:`@qualid` could not be read, so the assumptions it
+      relies on are not part of the reported ones.
+
 .. flag:: Printing All Assumptions
 
    Turn this :term:`flag` on to make :cmd:`Print Assumptions` report

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -631,6 +631,7 @@ type context_object =
   | Variable of Id.t (* A section variable or a Let definition *)
   | Axiom of axiom * (GlobRef.t * Constr.rel_context * types) list
   | Opaque of Constant.t     (* An opaque constant. *)
+  | UnreachableOpaque of Constant.t (* An opaque constant whose body could not be accessed. *)
   | Transparent of Constant.t
 
 (* Defines a set of [assumption] *)
@@ -671,6 +672,9 @@ struct
     | Opaque k1 , Opaque k2 -> Constant.UserOrd.compare k1 k2
     | Opaque _ , _ -> -1
     | _ , Opaque _ -> 1
+    | UnreachableOpaque k1 , UnreachableOpaque k2 -> Constant.UserOrd.compare k1 k2
+    | UnreachableOpaque _ , _ -> -1
+    | _ , UnreachableOpaque _ -> 1
     | Transparent k1 , Transparent k2 -> Constant.UserOrd.compare k1 k2
 end
 
@@ -746,14 +750,14 @@ let pr_assumptionset ?(flags=current_combined()) env sigma theory_info s =
           hov 2 (safe_pr_inductive env mind ++ spc () ++ strbrk"relies on indices not mattering.")
     in
     let fold t typ accu =
-      let (v, a, o, tr) = accu in
+      let (v, a, o, u, tr) = accu in
       match t with
       | Variable id ->
         let var = pr_id id ++ spc() ++ str ": " ++ pr_ltype_env ~flags env sigma typ in
-        (var :: v, a, o, tr)
+        (var :: v, a, o, u, tr)
       | Axiom (axiom, []) ->
         let ax = pr_axiom env axiom typ in
-        (v, ax :: a, o, tr)
+        (v, ax :: a, o, u, tr)
       | Axiom (axiom,l) ->
         let ax = pr_axiom env axiom typ ++
           spc() ++
@@ -767,16 +771,19 @@ let pr_assumptionset ?(flags=current_combined()) env sigma theory_info s =
             str "used in " ++ Id.print lab ++
             str " to prove" ++ fnl() ++ safe_pr_ltype_relctx (ctx,ty))
           l in
-        (v, ax :: a, o, tr)
+        (v, ax :: a, o, u, tr)
       | Opaque kn ->
         let opq = safe_pr_constant env kn ++ safe_pr_ltype env sigma typ in
-        (v, a, opq :: o, tr)
+        (v, a, opq :: o, u, tr)
+      | UnreachableOpaque kn ->
+        let unr = hov 2 (safe_pr_constant env kn ++ safe_pr_ltype env sigma typ) in
+        (v, a, o, unr :: u, tr)
       | Transparent kn ->
         let tran = safe_pr_constant env kn ++ safe_pr_ltype env sigma typ in
-        (v, a, o, tran :: tr)
+        (v, a, o, u, tran :: tr)
     in
-    let (vars, axioms, opaque, trans) =
-      ContextObjectMap.fold fold s ([], [], [], [])
+    let (vars, axioms, opaque, unreachable, trans) =
+      ContextObjectMap.fold fold s ([], [], [], [], [])
     in
     let theory =
       if show_theory_impredicative_set then
@@ -805,6 +812,7 @@ let pr_assumptionset ?(flags=current_combined()) env sigma theory_info s =
       opt_list (str "Transparent constants:") trans;
       opt_list (str "Section Variables:") vars;
       opt_list (str "Axioms:") axioms;
+      opt_list (str "Opaque proofs that could not be accessed:") unreachable;
       opt_list (str "Opaque constants:") opaque;
       opt_list (str "Theory:") theory;
     ] in

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -241,6 +241,7 @@ type context_object =
   | Variable of Id.t (* A section variable or a Let definition *)
   | Axiom of axiom * (GlobRef.t * Constr.rel_context * types) list
   | Opaque of Constant.t     (* An opaque constant. *)
+  | UnreachableOpaque of Constant.t (* An opaque constant whose body could not be accessed. *)
   | Transparent of Constant.t
 
 module ContextObjectSet : CSet.ExtS with type elt = context_object

--- a/test-suite/output/bug_16411.out
+++ b/test-suite/output/bug_16411.out
@@ -1,4 +1,8 @@
-Axioms:
+File "./output/bug_16411.v", line 5, characters 0-22:
+Warning:
+Cannot access the opaque body of TestSuite.for_vos.foo, its assumptions are unknown.
+[unreachable-opaque-body,vernacular,default]
+Opaque proofs that could not be accessed:
 foo : nat
 0
      : nat

--- a/test-suite/output/bug_16411.out
+++ b/test-suite/output/bug_16411.out
@@ -1,6 +1,5 @@
 File "./output/bug_16411.v", line 5, characters 0-22:
-Warning:
-Cannot access the opaque body of TestSuite.for_vos.foo, its assumptions are unknown.
+Warning: Cannot access the opaque body of foo, its assumptions are unknown.
 [unreachable-opaque-body,vernacular,default]
 Opaque proofs that could not be accessed:
 foo : nat

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -199,6 +199,15 @@ let fold_with_full_binders g f n acc c =
       Array.fold_left (fun acc (t,b) -> f n' (f n acc t) b) acc fd
   | Array(_u,t,def,ty) -> f n (f n (Array.fold_left (f n) acc t) def) ty
 
+let warn_unreachable_opaque_body =
+  CWarnings.create ~name:"unreachable-opaque-body" ~category:CWarnings.CoreCategories.vernacular
+    (fun kn -> Pp.(str "Cannot access the opaque body of " ++ Constant.print kn
+                   ++ str ", its assumptions are unknown."))
+
+(* Answers [None] both for a constant which has no body and for an opaque
+   constant whose body could not be read, for instance a delayed proof
+   missing in vok mode. The two are told apart by [Declareops.is_opaque] in
+   [assumptions] below. *)
 let get_constant_body access kn =
   let cb = lookup_constant kn in
   match cb.const_body with
@@ -207,7 +216,7 @@ let get_constant_body access kn =
   | OpaqueDef o ->
     match Global.force_proof access o with
     | c, _ -> Some c
-    | exception e when CErrors.noncritical e -> None (* missing delayed body, e.g. in vok mode *)
+    | exception e when CErrors.noncritical e -> warn_unreachable_opaque_body kn; None
 
 let rec traverse access (current:GlobRef.t) ctx accu t =
   let open GlobRef in
@@ -409,8 +418,13 @@ let assumptions ?(add_opaque=false) ?(add_transparent=false) access st grs =
       in
     if not (Option.has_some contents) then
       let t = type_of_constant cb in
-      let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
-      ContextObjectMap.add (Axiom (Constant kn,l)) t accu
+      (* An opaque constant reaches this point only when its body could not
+         be read. It is not an axiom, we just do not know what it assumes. *)
+      if Declareops.is_opaque cb then
+        ContextObjectMap.add (UnreachableOpaque kn) t accu
+      else
+        let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
+        ContextObjectMap.add (Axiom (Constant kn,l)) t accu
     else if add_opaque && (Declareops.is_opaque cb || not (Structures.PrimitiveProjections.is_transparent_constant st kn)) then
       let t = type_of_constant cb in
       ContextObjectMap.add (Opaque kn) t accu

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -201,8 +201,9 @@ let fold_with_full_binders g f n acc c =
 
 let warn_unreachable_opaque_body =
   CWarnings.create ~name:"unreachable-opaque-body" ~category:CWarnings.CoreCategories.vernacular
-    (fun kn -> Pp.(str "Cannot access the opaque body of " ++ Constant.print kn
-                   ++ str ", its assumptions are unknown."))
+    Pp.(fun kn -> str "Cannot access the opaque body of "
+                  ++ Nametab.pr_global_env Id.Set.empty (GlobRef.ConstRef kn)
+                  ++ str ", its assumptions are unknown.")
 
 (* Answers [None] both for a constant which has no body and for an opaque
    constant whose body could not be read, for instance a delayed proof


### PR DESCRIPTION
Print Assumptions forces the body of every opaque constant a proof depends on. When forcing fails the exception is swallowed and the constant is listed under Axioms, as if it had no body at all. This happens throughout a vok build and in any process that was handed a state it did not build. The same body makes Print raise an anomaly, so one command fails loudly while the other gives a confident wrong answer, and nothing in the output says that something went wrong.

This commit tells the two cases apart. A constant with no body is still an axiom. An opaque constant whose body could not be read becomes a new context object, UnreachableOpaque, listed under its own heading, and it emits the new warning unreachable-opaque-body so that a tool can detect the situation without reading the printed output.

The conservative reading does not change. Such a proof is still not closed under the global context and its hidden assumptions are still not reported, only the word axiom is left to the things which really are axioms. The expected output of test-suite/output/bug_16411 changes, and that is the point. It pinned the rough fix of PR #16434, which treats missing proofs as regular axioms, and it now expects foo under the new heading, which is what is actually known about it.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes https://github.com/rocq-prover/rocq/issues/22430


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.
<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->

<!-- If this breaks external libraries or plugins in CI: -->

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
