### PR TITLE
Correctly implement graph traversal in AcyclicGraph.merge_with_root.

### DIFF
--- a/lib/acyclicGraph.ml
+++ b/lib/acyclicGraph.ml
@@ -587,7 +587,10 @@ module Make (Point:Point) = struct
         if strict then raise CycleDetected (* Set < u *)
         else true, accu
       else if topo_compare ucan vcan < 0 then false, accu
-      else if Status.mem status vcan then Status.find status vcan, accu
+      else if Status.mem status vcan then
+        let found = Status.find status vcan in
+        let () = if found && strict then raise CycleDetected in
+        found, accu
       else
         let fold w nstrict (found, accu) =
           let wcan = repr g w in
@@ -626,7 +629,10 @@ module Make (Point:Point) = struct
         if strict then raise CycleDetected (* Set < u *)
         else true
       else if topo_compare ucan vcan < 0 then false
-      else if Status.mem status vcan then Status.find status vcan
+      else if Status.mem status vcan then
+        let found = Status.find status vcan in
+        let () = if found && strict then raise CycleDetected in
+        found
       else
         let fold w nstrict found =
           let wcan = repr g w in

--- a/test-suite/bugs/bug_22438.v
+++ b/test-suite/bugs/bug_22438.v
@@ -1,0 +1,25 @@
+Set Universe Polymorphism.
+
+Section Foo.
+
+Universes a z b u.
+Constraint a < b.
+Constraint z <= b.
+Constraint b <= u.
+
+Print Universes Subgraph (a z b u).
+(* Set <= a, Set <= z, Set < b, Set <= u, a < b, z <= b, b <= u *)
+
+Fail Constraint u <= Set.
+(* The above constraint does not fail despite leading to an inconsistent graph. *)
+
+Print Universes Subgraph (a z b u).
+(* Set <= a, z = a, b = a, u = a *)
+
+Definition foo := tt.
+
+End Foo.
+
+About foo.
+(* Any attempt at using the constant results in a universe error. *)
+(* Universe inconsistency. Cannot enforce Var(3) <= Set. *)


### PR DESCRIPTION
When finding a node known to reach the target level, we do not forget to check whether we came from a path strictly above Set.

As argued by the LLM report, this is unlikely to lead to a proof of False, but this is still a fairly damn serious issue.

Fixes #22438: contradictory universe constraints pass acyclicity check.
