### PR TITLE
Skip string literals when rocq dep looks for the end of a sentence

### DIFF
--- a/doc/changelog/09-cli-tools/22443-coqdep-string-literals-Fixed.rst
+++ b/doc/changelog/09-cli-tools/22443-coqdep-string-literals-Fixed.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  ``rocq dep`` no longer treats a ``. `` inside a string literal as the end of
+  a sentence, so a ``Require`` written inside a string is no longer recorded as
+  a dependency and no longer causes a spurious syntax error
+  (`#22443 <https://github.com/rocq-prover/rocq/pull/22443>`_,
+  fixes `#22442 <https://github.com/rocq-prover/rocq/issues/22442>`_,
+  by Jason Gross).

--- a/test-suite/misc/coqdep-string-literals.sh
+++ b/test-suite/misc/coqdep-string-literals.sh
@@ -8,7 +8,9 @@ set -e
 cd misc/coqdep-string-literals
 
 code=0
-$coqdep -worker @ROCQWORKER@ -R . 'Test' ./*.v > stdout 2> stderr || code=$?
+# List the files explicitly: the order of a glob depends on the locale's
+# collation, and Lib.v sorts differently from the lowercase names on macOS.
+$coqdep -worker @ROCQWORKER@ -R . 'Test' Lib.v dot_in_notation.v dot_in_string.v escaped_quote_in_string.v paren_in_string.v require_after_string.v > stdout 2> stderr || code=$?
 
 diff -u stdout.ref stdout
 diff -u stderr.ref stderr

--- a/test-suite/misc/coqdep-string-literals.sh
+++ b/test-suite/misc/coqdep-string-literals.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Check that rocq dep does not look for Require or sentence ends inside
+# string literals (#22442).
+
+set -e
+
+cd misc/coqdep-string-literals
+
+code=0
+$coqdep -worker @ROCQWORKER@ -R . 'Test' ./*.v > stdout 2> stderr || code=$?
+
+diff -u stdout.ref stdout
+diff -u stderr.ref stderr
+
+exit $code

--- a/test-suite/misc/coqdep-string-literals/.gitignore
+++ b/test-suite/misc/coqdep-string-literals/.gitignore
@@ -1,0 +1,2 @@
+/stderr
+/stdout

--- a/test-suite/misc/coqdep-string-literals/Lib.v
+++ b/test-suite/misc/coqdep-string-literals/Lib.v
@@ -1,0 +1,1 @@
+Definition n := 0.

--- a/test-suite/misc/coqdep-string-literals/dot_in_notation.v
+++ b/test-suite/misc/coqdep-string-literals/dot_in_notation.v
@@ -1,0 +1,2 @@
+Notation "x . y" := (x, y) (at level 50).
+Definition t := 0.

--- a/test-suite/misc/coqdep-string-literals/dot_in_string.v
+++ b/test-suite/misc/coqdep-string-literals/dot_in_string.v
@@ -1,0 +1,1 @@
+Definition t := "a. Require Import Lib. b".

--- a/test-suite/misc/coqdep-string-literals/escaped_quote_in_string.v
+++ b/test-suite/misc/coqdep-string-literals/escaped_quote_in_string.v
@@ -1,0 +1,1 @@
+Definition t := "a"". Require Import Lib. b".

--- a/test-suite/misc/coqdep-string-literals/paren_in_string.v
+++ b/test-suite/misc/coqdep-string-literals/paren_in_string.v
@@ -1,0 +1,1 @@
+Definition t := "a. Require (safe) Foo.".

--- a/test-suite/misc/coqdep-string-literals/require_after_string.v
+++ b/test-suite/misc/coqdep-string-literals/require_after_string.v
@@ -1,0 +1,2 @@
+Definition s := "a. b".
+Require Import Lib.

--- a/test-suite/misc/coqdep-string-literals/stdout.ref
+++ b/test-suite/misc/coqdep-string-literals/stdout.ref
@@ -1,0 +1,6 @@
+Lib.vo Lib.glob Lib.v.beautified Lib.required_vo: Lib.v @ROCQWORKER@
+dot_in_notation.vo dot_in_notation.glob dot_in_notation.v.beautified dot_in_notation.required_vo: dot_in_notation.v @ROCQWORKER@
+dot_in_string.vo dot_in_string.glob dot_in_string.v.beautified dot_in_string.required_vo: dot_in_string.v @ROCQWORKER@
+escaped_quote_in_string.vo escaped_quote_in_string.glob escaped_quote_in_string.v.beautified escaped_quote_in_string.required_vo: escaped_quote_in_string.v @ROCQWORKER@
+paren_in_string.vo paren_in_string.glob paren_in_string.v.beautified paren_in_string.required_vo: paren_in_string.v @ROCQWORKER@
+require_after_string.vo require_after_string.glob require_after_string.v.beautified require_after_string.required_vo: require_after_string.v Lib.vo @ROCQWORKER@

--- a/tools/coqdep/lib/lexer.mll
+++ b/tools/coqdep/lib/lexer.mll
@@ -70,7 +70,7 @@
     let rec ignore_to_dot curr len buf =
       if len <= curr then curr
       else match Bytes.unsafe_get buf curr with
-      | '.' -> curr
+      | '.' | '"' -> curr
       | '(' ->
         if curr + 1 < len && Bytes.unsafe_get buf (curr + 1) != '*' then
           ignore_to_dot (curr + 1) len buf
@@ -251,9 +251,23 @@ and skip_to_dot = parse
 and slow_skip_to_dot = parse
   | "(*"
       { comment lexbuf; skip_to_dot lexbuf }
+  | '"'
+      { skip_string lexbuf; skip_to_dot lexbuf }
   | dot { () }
   | eof { syntax_error lexbuf }
   | _   { skip_to_dot lexbuf }
+
+(* Skip the body of a string literal, whose opening quote has already been
+   consumed.  A doubled quote is an escaped quote, as in the Rocq lexer. *)
+and skip_string = parse
+  | "\"\""
+      { skip_string lexbuf }
+  | '"'
+      { () }
+  | eof
+      { syntax_error lexbuf }
+  | _
+      { skip_string lexbuf }
 
 and parse_dot = parse
   | dot { () }


### PR DESCRIPTION
Fixes #22442

`rocq dep` ended a sentence at any `. `, even inside a string literal, so a `Require` written inside a string became a dependency, and some in-string text was a syntax error. The sentence skipper now skips over string literals. Two choices: a doubled quote `""` is treated as an escaped quote, as in the Rocq lexer, and an unterminated string is reported as a syntax error, like an unterminated sentence.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.

<!--
offer-minimizer: on
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5.1)

https://claude.ai/code/session_01L9BGQT7XUuubV6C619DW4b
