### PR TITLE
Treat opaque Var nodes as structured constants in the VM.

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -372,6 +372,7 @@ let v_vm_caml_prim = v_enum "vm_caml_prim" 12
 
 let v_non_subst_reloc = v_sum "vm_non_subst_reloc" 0 [|
   [|v_sort|];
+  [|v_id|];
   [|v_fail "Evar"|];
   [|v_int|];
   [|v_instance|];

--- a/kernel/vmbytegen.ml
+++ b/kernel/vmbytegen.ml
@@ -579,7 +579,11 @@ let rec compile_lam env cenv lam sz cont =
   | Lproj (p,arg) ->
      compile_lam env cenv arg sz (Kproj (Projection.Repr.arg p) :: cont)
 
-  | Lvar id -> pos_named id cenv :: cont
+  | Lvar id ->
+    begin match Environ.named_body id env.env with
+    | None -> compile_structured_constant cenv (Const_var id) sz cont
+    | Some _ -> pos_named id cenv :: cont
+    end
 
   | Levar (evk, args) ->
       if Array.is_empty args then

--- a/kernel/vmemitcodes.ml
+++ b/kernel/vmemitcodes.ml
@@ -120,6 +120,7 @@ struct
     memory footprint, this data is kept on the VM segment. *)
 type t =
 | SReloc_Const_sort of Sorts.t
+| SReloc_Const_var of Id.t
 | SReloc_Const_evar of Evar.t
 | SReloc_Const_b0 of tag
 | SReloc_Const_univ_instance of UVars.Instance.t
@@ -132,6 +133,7 @@ type t =
 
 let to_reloc = function
 | SReloc_Const_sort s -> Reloc_const (Const_sort s)
+| SReloc_Const_var id -> Reloc_const (Const_var id)
 | SReloc_Const_evar e -> Reloc_const (Const_evar e)
 | SReloc_Const_b0 tag -> Reloc_const (Const_b0 tag)
 | SReloc_Const_univ_instance u -> Reloc_const (Const_univ_instance u)
@@ -673,6 +675,7 @@ let to_memory fv code =
     | Reloc_annot annot -> push (SReloc_annot annot)
     | Reloc_caml_prim prm -> push (SReloc_caml_prim prm)
     | Reloc_const (Const_sort s) -> push (SReloc_Const_sort s)
+    | Reloc_const (Const_var id) -> push (SReloc_Const_var id)
     | Reloc_const (Const_evar e) -> push (SReloc_Const_evar e)
     | Reloc_const (Const_b0 tag) -> push (SReloc_Const_b0 tag)
     | Reloc_const (Const_univ_instance u) -> push (SReloc_Const_univ_instance u)

--- a/kernel/vmsymtable.ml
+++ b/kernel/vmsymtable.ml
@@ -304,7 +304,7 @@ and slot_for_fv env sigma fv envcache table =
       begin match nv with
       | None ->
         let v = match env |> lookup_named id |> NamedDecl.get_value with
-          | None -> val_of_named id
+          | None -> assert false (* handled specifically in Vmbytegen *)
           | Some c -> val_of_constr env sigma c envcache table
         in
         cache_named envcache id v; v

--- a/kernel/vmvalues.ml
+++ b/kernel/vmvalues.ml
@@ -50,6 +50,7 @@ shared without reallocating a more structured representation. *)
 type structured_constant =
   | Const_sort of Sorts.t
   | Const_ind of inductive
+  | Const_var of Id.t
   | Const_evar of Evar.t
   | Const_b0 of tag
   | Const_univ_instance of UVars.Instance.t
@@ -102,6 +103,8 @@ let eq_structured_constant c1 c2 = match c1, c2 with
 | Const_sort _, _ -> false
 | Const_ind i1, Const_ind i2 -> Ind.UserOrd.equal i1 i2
 | Const_ind _, _ -> false
+| Const_var id1, Const_var id2 -> Id.equal id1 id2
+| Const_var _, _ -> false
 | Const_evar e1, Const_evar e2 -> Evar.equal e1 e2
 | Const_evar _, _ -> false
 | Const_b0 t1, Const_b0 t2 -> Int.equal t1 t2
@@ -122,13 +125,14 @@ let hash_structured_constant c =
   match c with
   | Const_sort s -> combinesmall 1 (Sorts.hash s)
   | Const_ind i -> combinesmall 2 (Ind.UserOrd.hash i)
-  | Const_evar e -> combinesmall 3 (Evar.hash e)
-  | Const_b0 t -> combinesmall 4 (Int.hash t)
-  | Const_univ_instance u -> combinesmall 5 (UVars.Instance.hash u)
-  | Const_val v -> combinesmall 6 (hash_structured_values v)
-  | Const_uint i -> combinesmall 7 (Uint63.hash i)
-  | Const_float f -> combinesmall 8 (Float64.hash f)
-  | Const_string s -> combinesmall 9 (Pstring.hash s)
+  | Const_var id -> combinesmall 3 (Id.hash id)
+  | Const_evar e -> combinesmall 4 (Evar.hash e)
+  | Const_b0 t -> combinesmall 5 (Int.hash t)
+  | Const_univ_instance u -> combinesmall 6 (UVars.Instance.hash u)
+  | Const_val v -> combinesmall 7 (hash_structured_values v)
+  | Const_uint i -> combinesmall 8 (Uint63.hash i)
+  | Const_float f -> combinesmall 9 (Float64.hash f)
+  | Const_string s -> combinesmall 10 (Pstring.hash s)
 
 let eq_annot_switch asw1 asw2 =
   let eq_rlc (i1, j1) (i2, j2) = Int.equal i1 i2 && Int.equal j1 j2 in
@@ -145,6 +149,7 @@ let hash_annot_switch asw =
 let pp_struct_const = function
   | Const_sort s -> Sorts.raw_pr s
   | Const_ind (mind, i) -> Pp.(MutInd.print mind ++ str"#" ++ int i)
+  | Const_var id -> Pp.(str "Var(" ++ Id.print id ++ str ")")
   | Const_evar e -> Pp.( str "Evar(" ++ int (Evar.repr e) ++ str ")")
   | Const_b0 i -> Pp.int i
   | Const_univ_instance u -> UVars.Instance.pr Sorts.raw_printer u
@@ -398,6 +403,7 @@ let obj_of_str_const str =
   match str with
   | Const_sort s -> obj_of_atom (Asort s)
   | Const_ind ind -> obj_of_atom (Aind ind)
+  | Const_var id -> obj_of_atom (Aid (VarKey id))
   | Const_evar e -> obj_of_atom (Aid (EvarKey e))
   | Const_b0 tag -> Obj.repr tag
   | Const_univ_instance u -> Obj.repr u

--- a/kernel/vmvalues.mli
+++ b/kernel/vmvalues.mli
@@ -37,6 +37,7 @@ val cofix_evaluated_tag : tag
 type structured_constant =
   | Const_sort of Sorts.t
   | Const_ind of inductive
+  | Const_var of Id.t
   | Const_evar of Evar.t
   | Const_b0 of tag
   | Const_univ_instance of UVars.Instance.t


### PR DESCRIPTION
This allows saving a lot of useless closure allocations for terms mentioning section and context variables. This is sound because contrarily to opaque constants which can be replaced by concrete terms by functor application, we never substitute section variables in the VM.