### PR TITLE
rocqchk: fix soundness bug accepting proofs of False through forged delta aliases

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -103,6 +103,7 @@ let check_constant_declaration env opac kn cb opacify =
     let opac = { opac with st_retro = (ind_retro, Cmap_env.remove kn cst_retro) } in
     Some retro, opac
   in
+  let () = Subtyping.check_constant_alias env kn cb in
   match body with
   | Some body when opacify -> retro, register_opacified_constant env opac kn body
   | Some _ | None -> retro, opac
@@ -339,7 +340,9 @@ and check_structure_field env opac mp lab res opacify = function
         let opac = { opac with st_retro = (Mindmap_env.remove kn ind_retro, cst_retro) } in
         opac
       in
-      CheckInductive.check_inductive env kn mib retro, opac
+      let env' = CheckInductive.check_inductive env kn mib retro in
+      let () = Subtyping.check_inductive_alias env kn mib in
+      env', opac
   | SFBmodule msb ->
       let mp = MPdot(mp, lab) in
       let opac = check_module env opac mp msb opacify in

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -316,6 +316,50 @@ let check_constant (cst, ustate) trace env l info1 cb2 subst1 subst2 =
                Anyway [check_conv] will handle that afterwards. *)
             check_conv (NotConvertibleBodyField (Some (env, c1, c2))) cst poly CONV env c1 c2))
 
+let check_constant_alias env cst cb =
+  let user = Constant.user cst in
+  let canonical = Constant.canonical cst in
+  if KerName.equal user canonical then ()
+  else
+    let target = Constant.make1 canonical in
+    let target_body = Environ.lookup_constant target env in
+    let target_body =
+      match target_body.const_body, cb.const_body with
+      | (Undef _ | OpaqueDef _), Def _ ->
+        let instance =
+          make_abstract_instance (constant_polymorphic_context target_body)
+        in
+        { target_body with const_body = Def (mkConstU (target, instance)) }
+      | _ -> target_body
+    in
+    let state = Environ.universes env, Conversion.checked_universes in
+    let _ =
+      check_constant state [] env (KerName.label user) (Constant target_body) cb
+        empty_subst empty_subst
+    in
+    ()
+
+let check_inductive_alias env mind mib =
+  let user = MutInd.user mind in
+  let canonical = MutInd.canonical mind in
+  if KerName.equal user canonical then ()
+  else
+    let target = MutInd.make1 canonical in
+    let target_body = Environ.lookup_mind target env in
+    let target_mp, target_label = KerName.repr canonical in
+    let user_mp = KerName.modpath user in
+    let target_resolver = empty_delta_resolver target_mp in
+    let user_resolver =
+      add_kn_delta_resolver user canonical (empty_delta_resolver user_mp)
+    in
+    let state = Environ.universes env, Conversion.checked_universes in
+    let _ =
+      check_inductive state [] env target_mp target_label
+        (IndType ((target, 0), target_body)) user_mp mib empty_subst empty_subst
+        target_resolver user_resolver
+    in
+    ()
+
 let rec check_modules state trace env mp1 msb1 mp2 msb2 subst1 subst2 =
   let mty1 = module_type_of_module msb1 in
   let mty2 = module_type_of_module msb2 in

--- a/kernel/subtyping.mli
+++ b/kernel/subtyping.mli
@@ -14,6 +14,11 @@ open Environ
 
 val check_subtypes : ('a, Conversion.graph_inconsistency) Conversion.universe_state -> env -> ModPath.t -> ModPath.t -> module_type_body -> 'a
 
+(** Check that a declaration whose user and canonical names differ is a valid
+    alias of the canonical declaration already present in the environment. *)
+val check_constant_alias : env -> Constant.t -> Declarations.constant_body -> unit
+val check_inductive_alias : env -> MutInd.t -> Declarations.mutual_inductive_body -> unit
+
 val check_polymorphic_universes :
   Environ.env ->
   UVars.AbstractContext.t -> UVars.AbstractContext.t ->

--- a/test-suite/misc/rocqchk-delta-alias/bad/Attack.v
+++ b/test-suite/misc/rocqchk-delta-alias/bad/Attack.v
@@ -1,0 +1,15 @@
+Unset Elimination Schemes.
+
+Inductive bool : Set := true | false.
+
+Module A.
+  Definition x : bool := true.
+  Inductive inhabited : Prop := witness : inhabited.
+End A.
+
+(* These declarations have the same user names as the included declarations
+   in good/Attack.v, but incompatible bodies. *)
+Module B.
+  Definition x : bool := false.
+  Inductive inhabited : Prop := .
+End B.

--- a/test-suite/misc/rocqchk-delta-alias/forge.ml
+++ b/test-suite/misc/rocqchk-delta-alias/forge.ml
@@ -1,0 +1,154 @@
+(* Replace a declaration in B by an incompatible declaration from another
+   compiled copy of the same logical library, while retaining the target's
+   resolver that aliases B's declaration to A's. The code is deliberately
+   independent of Rocq's OCaml libraries: this is an untrusted file producer,
+   not another path through the kernel API. *)
+
+type segment = {
+  name : string;
+  pos : int64;
+  len : int64;
+  hash : string;
+}
+
+let input_int64 ch =
+  let rec go i accu =
+    if i = 0 then accu
+    else
+      go (i - 1)
+        (Int64.logor (Int64.shift_left accu 8)
+           (Int64.of_int (input_byte ch)))
+  in
+  go 8 0L
+
+let output_int64 ch n =
+  for shift = 7 downto 0 do
+    output_byte ch
+      (Int64.to_int (Int64.logand 255L (Int64.shift_right_logical n (8 * shift))))
+  done
+
+let read_segments ch =
+  seek_in ch 8;
+  let summary_pos = input_int64 ch in
+  LargeFile.seek_in ch summary_pos;
+  let n = input_binary_int ch in
+  Array.init n (fun _ ->
+      let name = really_input_string ch (input_binary_int ch) in
+      let pos = input_int64 ch in
+      let len = input_int64 ch in
+      let hash = really_input_string ch 16 in
+      { name; pos; len; hash })
+
+let field v i = Obj.field v i
+
+let structure_of_module mb =
+  let signature = field mb 1 in
+  if Obj.is_int signature || Obj.tag signature <> 0 || Obj.size signature <> 1
+  then failwith "unexpected functorized module";
+  field signature 0
+
+let find_field name structure =
+  let rec loop cell =
+    if Obj.is_int cell then failwith ("missing structure field " ^ name)
+    else
+      let item = field cell 0 in
+      let label = field item 0 in
+      if not (Obj.is_int label) && Obj.tag label = Obj.string_tag
+         && String.equal (Obj.obj label) name
+      then field item 1
+      else loop (field cell 1)
+  in
+  loop structure
+
+let find_declaration expected_tag kind module_body name =
+  let body = find_field name (structure_of_module module_body) in
+  if Obj.is_int body || Obj.tag body <> expected_tag || Obj.size body <> 1 then
+    failwith (name ^ " is not " ^ kind);
+  body
+
+let root_module data =
+  let disk = Obj.repr (Marshal.from_string data 0) in
+  disk, structure_of_module (field (field disk 0) 1)
+
+let module_from root name =
+  let body = find_field name root in
+  if Obj.is_int body || Obj.tag body <> 3 || Obj.size body <> 1 then
+    failwith (name ^ " is not a module");
+  field body 0
+
+let poison_library mode data donor_data =
+  let disk, root = root_module data in
+  let _, donor_root = root_module donor_data in
+  let name, tag, kind = match mode with
+    | "constant" -> "x", 0, "a constant"
+    | "inductive" -> "inhabited", 1, "an inductive"
+    | _ -> failwith "expected mutation kind constant or inductive"
+  in
+  let target = find_declaration tag kind (module_from root "B") name in
+  let donor = find_declaration tag kind (module_from donor_root "B") name in
+  Obj.set_field target 0 (field donor 0);
+  Marshal.to_string (Obj.obj disk) []
+
+let library_data file =
+  let input = open_in_bin file in
+  let segments = read_segments input in
+  let rec find i =
+    if i = Array.length segments then failwith "missing library segment"
+    else if String.equal segments.(i).name "library" then segments.(i)
+    else find (i + 1)
+  in
+  let segment = find 0 in
+  LargeFile.seek_in input segment.pos;
+  let data = really_input_string input (Int64.to_int segment.len) in
+  close_in input;
+  data
+
+let () =
+  let file = Sys.argv.(1) in
+  let donor_data = library_data Sys.argv.(2) in
+  let mode = Sys.argv.(3) in
+  let input = open_in_bin file in
+  let header = really_input_string input 8 in
+  let segments = read_segments input in
+  let contents =
+    Array.map
+      (fun segment ->
+        LargeFile.seek_in input segment.pos;
+        let data = really_input_string input (Int64.to_int segment.len) in
+        let data =
+          if String.equal segment.name "library" then
+            poison_library mode data donor_data
+          else data
+        in
+        segment.name, data)
+      segments
+  in
+  close_in input;
+  let temporary = file ^ ".forged" in
+  let output = open_out_bin temporary in
+  output_string output header;
+  output_int64 output 0L;
+  let rewritten =
+    Array.map
+      (fun (name, data) ->
+        let pos = LargeFile.pos_out output in
+        output_string output data;
+        let hash = Digest.string data in
+        output_string output hash;
+        { name; pos; len = Int64.of_int (String.length data); hash })
+      contents
+  in
+  let summary_pos = LargeFile.pos_out output in
+  output_binary_int output (Array.length rewritten);
+  Array.iter
+    (fun segment ->
+      output_binary_int output (String.length segment.name);
+      output_string output segment.name;
+      output_int64 output segment.pos;
+      output_int64 output segment.len;
+      output_string output segment.hash)
+    rewritten;
+  LargeFile.seek_out output 8L;
+  output_int64 output summary_pos;
+  close_out output;
+  Sys.rename temporary file

--- a/test-suite/misc/rocqchk-delta-alias/good/Attack.v
+++ b/test-suite/misc/rocqchk-delta-alias/good/Attack.v
@@ -1,0 +1,36 @@
+Unset Elimination Schemes.
+
+Inductive bool : Set := true | false.
+
+Module A.
+  Definition x : bool := true.
+  Inductive inhabited : Prop := witness : inhabited.
+End A.
+
+(* Both declarations are legitimately aliases of A's declarations. *)
+Module B.
+  Include A.
+End B.
+
+Inductive eq (A0 : Type) (x0 : A0) : forall _ : A0, Prop :=
+| eq_refl : eq A0 x0 x0.
+
+Inductive False : Prop := .
+Inductive True : Prop := I : True.
+
+Definition discr (b : bool) : Prop :=
+  match b with
+  | true => True
+  | false => False
+  end.
+
+Definition alias : eq bool A.x B.x := eq_refl bool A.x.
+
+(* This has type False after B.x's body is replaced by false. *)
+Definition transported : discr B.x :=
+  match alias in eq _ _ y return discr y with
+  | eq_refl _ _ => I
+  end.
+
+(* This inhabits an empty inductive after B.inhabited is replaced. *)
+Definition inductive_transport : B.inhabited := A.witness.

--- a/test-suite/misc/rocqchk_delta_alias.sh
+++ b/test-suite/misc/rocqchk_delta_alias.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# rocqchk must not trust a serialized module's delta resolver to establish that
+# incompatible declarations have the same canonical name.
+
+set -e
+
+D=misc/rocqchk-delta-alias
+
+rm -f "$D"/good/*.vo "$D"/good/*.vok "$D"/good/*.vos "$D"/good/*.glob \
+      "$D"/bad/*.vo "$D"/bad/*.vok "$D"/bad/*.vos "$D"/bad/*.glob \
+      "$D"/out.log
+
+for kind in constant inductive; do
+  $coqc -noinit -R "$D/good" DeltaAlias "$D/good/Attack.v"
+  $coqc -noinit -R "$D/bad" DeltaAlias "$D/bad/Attack.v"
+  ocaml "$D/forge.ml" "$D/good/Attack.vo" "$D/bad/Attack.vo" "$kind"
+
+  if "$BIN"rocqchk -R "$D/good" DeltaAlias DeltaAlias.Attack > "$D/out.log" 2>&1; then
+    echo "rocqchk accepted a forged $kind delta alias and a closed proof of False"
+    cat "$D/out.log"
+    exit 1
+  fi
+
+  if ! grep -q "Module typing error" "$D/out.log"; then
+    echo "unexpected rocqchk failure for a forged $kind alias"
+    cat "$D/out.log"
+    exit 1
+  fi
+done


### PR DESCRIPTION
`rocqchk` derives each declaration's canonical name from the serialized module delta resolver. A crafted `.vo` can therefore give incompatible constants or inductives the same canonical name; the existing kerpair check then agrees with the poisoned environment and accepts a closed proof of `False`.

Validate every nontrivial serialized alias against the canonical declaration before adding it to the checker environment. Reuse module subtyping for the declaration comparison, while preserving legitimate transparent strengthening of abstract and opaque constants.

Add standalone constant and inductive regressions that rewrite valid marshalled libraries, recompute their segment digests, and verify that rocqchk rejects both forgeries.

- [x] Added / updated **test-suite**.