### PR TITLE
Slight cleanup in eq_constr_univs_test

### DIFF
--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -76,6 +76,7 @@ sig
 
   val make : UVars.Instance.t -> t
   val kind : Evd.evar_map -> t -> UVars.Instance.t
+  val equal : Evd.evar_map -> t -> t -> bool
   val empty : t
   val is_empty : t -> bool
   val length : t -> int * int

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -796,15 +796,12 @@ let eq_constr_univs_test ~evd ~extended_evd t u =
   (* spiwack: mild code duplication with {!Evd.eq_constr_univs}. *)
   let t = EConstr.Unsafe.to_constr t
   and u = EConstr.Unsafe.to_constr u in
-  let sigma = extended_evd in
   let eq_universes _ u1 u2 =
-    let u1 = EConstr.EInstance.(kind sigma (make u1)) in
-    let u2 = EConstr.EInstance.(kind sigma (make u2)) in
-    UVars.Instance.equal u1 u2
+    EConstr.EInstance.(equal extended_evd (make u1) (make u2))
   in
   let eq_sorts s1 s2 =
     if Sorts.equal s1 s2 then true
-    else Sorts.equal (EConstr.ESorts.(kind sigma (make s1))) (EConstr.ESorts.(kind sigma (make s2)))
+    else EConstr.ESorts.(equal extended_evd (make s1) (make s2))
   in
   let eq_existential eq e1 e2 =
     let eq c1 c2 = eq 0 (EConstr.Unsafe.to_constr c1) (EConstr.Unsafe.to_constr c2) in


### PR DESCRIPTION
Drop sigma = extended_evd alias, and use ESorts/EInstance.equal instead of Sorts/Instance.equal + kind (the E equal is just the non-E equal + kind so this does not change behaviour)

IDK if checking Sorts.equal as a fast path in eq_sorts is actually useful but keeping it for now.
