### PR TITLE
Speed up Search with a pattern for objects with very large types

### DIFF
--- a/pretyping/constr_matching.ml
+++ b/pretyping/constr_matching.ml
@@ -648,3 +648,133 @@ let is_matching_appsubterm ?(closed=true) env sigma pat c =
   let pat = (Id.Set.empty,pat) in
   let results = sub_match ~closed env sigma pat c in
   not (IStream.is_empty results)
+
+let cache_size = 1 lsl 18
+
+type subterm_cache_entry = {
+  term: Evd.econstr;
+  result: bool;
+}
+type subterm_cache = subterm_cache_entry option array ref
+
+let make_subterm_cache () = ref (Array.make cache_size None)
+
+(* A bounded hash of the top of the term.  Any function of a term agrees with
+   [==]; what this one has to be is O(1), where [Constr.hash] walks the whole
+   term.  Every name hash it uses is a memoized field. *)
+let rec hash_top n sigma c =
+  let open Hashset.Combine in
+  let open EConstr in
+  let sub c = if n <= 1 then 0 else hash_top (n - 1) sigma c in
+  match kind sigma c with
+  | Const (kn, _) -> combinesmall 1 (Constant.UserOrd.hash kn)
+  | Ind ((mi, i), _) -> combinesmall 2 (combine (MutInd.UserOrd.hash mi) i)
+  | Construct (((mi, i), j), _) ->
+    combinesmall 3 (combine3 (MutInd.UserOrd.hash mi) i j)
+  | Var id -> combinesmall 4 (Id.hash id)
+  | Rel i -> combinesmall 5 i
+  | App (f, args) ->
+    let k = Array.length args in
+    combinesmall 6
+      (combine3 (sub f) k (if Int.equal k 0 then 0 else sub args.(k - 1)))
+  | Lambda (_, t, b) -> combinesmall 7 (combine (sub t) (sub b))
+  | Prod (_, t, b) -> combinesmall 8 (combine (sub t) (sub b))
+  | LetIn (_, b, t, c) -> combinesmall 9 (combine3 (sub b) (sub t) (sub c))
+  | Proj (p, _, c) ->
+    combinesmall 10 (combine (Projection.CanOrd.hash p) (sub c))
+  | Case (ci, _, _, _, _, c, br) ->
+    combinesmall 11 (combine3 (Ind.UserOrd.hash ci.Constr.ci_ind)
+                       (Array.length br) (sub c))
+  | Cast (c, _, _) -> combinesmall 12 (sub c)
+  | Fix (_, (_, tl, _)) -> combinesmall 13 (Array.length tl)
+  | CoFix (_, (_, tl, _)) -> combinesmall 14 (Array.length tl)
+  | Array (_, t, _, _) -> combinesmall 15 (Array.length t)
+  | Int i -> combinesmall 16 (Uint63.hash i)
+  | Float _ -> 17
+  | String _ -> 18
+  | Sort _ -> 19
+  | Meta i -> combinesmall 20 i
+  | Evar _ -> 21
+
+let hash_top sigma c = hash_top 3 sigma c
+
+let sub_match_cached cache env sigma pat c =
+  let open EConstr in
+  let rec aux env c =
+  let hash = hash_top sigma c land (cache_size - 1) in
+  let keys = !cache in
+  let (cache_hit, cached_result) = (match Array.unsafe_get keys hash with
+  | Some {term; result} -> (term == c, result)
+  | None -> (false, false)) in
+  if cache_hit then cached_result
+  else begin
+    let here = (try
+      let _ = matches_core_closed env sigma pat c in true
+    with PatternMatchingFailure -> false)
+    in
+    let next () = match EConstr.kind sigma c with
+    | Cast (c1,k,c2) -> try_aux [env, c1]
+    | Lambda (x,c1,c2) ->
+        let env' = EConstr.push_rel (LocalAssum (x,c1)) env in
+        try_aux [(env, c1); (env', c2)]
+    | Prod (x,c1,c2) ->
+        let env' = EConstr.push_rel (LocalAssum (x,c1)) env in
+        try_aux [(env, c1); (env', c2)]
+    | LetIn (x,c1,t,c2) ->
+        let env' = EConstr.push_rel (LocalDef (x,c1,t)) env in
+        try_aux [(env, c1); (env', c2)]
+    | App (c1,lc) ->
+      let lc1 = Array.sub lc 0 (Array.length lc - 1) in
+      let app = mkApp (c1,lc1) in
+      try_aux [(env, app); (env, Array.last lc)]
+    | Case (ci,u,pms,hd0,iv,c1,lc0) ->
+        let (mib, mip) = Inductive.lookup_mind_specif env ci.ci_ind in
+        let (_, (hd,hdr), _, _, br) = expand_case env sigma (ci, u, pms, hd0, iv, c1, lc0) in
+        let hd =
+          let (ctx, hd) = decompose_lambda_decls sigma hd in
+          (push_rel_context ctx env, hd)
+        in
+        let map i br =
+          let decls = mip.Declarations.mind_consnrealdecls.(i) in
+          let (ctx, c) = decompose_lambda_n_decls sigma decls br in
+          (push_rel_context ctx env, c)
+        in
+        let lc = Array.to_list (Array.mapi map br) in
+        let sub = (env, c1) :: Array.fold_right (fun c accu -> (env, c) :: accu) pms (hd :: lc) in
+        try_aux sub
+    | Fix (indx,(names,types,bodies as recdefs)) ->
+      let env' = push_rec_types recdefs env in
+      let sub = subargs env types @ subargs env' bodies in
+      try_aux sub
+    | CoFix (i,(names,types,bodies as recdefs)) ->
+      let env' = push_rec_types recdefs env in
+      let sub = subargs env types @ subargs env' bodies in
+      try_aux sub
+    | Proj (p,_,c') ->
+      begin match Retyping.expand_projection env sigma p c' [] with
+      | term -> aux env term
+      | exception Retyping.RetypeError _ -> false
+      end
+    | Array(u, t, def, ty) ->
+      let sub = (env,def) :: (env,ty) :: subargs env t in
+      try_aux sub
+    | Construct _|Ind _|Evar _|Const _|Rel _|Meta _|Var _|Sort _|Int _|Float _|String _ -> false
+    in
+    let result = here || next() in
+    Array.unsafe_set keys hash (Some {term = c; result}); (* add result to the cache *)
+    result
+  end
+
+  (* Tries [sub_match] for all terms in the list *)
+  and try_aux lc =
+    let rec try_sub_match_rec lc =
+      match lc with
+      | [] -> false
+      | (env, c) :: tl -> aux env c || try_sub_match_rec tl
+    in
+    try_sub_match_rec lc in
+  aux env c
+
+let is_matching_appsubterm_cached cache env sigma pat c =
+  let pat = (Id.Set.empty,pat) in
+  sub_match_cached cache env sigma pat c

--- a/pretyping/constr_matching.mli
+++ b/pretyping/constr_matching.mli
@@ -79,3 +79,15 @@ val match_subterm : env -> Evd.evar_map ->
 (** [is_matching_appsubterm pat c] tells if a subterm of [c] matches
    against [pat] taking partial subterms into consideration *)
 val is_matching_appsubterm : ?closed:bool -> env -> Evd.evar_map -> constr_pattern -> constr -> bool
+
+type subterm_cache_entry = {
+  term: Evd.econstr;
+  result: bool;
+}
+type subterm_cache = subterm_cache_entry option array ref
+
+val make_subterm_cache : unit -> subterm_cache
+
+(** [is_matching_appsubterm_cached cache pat c] tells if a subterm of [c] matches
+   against [pat] taking partial subterms into consideration *)
+val is_matching_appsubterm_cached : subterm_cache  -> env -> Evd.evar_map -> constr_pattern -> constr -> bool

--- a/vernac/comSearch.ml
+++ b/vernac/comSearch.ml
@@ -88,7 +88,7 @@ let interp_search_item env sigma =
              untyped pattern as a fallback (i.e w/o no insertion of
              coercions, no compilation of pattern-matching) *)
           snd (Constrintern.interp_constr_pattern env sigma ~as_type:head pat) in
-      GlobSearchSubPattern (where,head,pat)
+      GlobSearchSubPattern (where,head,pat,Constr_matching.make_subterm_cache())
   | SearchString ((Anywhere,false),s,None)
       when Id.is_valid_ident_part s && String.equal (String.drop_simple_quotes s) s ->
       GlobSearchString s
@@ -97,7 +97,7 @@ let interp_search_item env sigma =
       let ref =
         Notation.interp_notation_as_global_reference
           ~head:false (fun _ -> true) s sc in
-      GlobSearchSubPattern (where,head,Pattern.PRef ref)
+      GlobSearchSubPattern (where,head,Pattern.PRef ref,Constr_matching.make_subterm_cache())
   | SearchKind (d,k) ->
      match kind_searcher env k with
      | Inl k -> GlobSearchKind (d,k)

--- a/vernac/comSearch.ml
+++ b/vernac/comSearch.ml
@@ -88,20 +88,20 @@ let interp_search_item env sigma =
              untyped pattern as a fallback (i.e w/o no insertion of
              coercions, no compilation of pattern-matching) *)
           snd (Constrintern.interp_constr_pattern env sigma ~as_type:head pat) in
-      GlobSearchSubPattern (where,head,pat,Constr_matching.make_subterm_cache())
+      make_search_item_sub_pattern where head pat
   | SearchString ((Anywhere,false),s,None)
       when Id.is_valid_ident_part s && String.equal (String.drop_simple_quotes s) s ->
-      GlobSearchString s
+      make_search_item_string s
   | SearchString ((where,head),s,sc) ->
       let sc = Option.map snd sc in
       let ref =
         Notation.interp_notation_as_global_reference
           ~head:false (fun _ -> true) s sc in
-      GlobSearchSubPattern (where,head,Pattern.PRef ref,Constr_matching.make_subterm_cache())
+      make_search_item_sub_pattern where head (Pattern.PRef ref)
   | SearchKind (d,k) ->
      match kind_searcher env k with
-     | Inl k -> GlobSearchKind (d,k)
-     | Inr f -> GlobSearchFilter f
+     | Inl k -> make_search_item_kind (d,k)
+     | Inr f -> make_search_item_filter f
 
 let rec interp_search_request env sigma = function
   | b, SearchLiteral i -> b, GlobSearchLiteral (interp_search_item env sigma i)

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -33,7 +33,7 @@ editors (like emacs), to generate a list of completion candidates
 without having to parse through the types of all symbols. *)
 
 type glob_search_item =
-  | GlobSearchSubPattern of glob_search_where * bool * constr_pattern
+  | GlobSearchSubPattern of glob_search_where * bool * constr_pattern * Constr_matching.subterm_cache
   | GlobSearchString of string
   | GlobSearchKind of (Vernacexpr.discharge * Decls.logical_kind)
   | GlobSearchFilter of (GlobRef.t -> bool)
@@ -302,7 +302,7 @@ let string_contains_upto ?limit ~pattern s =
      d <= limit
 
 let search_filter : _ -> filter_function = fun query gr kind env sigma typ -> match query with
-| GlobSearchSubPattern (where,head,pat) ->
+| GlobSearchSubPattern (where,head,pat,subterm_cache) ->
   let open Context.Rel.Declaration in
   let rec collect env hyps typ =
     match Constr.kind typ with
@@ -316,7 +316,7 @@ let search_filter : _ -> filter_function = fun query gr kind env sigma typ -> ma
   List.exists (fun (env,typ) ->
       let f =
         if head then Constr_matching.is_matching_head
-        else Constr_matching.is_matching_appsubterm ~closed:false in
+        else Constr_matching.is_matching_appsubterm_cached subterm_cache in
       f env sigma pat (EConstr.of_constr typ)) typl
 | GlobSearchString s -> string_contains_upto ~pattern:s (name_of_reference gr)
 | GlobSearchKind k -> (match kind with None -> false | Some k' -> k = k')

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -33,10 +33,21 @@ editors (like emacs), to generate a list of completion candidates
 without having to parse through the types of all symbols. *)
 
 type glob_search_item =
-  | GlobSearchSubPattern of glob_search_where * bool * constr_pattern * Constr_matching.subterm_cache
+  | GlobSearchSubPattern of glob_search_where * bool * constr_pattern * Constr_matching.subterm_cache option
   | GlobSearchString of string
   | GlobSearchKind of (Vernacexpr.discharge * Decls.logical_kind)
   | GlobSearchFilter of (GlobRef.t -> bool)
+
+let make_search_item_sub_pattern where head pat =
+  (* only make a cache if we need one: *)
+  let cache = if head then None else Some (Constr_matching.make_subterm_cache()) in
+  GlobSearchSubPattern (where,head,pat,cache)
+
+let make_search_item_string s = GlobSearchString s
+
+let make_search_item_kind kind = GlobSearchKind kind
+
+let make_search_item_filter filter = GlobSearchFilter filter
 
 type glob_search_request =
   | GlobSearchLiteral of glob_search_item
@@ -316,7 +327,7 @@ let search_filter : _ -> filter_function = fun query gr kind env sigma typ -> ma
   List.exists (fun (env,typ) ->
       let f =
         if head then Constr_matching.is_matching_head
-        else Constr_matching.is_matching_appsubterm_cached subterm_cache in
+        else Constr_matching.is_matching_appsubterm_cached (Option.get subterm_cache) in
       f env sigma pat (EConstr.of_constr typ)) typl
 | GlobSearchString s -> string_contains_upto ~pattern:s (name_of_reference gr)
 | GlobSearchKind k -> (match kind with None -> false | Some k' -> k = k')

--- a/vernac/search.mli
+++ b/vernac/search.mli
@@ -17,7 +17,7 @@ open Vernacexpr
 (** {6 Search facilities. } *)
 
 type glob_search_item =
-  | GlobSearchSubPattern of glob_search_where * bool * constr_pattern
+  | GlobSearchSubPattern of glob_search_where * bool * constr_pattern * Constr_matching.subterm_cache
   | GlobSearchString of string
   | GlobSearchKind of (Vernacexpr.discharge * Decls.logical_kind)
   | GlobSearchFilter of (GlobRef.t -> bool)

--- a/vernac/search.mli
+++ b/vernac/search.mli
@@ -16,11 +16,12 @@ open Vernacexpr
 
 (** {6 Search facilities. } *)
 
-type glob_search_item =
-  | GlobSearchSubPattern of glob_search_where * bool * constr_pattern * Constr_matching.subterm_cache
-  | GlobSearchString of string
-  | GlobSearchKind of (Vernacexpr.discharge * Decls.logical_kind)
-  | GlobSearchFilter of (GlobRef.t -> bool)
+type glob_search_item
+
+val make_search_item_sub_pattern : glob_search_where -> bool -> constr_pattern -> glob_search_item
+val make_search_item_string : string -> glob_search_item
+val make_search_item_kind : (Vernacexpr.discharge * Decls.logical_kind) -> glob_search_item
+val make_search_item_filter : (GlobRef.t -> bool) -> glob_search_item
 
 type glob_search_request =
   | GlobSearchLiteral of glob_search_item


### PR DESCRIPTION
This adapts the caching scheme from PR #22425 to skip walking repeated subterms in large types like those in UniMath, especially ones with many nested projections. Before this change a Search with one nontrivial pattern in UniMath took ~225 seconds on my machine, and after ~25.

The cache is created per pattern, meaning that if multiple objects' types share subterms each needs to be walked only once in the whole search.

I experimented with different values for the cache size and hashing depth but found that the same ones zeldovich used gave the best results.

The top 5 slowest objects in UniMath to check against a pattern before:
```
                                             Name  Time (s)
                         inserter_slice_cell_cell  79.160
                inserter_ump_1_slice_mor_inv2cell  41.031
               inserter_ump_1_slice_pr1_cell_cell  38.737
            is_pb_to_cartesian_lift_2cell_cell_eq   2.750
                              comp_disp_map_fiber   2.638
```
and after:
```
                                             Name  Time (s)
                         inserter_slice_cell_cell  2.799
                inserter_ump_1_slice_mor_inv2cell  2.171
                              comp_disp_map_fiber  1.847
                                   comp_cod_fiber  1.317
            is_pb_to_cartesian_lift_2cell_cell_eq  1.120
```
These objects have huge 'effective' types as they have many nested projections and for each of those the implicit type arguments are expanded by the call to `Retyping.expand_projections` in `sub_match`, causing the types of the elements of the inner tuples to be multiplied many times. For example the type of `inserter_ump_1_slice_mor_inv2cell` seems small at its definition
```
Definition inserter_ump_1_slice_mor_inv2cell
  : invertible_2cell
      (pr21 q)
      (inserter_ump_1_slice_mor_to_eq · (p' · p · pr2 h₁)).
```
but it looks like this when Checked outside its section:
```
inserter_ump_1_slice_mor_inv2cell
     : ∏ (ins_B : has_inserters ?B) (eq_B : has_equifiers ?B) 
       (b : ?B) (h₁ h₂ : slice_bicat b) (α β : slice_bicat b ⟦ h₁, h₂ ⟧)
       (q : inserter_cone α β),
       invertible_2cell (pr21 q)
         (inserter_ump_1_slice_mor_to_eq ins_B eq_B α β q
          · (pr12 (eq_B (pr1 (ins_B (pr1 h₁) (pr1 h₂) (pr1 α) (pr1 β))) b
                     (pr12 (ins_B (pr1 h₁) (pr1 h₂) (pr1 α) (pr1 β)) · pr2 h₁)
                     (pr12 (ins_B (pr1 h₁) (pr1 h₂) (pr1 α) (pr1 β)) · pr1 β
                      · pr2 h₂)
                     (vcomp2
                        (vcomp2
                           (lwhisker
                              (pr12 (ins_B (pr1 h₁) (pr1 h₂) (pr1 α) (pr1 β)))
                              (pr12 α))
                           (lassociator
                              (pr12 (ins_B (pr1 h₁) (pr1 h₂) (pr1 α) (pr1 β)))
                              (pr1 α) (pr2 h₂)))
                        (rwhisker (pr2 h₂)
                           (pr122 (ins_B (pr1 h₁) (pr1 h₂) (pr1 α) (pr1 β)))))
                     (vcomp2
                        (lwhisker
                           (pr12 (ins_B (pr1 h₁) (pr1 h₂) (pr1 α) (pr1 β)))
                           (pr12 β))
                        (lassociator
                           (pr12 (ins_B (pr1 h₁) (pr1 h₂) (pr1 α) (pr1 β)))
                           (pr1 β) (pr2 h₂))))
             · pr12 (ins_B (pr1 h₁) (pr1 h₂) (pr1 α) (pr1 β)) · 
             pr2 h₁))
where
?B : [ |- bicat]
```
and after enabling the following printing flags it grows to over 34000 lines with lots of large repeated subterms.
```
Set Printing Primitive Projection Parameters.
Set Printing Implicit.
Set Printing Coercions.
Set Printing Projections.
```

This PR is a draft because I think the following things should be improved:
- I duplicated zeldovich's `hash_top` function to make it work for `EConstr` instead of regular `constr` (and also because his PR isn't merged yet), is there a way we could make one copy of it work for both?
- I duplicated `sub_match` and made it return a bool indicating whether any match is found instead of returning a stream of matches so that the result can be easily cached.
- ~~Currently the cache is being created for every pattern, while it is only necessary for patterns configured to match `Anywhere`, I left this and other polish until after I get confirmation that this is a worthwhile direction.~~

