### PR TITLE
Fix Mod_subst.subst_mp_delta losing kername equivalences.

### DIFF
--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -573,7 +573,25 @@ let subst_mp_delta subst mp mkey =
     (* root(resolve) ⊆ mp' *)
       let mp1 = find_prefix resolve mp' in
       let resolve1 = subset_prefixed_by mp1 resolve in
-      subst_dom_delta_resolver mp1 mkey resolve1, mp1
+      let reso = subst_dom_delta_resolver mp1 mkey resolve1 in
+      let reso =
+        if ModPath.equal mp1 mp' then reso
+        else
+          (* [mp1] is the canonical form of [mp'], so the equivalences [resolve]
+             records under [mp'] describe the same names as the ones it records
+             under [mp1]. The latter are typically absent so we must not drop
+             the former to preserve canonicity of the names. *)
+          let subst' = map_mp mp' mkey (empty_delta_resolver mkey) in
+          let transfer kn hint accu = match hint with
+          | Inline _ -> accu
+          | Equiv _ ->
+            if mp_in_mp mp' (KerName.modpath kn) then
+              Deltamap.add_kn (subst_kn subst' kn) hint accu
+            else accu
+          in
+          Deltamap.fold_kn transfer resolve reso
+      in
+      reso, mp1
 
 let gen_subst_delta_resolver dom subst resolver =
   let mp_apply_subst mkey mequ rslv =

--- a/test-suite/bugs/bug_22412_1.v
+++ b/test-suite/bugs/bug_22412_1.v
@@ -1,0 +1,32 @@
+(* The canonical name a delta-resolver assigns must itself be canonical.
+
+   [Include Inner] gives [Outer.M] two pieces of information: the modpath
+   equivalence [Outer.M ↦ Outer.Inner.M] and the kername equivalence
+   [Outer.M.n ↦ M0.n]. The former is canonical as a modpath, but the fields of
+   [Outer.Inner.M] are *not* canonical (they come from [Include M0]), so the
+   kername equivalence is strictly finer and cannot be recovered from the
+   modpath one.
+
+   [Mod_subst.subst_mp_delta] used to resolve the modpath and then keep only
+   the equivalences rooted at its canonical form, dropping the ones rooted at
+   the path it started from. [Outer.E.n] then got the canonical name
+   [Outer.Inner.M.n], which is itself an alias of [M0.n], while the resolver of
+   the enclosing [Outer] said [M0.n] and the two disagreeing views made the
+   last definition below fail with
+
+     Ill-formed constant Outer.E.n: expected canonical name
+     Outer.Inner.M.n but found M0.n *)
+
+Module Type T. Parameter n : bool. End T.
+Module M0. Definition n := true. End M0.
+Module Id (X : T) := X.
+
+Module Outer.
+  Module Inner.
+    Module M. Include M0. End M.
+  End Inner.
+  Include Inner.
+  Module E. Include Id Outer.M. End E.
+End Outer.
+
+Definition check : Outer.E.n = M0.n := eq_refl.

--- a/test-suite/bugs/bug_22412_2.v
+++ b/test-suite/bugs/bug_22412_2.v
@@ -1,0 +1,20 @@
+(* Guards against over-fixing the [subst_mp_delta] bug.
+
+   The fix transfers the equivalences [resolve] records under [mp'] over to
+   [mkey], but only the [Equiv] ones.  Transferring the [Inline] ones as well,
+   which is what the obvious keep-everything-under-[mp'] version does,
+   breaks this program. *)
+
+Module Type T. Parameter Inline n : bool. End T.
+Module M. Definition n := false. End M.
+Module F (X : T).
+  Definition n := X.n.
+  Module Alias := X.
+End F.
+Module R1 := F M.
+Module R2 := F R1.Alias.
+Module R3 := F R2.
+Module Type S. Module B := R3.Alias. End S.
+Module G (X : S). End G.
+Module A : S. Module B := R3.Alias. End A.
+Module R4 := G A.


### PR DESCRIPTION
A delta-resolver binding [mp1 -> mp2] is canonical at the modpath level, but the fields of [mp2] need not be canonical, e.g. after inclusion.

[subst_mp_delta] was resolving the modpath and then keeping only the equivalences rooted at the canonical form [mp2], which are typically absent since the resolver is rooted at [mp1]. The canonical name it produced was then itself an alias, and disagreed with the view of the enclosing module.

We now also transfer the equivalences rooted at [mp1].

Fixes #22412: Incompleteness in conversion due to a faulty module substitution.